### PR TITLE
feat: add shared review skill and claude rules

### DIFF
--- a/.claude/rules/backend/typescript-base.md
+++ b/.claude/rules/backend/typescript-base.md
@@ -1,0 +1,31 @@
+---
+paths:
+    - "**/*.ts"
+---
+
+# TypeScript Development Guidelines
+
+## Code Organization
+
+-   Avoid over-abstraction and prioritize composition over inheritance
+-   Use dependency injection and follow SOLID principles
+-   Prevent circular dependencies using the internal module pattern
+-   Libraries should have an `external.ts` file for public exports
+
+## Type Safety
+
+-   Avoid `any`; use `unknown` when type is uncertain
+-   Use runtime type-checking (Zod) for environment variables
+-   Maintain `bigint` types from external APIs
+
+## Documentation
+
+-   Use JSDoc for all code elements
+-   Document public APIs thoroughly
+-   Include examples for complex functionality
+
+## Best Practices
+
+-   Implement static async factory functions for constructors
+-   Follow established naming conventions
+-   Keep functions focused and single-purpose

--- a/.claude/rules/backend/typescript-errors.md
+++ b/.claude/rules/backend/typescript-errors.md
@@ -1,0 +1,19 @@
+---
+paths:
+    - "**/errors/**/*.ts"
+---
+
+# Error Class Guidelines
+
+## Naming Conventions
+
+-   Use declarative, descriptive names
+-   Avoid suffixes like `Exception` or `Error`
+-   Example: Use `EmptyArray` instead of `EmptyArrayException`
+
+## Best Practices
+
+-   Extend the base Error class
+-   Set appropriate error names
+-   Include helpful error messages
+-   Consider adding context-specific properties

--- a/.claude/rules/backend/typescript-providers.md
+++ b/.claude/rules/backend/typescript-providers.md
@@ -1,0 +1,18 @@
+---
+paths:
+    - "**/providers/**/*.ts"
+---
+
+# Provider Layer Guidelines
+
+## Architecture
+
+-   Narrowly scoped data/resource handling
+-   Single responsibility for data access
+-   Implement `IMetadataProvider` interface when applicable
+
+## Naming
+
+-   Consistent naming for metadata interactions (e.g., `GithubProvider`)
+-   Names should reflect the resource being provided
+-   Use consistent suffixes (`Provider` for providers)

--- a/.claude/rules/backend/typescript-scripts.md
+++ b/.claude/rules/backend/typescript-scripts.md
@@ -1,0 +1,25 @@
+---
+paths:
+    - "scripts/**/*.ts"
+---
+
+# Script Guidelines
+
+## Organization
+
+-   Use `process.cwd()` for root directory references
+-   Follow folder conventions:
+-   `infra/` for infrastructure scripts
+-   `utilities/` for utility scripts
+
+## Naming
+
+-   Organize in `package.json` using:
+-   `script:infra:{name}` for infrastructure scripts
+-   `script:util:{name}` for utility scripts
+
+## Best Practices
+
+-   Include proper error handling
+-   Add logging for important operations
+-   Document script purpose and usage

--- a/.claude/rules/backend/typescript-services.md
+++ b/.claude/rules/backend/typescript-services.md
@@ -1,0 +1,18 @@
+---
+paths:
+    - "**/services/**/*.ts"
+---
+
+# Service Layer Guidelines
+
+## Architecture
+
+-   Proper encapsulation of business workflows
+-   Orchestrate multiple components or data sources
+-   Use Providers for resource access
+
+## Naming
+
+-   Clear, descriptive service names (e.g., `AggregatorService`, `MetricsService`)
+-   Names should reflect domain-specific tasks
+-   Use consistent suffixes (`Service` for services)

--- a/.claude/rules/backend/typescript-tests.md
+++ b/.claude/rules/backend/typescript-tests.md
@@ -1,0 +1,20 @@
+---
+paths:
+    - "**/*.test.ts"
+---
+
+# Test Guidelines
+
+## Test Structure
+
+-   Write descriptive test names without using "should"
+-   Follow test library best practices (Mocha/Chai/Jest/Vitest/Cypress)
+-   Keep tests focused and single-purpose
+-   Use appropriate test hooks and lifecycle methods
+
+## Best Practices
+
+-   Write clear, descriptive assertions
+-   Test edge cases and error conditions
+-   Use appropriate mocking strategies
+-   Follow the Arrange-Act-Assert pattern

--- a/.claude/rules/frontend/accessibility.md
+++ b/.claude/rules/frontend/accessibility.md
@@ -1,0 +1,30 @@
+# Accessibility (a11y) Guidelines
+
+## Semantic HTML
+
+-   Use semantic elements (`<button>`, `<nav>`, `<main>`, `<article>`)
+-   Never use `<div>` for interactive elements
+-   Use heading hierarchy correctly (h1 → h2 → h3)
+
+## Interactive Elements
+
+-   All interactive elements must be keyboard accessible
+-   Focus states must be visible
+-   Click handlers on non-button elements need `role` and `tabIndex`
+
+## Images and Media
+
+-   All `<img>` must have `alt` attribute
+-   Decorative images: `alt=""`
+-   Videos should have captions/transcripts
+
+## Forms
+
+-   All inputs must have associated `<label>`
+-   Error messages linked with `aria-describedby`
+-   Required fields marked with `aria-required`
+
+## Color and Contrast
+
+-   Minimum contrast ratio: 4.5:1 for normal text
+-   Don't convey information with color alone

--- a/.claude/rules/frontend/react-components.md
+++ b/.claude/rules/frontend/react-components.md
@@ -1,0 +1,37 @@
+---
+paths:
+    - "**/*.tsx"
+---
+
+# React Component Guidelines
+
+## Component Structure
+
+-   Abstract complex logic from render functions
+-   Business logic must live in helper functions or services, never in components
+-   Keep render methods simple and declarative
+-   Split complex components into smaller ones
+-   Use hooks for side effects and state management
+-   One component per file
+-   Use functional components with hooks
+-   Props interface defined above component
+-   Export component as named export
+
+## Import Order
+
+1. React imports
+2. Third-party libraries
+3. Internal files
+
+## Naming
+
+-   PascalCase for components: `UserProfile.tsx`
+-   camelCase for hooks: `useAuth.ts`
+-   Props interface: `ComponentNameProps`
+
+## Best Practices
+
+-   Use logical AND (`&&`) over ternary conditionals for clarity
+-   Keep components focused and reusable
+-   Follow React hooks best practices
+-   Avoid inline styles

--- a/.claude/rules/frontend/react-performance.md
+++ b/.claude/rules/frontend/react-performance.md
@@ -1,0 +1,36 @@
+---
+paths:
+    - "**/*.tsx"
+---
+
+# React Performance Guidelines
+
+## Optimization
+
+-   Implement proper memoization (useMemo, useCallback)
+-   Optimize re-renders with React.memo when profiling shows benefit
+-   Lazy load components when appropriate
+-   Optimize images to be under 250kB
+-   Avoid inline object/array creation in JSX
+
+## State Management
+
+-   Use appropriate state management solutions
+-   Avoid unnecessary state
+-   Keep state as local as possible
+-   Use context API appropriately
+-   Derive values from existing state when possible
+
+## Hooks Performance
+
+### useEffect
+
+-   Prefer derived values over state + effect patterns
+-   Use `useMemo` for expensive calculations, not `useEffect`
+-   Always include cleanup functions for subscriptions/timers
+
+### useCallback
+
+-   Use for event handlers passed to memoized children
+-   Don't wrap every function - only when necessary
+-   Include all dependencies in the dependency array

--- a/.claude/rules/frontend/styling.md
+++ b/.claude/rules/frontend/styling.md
@@ -1,0 +1,24 @@
+# Styling Conventions
+
+## General Principles
+
+-   Prefer CSS-in-JS or CSS Modules for scoped styles
+-   Use design tokens/CSS variables for theming
+-   Mobile-first responsive design
+
+## Constraints
+
+-   **Direct edit to visual/styling code requires approval**
+-   Always propose styling changes, wait for approval
+-   Never change colors, spacing, or layout without explicit request
+
+## Responsive Design
+
+-   Use relative units (rem, em, %) over absolute (px)
+-   Define breakpoints as CSS variables or constants
+-   Test all breakpoints before completion
+
+## Theming
+
+-   All colors should reference design tokens
+-   Support light/dark mode via CSS variables

--- a/.claude/rules/frontend/typescript.md
+++ b/.claude/rules/frontend/typescript.md
@@ -1,0 +1,31 @@
+---
+paths:
+    - "**/*.{ts,tsx}"
+---
+
+# TypeScript Rules (Frontend)
+
+## Naming Conventions
+
+-   PascalCase for interfaces, types, classes, components
+-   camelCase for functions, variables, methods
+-   SCREAMING_SNAKE_CASE for constants
+-   kebab-case for file names
+
+## Type Safety
+
+-   NO `any` without explicit justification
+-   Prefer `unknown` over `any` when type is truly unknown
+-   Use explicit return types on exported functions
+-   Prefer enums over string literals for better refactoring and explicit intent
+
+## Imports
+
+-   Group imports: external → internal → relative
+-   Use named exports over default exports
+-   No circular dependencies
+
+## React-Specific Types
+
+-   Use explicit props typing over `React.FC`
+-   Event handlers: `React.MouseEvent<HTMLButtonElement>`

--- a/.claude/skills/review-interop-sdk/SKILL.md
+++ b/.claude/skills/review-interop-sdk/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: review-interop-sdk
+description: This skill should be used when the user asks to review code, review a pull request, review changes, review a diff, or perform a code review. It provides project-aware review with checks for TypeScript best practices, documentation, changesets, and test coverage.
+allowed-tools: Read, Glob, Grep, Bash
+---
+
+# Code Review
+
+You are acting as a code reviewer for the **interop-sdk** monorepo — a TypeScript pnpm workspace with Turbo, Changesets, Vitest, and Playwright.
+
+## Step 1 — Determine review scope
+
+Figure out what the user wants reviewed. Run these checks:
+
+1. Check `git branch --show-current` and `git status`.
+2. If the user passed a PR number or URL, use `gh pr view <number> --json baseRefName,headRefName,number,title,url` to get details.
+3. If no PR was specified and the current branch is **not** `dev` or `main`, assume the user wants to review the current branch against `dev`.
+4. If the current branch **is** `dev` or `main` and no PR/commit was specified, ask the user what they want reviewed (unstaged changes, a specific PR, a commit range, etc.).
+5. **Never** run `git checkout` or `git switch` without explicit user approval.
+
+Once the scope is clear, obtain the diff:
+
+| Scope                       | Command                                         |
+| --------------------------- | ----------------------------------------------- |
+| PR (current branch vs base) | `git diff dev...HEAD` (or the appropriate base) |
+| Unstaged changes            | `git diff`                                      |
+| Staged changes              | `git diff --cached`                             |
+| Specific commit             | `git show <sha>`                                |
+
+## Step 2 — Read changed files for context
+
+For each file in the diff, read the full file so you understand the surrounding context (imports, types, module structure). Use `Glob` and `Read` — do not rely solely on the diff hunks.
+
+## Step 3 — Evaluate against the checklist
+
+Review every item below. Only flag issues that:
+
+-   Were **introduced in the diff**, not pre-existing code.
+-   Are **discrete and actionable** — one issue per finding, not general observations.
+-   Have **provable impact** on correctness, performance, security, or maintainability — don't speculate that a change _might_ break something; identify the affected code.
+-   The **author would likely fix** if aware of them.
+-   Don't rely on **unstated assumptions** about the codebase or author's intent.
+-   Are **clearly not intentional** changes by the author.
+
+Ignore trivial style issues unless they obscure meaning or violate documented standards. Don't stop at the first finding — list every qualifying issue. Do not generate a full PR fix; only flag issues with optional short suggestions.
+
+### 3.1 Correctness & Security
+
+-   Look for logic errors, race conditions, and incorrect assumptions.
+-   Flag untrusted-input issues: open redirects, unparameterised SQL, SSRF on user-supplied URLs, unsanitised HTML (prefer escaping over sanitising).
+-   Flag newly added dependencies — explain why they are or aren't justified.
+-   Prefer fail-fast behaviour; flag logging-and-continue patterns that hide errors. Crashing is better than silent degradation.
+-   Treat back-pressure handling as critical to system stability.
+-   Ensure errors are checked against codes or stable identifiers, never error message strings.
+
+### 3.2 TypeScript & Readability
+
+Enforce the project's TypeScript and code-organisation rules as defined in:
+
+-   `.claude/rules/backend/typescript-base.md` — type safety, code organisation, JSDoc
+-   `.claude/rules/frontend/typescript.md` — naming, imports, `any` policy, explicit return types
+-   `.claude/rules/backend/typescript-errors.md` — error class naming and structure
+-   `.claude/rules/frontend/react-components.md` — component structure, single responsibility, import order
+
+These rules are auto-loaded by path glob. During review, flag violations **only in the diff** — don't demand rigour inconsistent with the rest of the codebase.
+
+### 3.3 Documentation
+
+Check whether the change requires documentation updates at any of these layers:
+
+| Layer                | Location                                                           | When to flag                                       |
+| -------------------- | ------------------------------------------------------------------ | -------------------------------------------------- |
+| Package / app README | `packages/*/README.md`, `apps/*/README.md`, `examples/*/README.md` | Public API changes, new exports, changed behaviour |
+| Docs site            | `apps/docs/docs/**`                                                | New features, changed APIs, new concepts           |
+| Inline JSDoc         | Exported functions and types                                       | New or changed public surface                      |
+
+Flag missing docs as **[P2]** with a concrete suggestion of which file(s) to update.
+
+### 3.4 Changesets
+
+If the diff touches files inside a publishable package (`packages/addresses`, `packages/cross-chain`, or `apps/sdk`), check whether a `.changeset/*.md` file is included in the diff.
+
+-   **Missing changeset → [P1]**: remind the contributor to run `pnpm changeset`.
+-   **Changeset present**: verify the bump level (patch / minor / major) is appropriate for the scope of change.
+
+### 3.5 Test Coverage
+
+-   Changes to `packages/*` or `apps/sdk` should have corresponding **Vitest** tests in the package's `test/` directory.
+-   User-facing behaviour changes in `examples/ui` should consider **Playwright** E2E coverage in `examples/ui/tests/`.
+-   Flag missing tests as **[P2]** with guidance on what scenarios to cover.
+-   Do **not** demand tests for trivial changes (typos, config tweaks, docs-only).
+
+## Step 4 — Format findings
+
+Tag each finding with a priority level:
+
+-   **[P0]** — Drop everything. Blocking release or operations. Only for issues that do not depend on assumptions about inputs.
+-   **[P1]** — Urgent. Should be addressed before merge.
+-   **[P2]** — Normal. To be fixed eventually.
+-   **[P3]** — Low. Nice to have.
+
+For each finding, include:
+
+1. Priority tag and short title.
+2. File path and line range (keep ranges under ~5–10 lines).
+3. One paragraph explanation of why this is a problem and in what scenario it arises.
+4. Optional `suggestion` code block with concrete replacement code (max 3 lines, preserve indentation).
+
+### Comment style
+
+-   Matter-of-fact, helpful tone — not accusatory.
+-   Brief: at most one paragraph per finding.
+-   No excessive flattery or filler phrases.
+-   Write for quick comprehension.
+
+## Step 5 — Verdict
+
+End the review with one of:
+
+-   **Verdict: correct** — No blocking issues found.
+-   **Verdict: needs attention** — Has [P0] or [P1] findings that should be addressed before merge.
+
+If there are zero qualifying findings, explicitly state the code looks good.

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,14 @@ lcov.info
 .cursor
 
 # claude
-.claude/
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/review-interop-sdk/
+!.claude/rules
+.claude/rules/*
+!.claude/rules/backend
+!.claude/rules/frontend
 
 # playwright mcp
 .playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -181,13 +181,40 @@ See [.changeset/README.md](./.changeset/README.md) for more details.
 
 ## Contributing
 
-Wonderland is a team of top Web3 researchers, developers, and operators who believe that the future needs to be open-source, permissionless, and decentralized.
+This project is maintained by [Wonderland](https://wonderland.xyz) — a team of top Web3 researchers, developers, and operators who believe that the future needs to be open-source, permissionless, and decentralized. We welcome outside contributions.
 
-[Wonderland](https://wonderland.xyz), but Wonderland is here to make it better.
+-   **Large changes** — please open an issue first to discuss your proposal before investing time in a PR.
+-   **Small changes** (bug fixes, typos, minor improvements) — PRs are welcome directly.
+
+### Submitting a Pull Request
+
+1. Fork the repo and create your branch from `dev`.
+2. Make your changes and ensure `pnpm build`, `pnpm lint`, and `pnpm test` pass.
+3. If your change modifies a publishable package (`packages/addresses`, `packages/cross-chain`, or `apps/sdk`), create a changeset:
+    ```bash
+    pnpm changeset
+    ```
+    Select the affected packages, choose the appropriate bump level (patch / minor / major), and write a short description. Commit the generated `.changeset/*.md` file with your PR.
+4. If your change adds or modifies public API surface, update the relevant documentation:
+    - Package README (`packages/*/README.md`)
+    - Docs site (`apps/docs/docs/`)
+    - Inline JSDoc on exported functions and types
+5. Run `/review-interop-sdk` (see below) to catch common issues before requesting human review.
+6. Open your PR against `dev` and fill in the template.
 
 ### 💻 Conventional Commits
 
 We follow the Conventional Commits [specification](https://www.conventionalcommits.org/en/v1.0.0/#specification).
+
+### 🔍 Code Review Skill
+
+This repo includes a shared review skill at [`.claude/skills/review-interop-sdk/`](./.claude/skills/review-interop-sdk/). Invoke it from any compatible AI agent to get a project-aware review of your changes:
+
+```
+/review-interop-sdk
+```
+
+It checks the current branch diff (or a specific PR) against the project's TypeScript rules, changeset policy, documentation requirements, and test coverage expectations.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add a shared code review skill (`.claude/skills/review-interop-sdk/`) that any contributor can invoke via `/review-interop-sdk` to get a project-aware review of their changes
- Add shared claude rules (`.claude/rules/`) for TypeScript, React, accessibility, styling, and testing conventions
- Update the Contributing section in README with PR submission guidelines, changeset instructions, and a reference to the review skill
- Update `.gitignore` to un-ignore `.claude/skills/` and `.claude/rules/`

## Test plan

- [ ] Verify `/review-interop-sdk` can be invoked from a compatible AI agent
- [ ] Confirm `.claude/rules/` files are loaded by path glob when editing matching files
- [ ] Check README Contributing section renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)