### PR TITLE
feat: sync the url search params with the route selection

### DIFF
--- a/examples/ui/app/cross-chain/hooks/useRouteSelection.ts
+++ b/examples/ui/app/cross-chain/hooks/useRouteSelection.ts
@@ -1,64 +1,7 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { readRouteParams, syncRouteParams } from '../utils/routeParams';
+import { createRouteSelector } from '../utils/routeSelection';
 import { useTokenConfig } from './useNetworkConfig';
-import type { UITokenInfo } from '../types/assets';
-
-// TODO: Replace with dynamic lookup via Across /available-routes endpoint.
-// See: https://docs.across.to/reference/api-reference
-const ACROSS_WHITELISTED_SYMBOLS = new Set(['USDC', 'USDT', 'WETH', 'DAI', 'ETH']);
-
-function isAcrossWhitelisted(token: UITokenInfo): boolean {
-  return !token.providers.includes('across') || ACROSS_WHITELISTED_SYMBOLS.has(token.symbol);
-}
-
-/** All whitelisted tokens on a chain (for the input dropdown). */
-function availableTokens(addresses: readonly string[], tokenInfo: Record<string, UITokenInfo>): string[] {
-  return addresses.filter((addr) => {
-    const meta = tokenInfo[addr];
-    return !meta || isAcrossWhitelisted(meta);
-  });
-}
-
-/** Tokens reachable from the selected input via a shared provider (for the output dropdown). */
-function compatibleTokens(
-  addresses: readonly string[],
-  tokenInfo: Record<string, UITokenInfo>,
-  providers: string[],
-  inputSymbol: string | undefined,
-): string[] {
-  return addresses.filter((addr) => {
-    const meta = tokenInfo[addr];
-    if (!meta || !isAcrossWhitelisted(meta)) return false;
-
-    const shared = meta.providers.filter((p) => providers.includes(p));
-    if (shared.length === 0) return false;
-
-    // Across can only bridge same-symbol (USDC→USDC), not swap (USDC→DAI)
-    const onlyViaAcross = shared.length === 1 && shared[0] === 'across';
-    return !(onlyViaAcross && meta.symbol !== inputSymbol);
-  });
-}
-
-function pickFirst(tokens: string[], current: string): string {
-  return tokens.includes(current) ? current : (tokens[0] ?? '');
-}
-
-/** Resolves the output token for the current output chain. Returns '' if no compatible tokens exist. */
-function resolveOutputToken(
-  currentOutputChainId: number,
-  providers: string[],
-  inputSymbol: string | undefined,
-  currentOutputToken: string,
-  byChain: Record<number, readonly string[]>,
-  tokenInfo: Record<number, Record<string, UITokenInfo>>,
-): string {
-  const compatible = compatibleTokens(
-    byChain[currentOutputChainId] || [],
-    tokenInfo[currentOutputChainId] || {},
-    providers,
-    inputSymbol,
-  );
-  return pickFirst(compatible, currentOutputToken);
-}
 
 /**
  * Manages chain/token selection state with route-aware cascading.
@@ -68,98 +11,47 @@ function resolveOutputToken(
 export function useRouteSelection(defaultInputChainId: number, defaultOutputChainId: number) {
   const { SUPPORTED_TOKEN_BY_CHAIN_ID: byChain, TOKEN_INFO: tokenInfo } = useTokenConfig();
 
-  const [selection, setSelection] = useState({
-    inputChainId: defaultInputChainId,
-    outputChainId: defaultOutputChainId,
-    inputToken: '',
-    outputToken: '',
+  const selector = useMemo(() => createRouteSelector({ byChain, tokenInfo }), [byChain, tokenInfo]);
+
+  const [selection, setSelection] = useState(() => {
+    const urlParams = readRouteParams();
+    return selector.selectionFromUrl(urlParams, defaultInputChainId, defaultOutputChainId);
   });
 
-  // Filtered input tokens for the dropdown
-  const inputTokens = useMemo(() => {
-    const tokens = byChain[selection.inputChainId] || [];
-    const info = tokenInfo[selection.inputChainId] || {};
-    return availableTokens(tokens, info);
-  }, [byChain, tokenInfo, selection.inputChainId]);
-
-  // Resolve effective input token (handles initial load / discovery)
-  const inputToken = pickFirst(inputTokens, selection.inputToken);
-
-  // Filtered output tokens for the dropdown (depends on resolved input)
-  const outputTokens = useMemo(() => {
-    const meta = tokenInfo[selection.inputChainId]?.[inputToken];
-    const providers = meta?.providers ?? [];
-    const tokens = byChain[selection.outputChainId] || [];
-    const info = tokenInfo[selection.outputChainId] || {};
-    return compatibleTokens(tokens, info, providers, meta?.symbol);
-  }, [byChain, tokenInfo, selection.inputChainId, inputToken, selection.outputChainId]);
-
-  // Resolve effective output token
-  const outputToken = pickFirst(outputTokens, selection.outputToken);
+  const resolved = useMemo(() => selector.resolve(selection), [selector, selection]);
 
   const setInputChain = useCallback(
-    (chainId: number) => {
-      setSelection((prev) => {
-        const newInput = pickFirst(availableTokens(byChain[chainId] || [], tokenInfo[chainId] || {}), prev.inputToken);
-        const meta = tokenInfo[chainId]?.[newInput];
-        const outputToken = resolveOutputToken(
-          prev.outputChainId,
-          meta?.providers ?? [],
-          meta?.symbol,
-          prev.outputToken,
-          byChain,
-          tokenInfo,
-        );
-        return { ...prev, inputChainId: chainId, inputToken: newInput, outputToken };
-      });
-    },
-    [byChain, tokenInfo],
+    (chainId: number) => setSelection((prev) => selector.setInputChain(prev, chainId)),
+    [selector],
   );
 
   const setOutputChain = useCallback(
-    (chainId: number) => {
-      setSelection((prev) => {
-        const meta = tokenInfo[prev.inputChainId]?.[prev.inputToken];
-        const providers = meta?.providers ?? [];
-        const tokens = byChain[chainId] || [];
-        const info = tokenInfo[chainId] || {};
-        const newOutput = pickFirst(compatibleTokens(tokens, info, providers, meta?.symbol), prev.outputToken);
-
-        return { ...prev, outputChainId: chainId, outputToken: newOutput };
-      });
-    },
-    [byChain, tokenInfo],
+    (chainId: number) => setSelection((prev) => selector.setOutputChain(prev, chainId)),
+    [selector],
   );
 
   const setInputToken = useCallback(
-    (address: string) => {
-      setSelection((prev) => {
-        const meta = tokenInfo[prev.inputChainId]?.[address];
-        const outputToken = resolveOutputToken(
-          prev.outputChainId,
-          meta?.providers ?? [],
-          meta?.symbol,
-          prev.outputToken,
-          byChain,
-          tokenInfo,
-        );
-        return { ...prev, inputToken: address, outputToken };
-      });
-    },
-    [byChain, tokenInfo],
+    (address: string) => setSelection((prev) => selector.setInputToken(prev, address)),
+    [selector],
   );
 
   const setOutputToken = useCallback((address: string) => {
     setSelection((prev) => ({ ...prev, outputToken: address }));
   }, []);
 
+  useEffect(() => {
+    const configLoaded = Object.keys(byChain).length > 0;
+    if (!configLoaded) return;
+    syncRouteParams(resolved.inputChainId, resolved.outputChainId, resolved.inputToken, resolved.outputToken);
+  }, [byChain, resolved.inputChainId, resolved.outputChainId, resolved.inputToken, resolved.outputToken]);
+
   return {
-    inputChainId: selection.inputChainId,
-    outputChainId: selection.outputChainId,
-    inputToken,
-    outputToken,
-    inputTokens,
-    outputTokens,
+    inputChainId: resolved.inputChainId,
+    outputChainId: resolved.outputChainId,
+    inputToken: resolved.inputToken,
+    outputToken: resolved.outputToken,
+    inputTokens: resolved.inputTokens,
+    outputTokens: resolved.outputTokens,
     setInputChain,
     setOutputChain,
     setInputToken,

--- a/examples/ui/app/cross-chain/utils/routeParams.ts
+++ b/examples/ui/app/cross-chain/utils/routeParams.ts
@@ -1,0 +1,74 @@
+import { isAddress } from 'viem';
+import { viemChainNameMap } from '../../utils/viem-chains';
+
+const ROUTE_PARAMS = {
+  fromChain: 'fromChain',
+  toChain: 'toChain',
+  fromToken: 'fromToken',
+  toToken: 'toToken',
+} as const;
+
+export interface RouteParams {
+  fromChain?: number;
+  toChain?: number;
+  fromToken?: string;
+  toToken?: string;
+}
+
+function parseChainId(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) return undefined;
+  if (!(n in viemChainNameMap)) return undefined;
+  return n;
+}
+
+function parseTokenAddress(value: string | null): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!isAddress(trimmed)) return undefined;
+  return trimmed;
+}
+
+export function readRouteParams(): RouteParams {
+  if (typeof window === 'undefined') return {};
+  try {
+    const params = new URLSearchParams(window.location.search);
+    return {
+      fromChain: parseChainId(params.get(ROUTE_PARAMS.fromChain)),
+      toChain: parseChainId(params.get(ROUTE_PARAMS.toChain)),
+      fromToken: parseTokenAddress(params.get(ROUTE_PARAMS.fromToken)),
+      toToken: parseTokenAddress(params.get(ROUTE_PARAMS.toToken)),
+    };
+  } catch {
+    return {};
+  }
+}
+
+export function findTokenCaseInsensitive(tokens: readonly string[], target: string): string | undefined {
+  const lower = target.toLowerCase();
+  return tokens.find((t) => t.toLowerCase() === lower);
+}
+
+export function syncRouteParams(
+  inputChainId: number,
+  outputChainId: number,
+  inputToken: string,
+  outputToken: string,
+): void {
+  if (typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+
+  url.searchParams.set(ROUTE_PARAMS.fromChain, String(inputChainId));
+  if (inputToken) url.searchParams.set(ROUTE_PARAMS.fromToken, inputToken);
+  else url.searchParams.delete(ROUTE_PARAMS.fromToken);
+
+  url.searchParams.set(ROUTE_PARAMS.toChain, String(outputChainId));
+  if (outputToken) url.searchParams.set(ROUTE_PARAMS.toToken, outputToken);
+  else url.searchParams.delete(ROUTE_PARAMS.toToken);
+
+  if (url.search !== window.location.search) {
+    window.history.replaceState(null, '', url.toString());
+  }
+}

--- a/examples/ui/app/cross-chain/utils/routeSelection.spec.ts
+++ b/examples/ui/app/cross-chain/utils/routeSelection.spec.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import { createRouteSelector, type RouteConfig, type Selection } from './routeSelection';
+import type { UITokenInfo } from '../types/assets';
+
+const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+const SHIB = '0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE';
+const UNKNOWN = '0x0000000000000000000000000000000000000001';
+
+function token(symbol: string, providers: string[]): UITokenInfo {
+  return { symbol, decimals: 18, providers };
+}
+
+const config: RouteConfig = {
+  byChain: {
+    1: [USDC, WETH, DAI, SHIB],
+    10: [USDC, WETH, DAI, SHIB],
+  },
+  tokenInfo: {
+    1: {
+      [USDC]: token('USDC', ['across', 'sample']),
+      [WETH]: token('WETH', ['across']),
+      [DAI]: token('DAI', ['sample']),
+      [SHIB]: token('SHIB', ['across']),
+    },
+    10: {
+      [USDC]: token('USDC', ['across', 'sample']),
+      [WETH]: token('WETH', ['across']),
+      [DAI]: token('DAI', ['sample']),
+      [SHIB]: token('SHIB', ['across']),
+    },
+  },
+};
+
+const VALID_TOKENS = [USDC, WETH, DAI];
+
+function sel(overrides: Partial<Selection> = {}): Selection {
+  return { inputChainId: 1, outputChainId: 10, inputToken: USDC, outputToken: USDC, ...overrides };
+}
+
+describe('selectionFromUrl', () => {
+  const selector = createRouteSelector(config);
+
+  it('uses URL chains when supported', () => {
+    const result = selector.selectionFromUrl({ fromChain: 10, toChain: 1 }, 1, 10);
+    expect(result.inputChainId).toBe(10);
+    expect(result.outputChainId).toBe(1);
+  });
+
+  it('falls back to defaults for missing or unsupported chains', () => {
+    expect(selector.selectionFromUrl({}, 1, 10).inputChainId).toBe(1);
+    expect(selector.selectionFromUrl({ fromChain: 999 }, 1, 10).inputChainId).toBe(1);
+    expect(selector.selectionFromUrl({ toChain: 888 }, 1, 10).outputChainId).toBe(10);
+  });
+
+  it('avoids same-chain by falling back when URL toChain equals inputChainId', () => {
+    const result = selector.selectionFromUrl({ fromChain: 1, toChain: 1 }, 1, 10);
+    expect(result.outputChainId).toBe(10);
+  });
+
+  it('matches URL token addresses case-insensitively', () => {
+    const result = selector.selectionFromUrl({ fromToken: USDC.toLowerCase(), toToken: DAI.toUpperCase() }, 1, 10);
+    expect(result.inputToken).toBe(USDC);
+    expect(result.outputToken).toBe(DAI);
+  });
+
+  it('leaves tokens empty when missing or not on chain', () => {
+    expect(selector.selectionFromUrl({}, 1, 10).inputToken).toBe('');
+    expect(selector.selectionFromUrl({ fromToken: UNKNOWN }, 1, 10).inputToken).toBe('');
+  });
+});
+
+describe('resolve', () => {
+  const selector = createRouteSelector(config);
+
+  it('preserves tokens that are already valid', () => {
+    const resolved = selector.resolve(sel({ inputToken: USDC, outputToken: USDC }));
+    expect(resolved.inputToken).toBe(USDC);
+    expect(resolved.outputToken).toBe(USDC);
+  });
+
+  it('corrects stale tokens to first available', () => {
+    const resolved = selector.resolve(sel({ inputToken: UNKNOWN, outputToken: UNKNOWN }));
+    expect(resolved.inputToken).toBe(VALID_TOKENS[0]);
+    expect(resolved.outputToken).not.toBe(UNKNOWN);
+  });
+
+  it('cascades: correcting input token changes output list', () => {
+    // WETH is across-only → only same-symbol (WETH) is reachable on output chain
+    const resolved = selector.resolve(sel({ inputToken: WETH, outputToken: DAI }));
+    expect(resolved.outputToken).toBe(WETH);
+    expect(resolved.outputTokens).toEqual([WETH]);
+  });
+
+  it('filters by across whitelist and provider compatibility', () => {
+    const resolved = selector.resolve(sel({ inputToken: USDC }));
+    expect(resolved.inputTokens).toEqual(VALID_TOKENS);
+    expect(resolved.inputTokens).not.toContain(SHIB);
+    // USDC (across + sample) can reach DAI (sample) via shared sample
+    expect(resolved.outputTokens).toContain(DAI);
+  });
+
+  it('across-only input limits output to same-symbol', () => {
+    const resolved = selector.resolve(sel({ inputToken: WETH }));
+    expect(resolved.outputTokens).toContain(WETH);
+    expect(resolved.outputTokens).not.toContain(USDC);
+    expect(resolved.outputTokens).not.toContain(DAI);
+  });
+});
+
+describe('cascading', () => {
+  const selector = createRouteSelector(config);
+
+  it('setInputChain preserves tokens when they exist on the new chain', () => {
+    const next = selector.setInputChain(sel({ inputToken: USDC, outputToken: DAI }), 10);
+    expect(next.inputChainId).toBe(10);
+    expect(next.inputToken).toBe(USDC);
+    expect(next.outputToken).toBe(DAI);
+  });
+
+  it('setInputChain falls back input token when it does not exist on new chain', () => {
+    const onlyChain1 = '0x1111111111111111111111111111111111111111';
+    const s = createRouteSelector({
+      byChain: { 1: [onlyChain1, USDC], 10: [USDC, WETH] },
+      tokenInfo: {
+        1: { [onlyChain1]: token('UNI', ['sample']), [USDC]: token('USDC', ['across', 'sample']) },
+        10: { [USDC]: token('USDC', ['across', 'sample']), [WETH]: token('WETH', ['across']) },
+      },
+    });
+    const next = s.setInputChain({ inputChainId: 1, outputChainId: 10, inputToken: onlyChain1, outputToken: USDC }, 10);
+    expect(next.inputToken).toBe(USDC);
+  });
+
+  it('setOutputChain leaves input unchanged and re-evaluates output', () => {
+    const prev = sel({ inputChainId: 1, inputToken: USDC, outputToken: USDC });
+    const next = selector.setOutputChain(prev, 10);
+    expect(next.inputChainId).toBe(1);
+    expect(next.inputToken).toBe(USDC);
+    expect(next.outputToken).toBe(USDC);
+  });
+
+  it('setInputToken preserves output when still compatible', () => {
+    const next = selector.setInputToken(sel({ inputToken: USDC, outputToken: USDC }), DAI);
+    expect(next.inputToken).toBe(DAI);
+    expect(next.outputToken).toBe(USDC);
+  });
+
+  it('setInputToken resets output when providers no longer overlap', () => {
+    const next = selector.setInputToken(sel({ inputToken: DAI, outputToken: DAI }), WETH);
+    expect(next.outputToken).toBe(WETH);
+  });
+});
+
+describe('edge cases', () => {
+  it('empty config or unknown chain yields empty results', () => {
+    const empty = createRouteSelector({ byChain: {}, tokenInfo: {} }).resolve(sel());
+    expect(empty.inputToken).toBe('');
+    expect(empty.outputToken).toBe('');
+    expect(empty.inputTokens).toEqual([]);
+
+    const unknown = createRouteSelector(config).resolve(sel({ inputChainId: 999, outputChainId: 888 }));
+    expect(unknown.inputTokens).toEqual([]);
+    expect(unknown.outputTokens).toEqual([]);
+  });
+
+  it('token with no metadata stays visible in available tokens', () => {
+    const s = createRouteSelector({
+      byChain: { 1: [USDC, UNKNOWN], 10: [USDC] },
+      tokenInfo: {
+        1: { [USDC]: token('USDC', ['across', 'sample']) },
+        10: { [USDC]: token('USDC', ['across', 'sample']) },
+      },
+    });
+    expect(s.resolve(sel({ inputChainId: 1 })).inputTokens).toContain(UNKNOWN);
+  });
+});

--- a/examples/ui/app/cross-chain/utils/routeSelection.ts
+++ b/examples/ui/app/cross-chain/utils/routeSelection.ts
@@ -1,8 +1,6 @@
 import { findTokenCaseInsensitive, type RouteParams } from './routeParams';
 import type { UITokenInfo } from '../types/assets';
 
-// TODO: Replace with dynamic lookup via Across /available-routes endpoint.
-// See: https://docs.across.to/reference/api-reference
 const ACROSS_WHITELISTED_SYMBOLS = new Set(['USDC', 'USDT', 'WETH', 'DAI', 'ETH']);
 
 export interface Selection {

--- a/examples/ui/app/cross-chain/utils/routeSelection.ts
+++ b/examples/ui/app/cross-chain/utils/routeSelection.ts
@@ -1,0 +1,169 @@
+import { findTokenCaseInsensitive, type RouteParams } from './routeParams';
+import type { UITokenInfo } from '../types/assets';
+
+// TODO: Replace with dynamic lookup via Across /available-routes endpoint.
+// See: https://docs.across.to/reference/api-reference
+const ACROSS_WHITELISTED_SYMBOLS = new Set(['USDC', 'USDT', 'WETH', 'DAI', 'ETH']);
+
+export interface Selection {
+  inputChainId: number;
+  outputChainId: number;
+  inputToken: string;
+  outputToken: string;
+}
+
+export interface ResolvedSelection extends Selection {
+  inputTokens: string[];
+  outputTokens: string[];
+}
+
+export type TokensByChain = Record<number, readonly string[]>;
+export type TokenInfoByChain = Record<number, Record<string, UITokenInfo>>;
+
+export interface RouteConfig {
+  byChain: TokensByChain;
+  tokenInfo: TokenInfoByChain;
+}
+
+function passesAcrossFilter(token: UITokenInfo): boolean {
+  const isAcrossToken = token.providers.includes('across');
+  if (!isAcrossToken) return true;
+  return ACROSS_WHITELISTED_SYMBOLS.has(token.symbol);
+}
+
+/** Tokens on a chain that pass the Across whitelist filter. */
+function availableTokens(addresses: readonly string[], tokenInfo: Record<string, UITokenInfo>): string[] {
+  return addresses.filter((addr) => {
+    const meta = tokenInfo[addr];
+    if (!meta) return true; // Not yet discovered — keep visible until metadata loads
+    return passesAcrossFilter(meta);
+  });
+}
+
+/** Tokens on the output chain reachable from the input token via a shared bridge/swap provider. */
+function compatibleTokens(
+  addresses: readonly string[],
+  tokenInfo: Record<string, UITokenInfo>,
+  inputProviders: string[],
+  inputSymbol: string | undefined,
+): string[] {
+  return addresses.filter((addr) => {
+    const meta = tokenInfo[addr];
+    if (!meta || !passesAcrossFilter(meta)) return false;
+
+    const sharedProviders = meta.providers.filter((p) => inputProviders.includes(p));
+    if (sharedProviders.length === 0) return false;
+
+    // Across can only bridge same-symbol (USDC->USDC), not cross-symbol (USDC->DAI)
+    const onlyViaAcross = sharedProviders.length === 1 && sharedProviders[0] === 'across';
+    const isDifferentSymbol = meta.symbol !== inputSymbol;
+    if (onlyViaAcross && isDifferentSymbol) return false;
+
+    return true;
+  });
+}
+
+function pickFirst(tokens: string[], current: string): string {
+  return tokens.includes(current) ? current : (tokens[0] ?? '');
+}
+
+function resolveInitialOutputChain(
+  url: RouteParams,
+  byChain: TokensByChain,
+  inputChainId: number,
+  defaultInputChainId: number,
+  defaultOutputChainId: number,
+): number {
+  const urlChainIsSupported = url.toChain != null && byChain[url.toChain] != null;
+  const urlChainDiffersFromInput = url.toChain !== inputChainId;
+  if (urlChainIsSupported && urlChainDiffersFromInput) {
+    return url.toChain!;
+  }
+  if (defaultOutputChainId !== inputChainId) {
+    return defaultOutputChainId;
+  }
+  return defaultInputChainId;
+}
+
+export function createRouteSelector(config: RouteConfig) {
+  const { byChain, tokenInfo } = config;
+
+  function inputTokensFor(chainId: number): string[] {
+    const addresses = byChain[chainId] ?? [];
+    const meta = tokenInfo[chainId] ?? {};
+    return availableTokens(addresses, meta);
+  }
+
+  function outputTokensFor(inputChainId: number, inputToken: string, outputChainId: number): string[] {
+    const inputMeta = tokenInfo[inputChainId]?.[inputToken];
+    const addresses = byChain[outputChainId] ?? [];
+    const meta = tokenInfo[outputChainId] ?? {};
+    return compatibleTokens(addresses, meta, inputMeta?.providers ?? [], inputMeta?.symbol);
+  }
+
+  function bestOutputToken(
+    inputChainId: number,
+    inputToken: string,
+    outputChainId: number,
+    currentOutputToken: string,
+  ): string {
+    const candidates = outputTokensFor(inputChainId, inputToken, outputChainId);
+    return pickFirst(candidates, currentOutputToken);
+  }
+
+  function selectionFromUrl(url: RouteParams, defaultInputChainId: number, defaultOutputChainId: number): Selection {
+    const urlInputChainIsSupported = url.fromChain != null && byChain[url.fromChain] != null;
+    const inputChainId = urlInputChainIsSupported ? url.fromChain! : defaultInputChainId;
+
+    const outputChainId = resolveInitialOutputChain(
+      url,
+      byChain,
+      inputChainId,
+      defaultInputChainId,
+      defaultOutputChainId,
+    );
+
+    const inputChainTokens = byChain[inputChainId] ?? [];
+    const outputChainTokens = byChain[outputChainId] ?? [];
+
+    const inputToken = url.fromToken ? (findTokenCaseInsensitive(inputChainTokens, url.fromToken) ?? '') : '';
+    const outputToken = url.toToken ? (findTokenCaseInsensitive(outputChainTokens, url.toToken) ?? '') : '';
+
+    return { inputChainId, outputChainId, inputToken, outputToken };
+  }
+
+  function resolve(selection: Selection): ResolvedSelection {
+    const inputTokens = inputTokensFor(selection.inputChainId);
+    const inputToken = pickFirst(inputTokens, selection.inputToken);
+
+    const outputTokens = outputTokensFor(selection.inputChainId, inputToken, selection.outputChainId);
+    const outputToken = pickFirst(outputTokens, selection.outputToken);
+
+    return {
+      inputChainId: selection.inputChainId,
+      outputChainId: selection.outputChainId,
+      inputToken,
+      outputToken,
+      inputTokens,
+      outputTokens,
+    };
+  }
+
+  function setInputChain(prev: Selection, chainId: number): Selection {
+    const inputToken = pickFirst(inputTokensFor(chainId), prev.inputToken);
+    const outputToken = bestOutputToken(chainId, inputToken, prev.outputChainId, prev.outputToken);
+    return { ...prev, inputChainId: chainId, inputToken, outputToken };
+  }
+
+  function setOutputChain(prev: Selection, chainId: number): Selection {
+    const outputToken = bestOutputToken(prev.inputChainId, prev.inputToken, chainId, prev.outputToken);
+    return { ...prev, outputChainId: chainId, outputToken };
+  }
+
+  function setInputToken(prev: Selection, address: string): Selection {
+    const outputToken = bestOutputToken(prev.inputChainId, address, prev.outputChainId, prev.outputToken);
+    return { ...prev, inputToken: address, outputToken };
+  }
+
+  return { selectionFromUrl, resolve, setInputChain, setOutputChain, setInputToken };
+}


### PR DESCRIPTION
# 🤖 Linear

Closes EFI-819

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cross-chain routes can now be saved and shared via URL parameters (fromChain, toChain, fromToken, toToken), enabling seamless link sharing and bookmarking with selections preserved.
  * Route selections are automatically restored from URL parameters when visiting a shared link.

* **Tests**
  * Added comprehensive test coverage for route selection logic, including URL-driven selection, token resolution, and chain/token compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->