### PR TITLE
feat(cross-chain): add Relay protocol provider (POC)

### DIFF
--- a/.changeset/warm-flies-help.md
+++ b/.changeset/warm-flies-help.md
@@ -1,0 +1,13 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+feat: add Relay protocol provider (POC)
+
+-   **`RelayProvider`** — new cross-chain provider for [Relay](https://relay.link) bridge transfers and swaps
+-   Supports `POST /quote/v2` for fetching quotes and `GET /intents/status/v3` for order tracking
+-   Transaction-based execution (same pattern as Across) with multi-step order support (approve + deposit)
+-   Configurable API key, source header, and testnet/mainnet switching
+-   Tracking via `requestId` polling (not txHash-based)
+-   Registered in factory: `createCrossChainProvider("relay", config?)`
+-   POC limitations: no asset discovery, no payload validation, signature steps excluded

--- a/apps/docs/docs/cross-chain/providers.md
+++ b/apps/docs/docs/cross-chain/providers.md
@@ -9,9 +9,8 @@ This document lists all cross-chain providers supported by the Interop SDK.
 | Provider                                | Status  | Description                                     |
 | --------------------------------------- | ------- | ----------------------------------------------- |
 | [Across Protocol](./across-provider.md) | Testnet | Cross-chain token transfers using Across bridge |
+| [Relay](./relay-provider.md)            | POC     | Cross-chain transfers and swaps using Relay     |
 | [OIF](./oif-provider.md)                | Active  | Direct integration with OIF-compliant solvers   |
-
-> Additional protocols are planned for future releases.
 
 ## Creating Custom Providers
 

--- a/apps/docs/docs/cross-chain/relay-provider.md
+++ b/apps/docs/docs/cross-chain/relay-provider.md
@@ -1,0 +1,146 @@
+---
+title: Relay Provider
+---
+
+The Relay provider enables cross-chain token transfers and swaps using the [Relay](https://relay.link) bridge infrastructure.
+
+**Status**: POC
+
+## Configuration
+
+| Field        | Type    | Required | Description                                        |
+| ------------ | ------- | -------- | -------------------------------------------------- |
+| `isTestnet`  | boolean | No       | Use testnet API (default: false)                   |
+| `apiUrl`     | string  | No       | Custom API endpoint URL (overrides isTestnet)      |
+| `apiKey`     | string  | No       | Relay API key for authenticated requests           |
+| `source`     | string  | No       | Source identifier sent via `x-relay-source` header |
+| `providerId` | string  | No       | Custom provider identifier                         |
+
+Notes:
+
+-   Default API URLs: mainnet `https://api.relay.link`, testnet `https://api.testnets.relay.link`
+-   `apiUrl` overrides both `isTestnet` and the default URL
+
+## Creating the Provider
+
+```typescript
+import { createCrossChainProvider } from "@wonderland/interop-cross-chain";
+
+// Relay config is optional - defaults to mainnet
+const relayProvider = createCrossChainProvider("relay");
+
+// With testnet config
+const testnetProvider = createCrossChainProvider("relay", { isTestnet: true });
+
+// With API key and source
+const authedProvider = createCrossChainProvider("relay", {
+    apiKey: "your-api-key",
+    source: "my-app",
+});
+```
+
+## Getting Quotes
+
+Use the `ProviderExecutor` for SDK-friendly types with readable addresses:
+
+```typescript
+import { createProviderExecutor } from "@wonderland/interop-cross-chain";
+
+const executor = createProviderExecutor({ providers: [relayProvider] });
+
+const response = await executor.getQuotes({
+    user: { chainId: 1, address: "0xYourAddress..." },
+    intent: {
+        inputs: [
+            {
+                asset: { chainId: 1, address: "0xInputToken..." },
+                amount: "1000000000000000000",
+            },
+        ],
+        outputs: [
+            {
+                asset: { chainId: 8453, address: "0xOutputToken..." },
+            },
+        ],
+        swapType: "exact-input",
+    },
+});
+
+const quote = response.quotes[0];
+```
+
+## Executing Transactions
+
+This integration returns **transaction steps** — send the transaction directly:
+
+```typescript
+import { createWalletClient, http } from "viem";
+import { mainnet } from "viem/chains";
+
+const walletClient = createWalletClient({
+    chain: mainnet,
+    transport: http(),
+    account: yourAccount,
+});
+
+// Relay may return multi-step orders (e.g. approve + deposit)
+// Execute steps sequentially
+for (const step of quote.order.steps) {
+    if (step.kind === "transaction") {
+        const hash = await walletClient.sendTransaction({
+            to: step.transaction.to,
+            data: step.transaction.data,
+            ...(step.transaction.value && { value: BigInt(step.transaction.value) }),
+        });
+        console.log("Transaction sent:", hash);
+    }
+}
+```
+
+## Tracking
+
+Relay orders are tracked by `requestId` (returned in quote metadata), not by transaction hash:
+
+```typescript
+const quote = response.quotes[0];
+const requestId = quote.metadata?.requestId;
+
+// Track using orderId (requestId from the quote)
+const tracker = executor.prepareTracking(quote.provider);
+const status = await tracker.track({
+    orderId: requestId,
+    originChainId: 1,
+    destinationChainId: 8453,
+});
+```
+
+Tracking polls `GET /intents/status/v3?requestId=<requestId>` with a 5-second interval.
+
+### Status Mapping
+
+| Relay Status | SDK Status  |
+| ------------ | ----------- |
+| `success`    | `Finalized` |
+| `failure`    | `Failed`    |
+| `refunded`   | `Refunded`  |
+| `refund`     | `Refunded`  |
+| All others   | `Pending`   |
+
+## Features
+
+-   Cross-chain token transfers and swaps
+-   Quote fetching with fee details
+-   Multi-step order support (approve + deposit)
+-   Order tracking via requestId polling
+-   Configurable API key and source headers
+
+## Current Limitations (POC)
+
+-   **Transaction-only**: Relay supports signature flows (e.g. permits), but this integration only handles transaction-based intents. Quotes with signature steps are excluded for now.
+-   **No asset discovery**: `getDiscoveryConfig()` returns `null`
+-   **No payload validation**: Calldata from the API is not validated against intent
+
+## References
+
+-   [Relay Documentation](https://docs.relay.link/)
+-   [Relay API Reference](https://docs.relay.link/references/api)

--- a/apps/docs/docs/cross-chain/relay-provider.md
+++ b/apps/docs/docs/cross-chain/relay-provider.md
@@ -85,6 +85,8 @@ const walletClient = createWalletClient({
 
 // Relay may return multi-step orders (e.g. approve + deposit)
 // Execute steps sequentially
+// NOTE: In production, validate step.transaction.to against trusted contract
+// addresses before sending to protect against compromised API responses.
 for (const step of quote.order.steps) {
     if (step.kind === "transaction") {
         const hash = await walletClient.sendTransaction({

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -43,6 +43,7 @@ const sidebars: SidebarsConfig = {
                 "cross-chain/getting-started",
                 "cross-chain/providers",
                 "cross-chain/across-provider",
+                "cross-chain/relay-provider",
                 "cross-chain/oif-provider",
                 "cross-chain/example",
                 "cross-chain/flow",

--- a/examples/ui/app/cross-chain/constants/providers.ts
+++ b/examples/ui/app/cross-chain/constants/providers.ts
@@ -19,7 +19,7 @@ export const PROVIDERS: ProviderConfig[] = [
     id: PROTOCOLS.RELAY,
     displayName: 'Relay',
     config: {
-      apiUrl: process.env.NEXT_PUBLIC_RELAY_API_URL,
+      apiUrl: process.env.NEXT_PUBLIC_RELAY_API_URL || 'https://api.relay.link',
       providerId: 'relay',
     },
   },

--- a/examples/ui/app/cross-chain/constants/providers.ts
+++ b/examples/ui/app/cross-chain/constants/providers.ts
@@ -15,6 +15,14 @@ export const PROVIDERS: ProviderConfig[] = [
       providerId: 'across',
     },
   },
+  {
+    id: PROTOCOLS.RELAY,
+    displayName: 'Relay',
+    config: {
+      apiUrl: process.env.NEXT_PUBLIC_RELAY_API_URL,
+      providerId: 'relay',
+    },
+  },
 ];
 
 /**

--- a/examples/ui/app/cross-chain/hooks/useOrderExecution.ts
+++ b/examples/ui/app/cross-chain/hooks/useOrderExecution.ts
@@ -97,8 +97,11 @@ export function useOrderExecution(): UseOrderExecutionReturn {
         );
         expectedWalletChainIdRef.current = null;
 
-        // Execute the first step of the order
-        const step = quote.order.steps[0];
+        // For multi-step orders (e.g. Relay's approve + deposit), use the last
+        // step for execution. The UI's handleTokenApproval already handles
+        // ERC-20 approvals independently, so intermediate approve steps are
+        // redundant and can be skipped safely.
+        const step = quote.order.steps[quote.order.steps.length - 1];
         if (!step) {
           throw new Error('Invalid quote: order has no steps');
         }
@@ -114,10 +117,15 @@ export function useOrderExecution(): UseOrderExecutionReturn {
           onStateChange: setState,
         };
 
-        const trackingId =
+        const stepResult =
           step.kind === 'signature'
             ? await executeSignatureStep({ ...flowParams, step })
             : await executeTransactionStep({ ...flowParams, step });
+
+        // For providers that track by requestId (e.g. Relay), use orderId-based
+        // tracking instead of txHash-based tracking.
+        const requestId = quote.metadata?.requestId as string | undefined;
+        const trackingId = requestId ? { orderId: requestId as Hex } : stepResult;
 
         // Common: track order
         await trackOrder(quote._providerId, trackingId, chainContext, abortControllerRef.current?.signal, setState);

--- a/examples/ui/app/cross-chain/hooks/useOrderExecution.ts
+++ b/examples/ui/app/cross-chain/hooks/useOrderExecution.ts
@@ -101,6 +101,15 @@ export function useOrderExecution(): UseOrderExecutionReturn {
         // step for execution. The UI's handleTokenApproval already handles
         // ERC-20 approvals independently, so intermediate approve steps are
         // redundant and can be skipped safely.
+        if (quote.order.steps.length > 1) {
+          console.warn(
+            `[useOrderExecution] Order has ${quote.order.steps.length} steps, using last step only. ` +
+              `Skipped steps: ${quote.order.steps
+                .slice(0, -1)
+                .map((s) => s.description ?? s.kind)
+                .join(', ')}`,
+          );
+        }
         const step = quote.order.steps[quote.order.steps.length - 1];
         if (!step) {
           throw new Error('Invalid quote: order has no steps');
@@ -124,7 +133,8 @@ export function useOrderExecution(): UseOrderExecutionReturn {
 
         // For providers that track by requestId (e.g. Relay), use orderId-based
         // tracking instead of txHash-based tracking.
-        const requestId = quote.metadata?.requestId as string | undefined;
+        const rawRequestId = quote.metadata?.requestId;
+        const requestId = typeof rawRequestId === 'string' ? rawRequestId : undefined;
         const trackingId = requestId ? { orderId: requestId as Hex } : stepResult;
 
         // Common: track order

--- a/examples/ui/app/cross-chain/services/sdk.ts
+++ b/examples/ui/app/cross-chain/services/sdk.ts
@@ -26,6 +26,10 @@ const PROVIDER_CONFIGS = [
     providerId: 'oif',
     displayName: 'OIF Sample Solver',
   },
+  {
+    providerId: 'relay',
+    displayName: 'Relay',
+  },
 ];
 
 /**
@@ -40,6 +44,10 @@ const providers: CrossChainProvider[] = [
     solverId: OIF_SOLVER_ID,
     url: OIF_API_URL,
     providerId: 'oif',
+  }),
+  createCrossChainProvider(PROTOCOLS.RELAY, {
+    isTestnet: IS_TESTNET,
+    providerId: 'relay',
   }),
 ];
 

--- a/examples/ui/app/cross-chain/utils/routeSelection.ts
+++ b/examples/ui/app/cross-chain/utils/routeSelection.ts
@@ -1,7 +1,13 @@
 import { findTokenCaseInsensitive, type RouteParams } from './routeParams';
 import type { UITokenInfo } from '../types/assets';
 
-const ACROSS_WHITELISTED_SYMBOLS = new Set(['USDC', 'USDT', 'WETH', 'DAI', 'ETH']);
+// TODO: Replace with dynamic lookup via protocol-specific route endpoints.
+// See: https://docs.across.to/reference/api-reference
+// See: https://docs.relay.link/references/api/get-config
+const BRIDGE_WHITELISTED_SYMBOLS = new Set(['USDC', 'USDT', 'WETH', 'DAI', 'ETH']);
+
+/** Providers that share the same asset whitelist for the UI. */
+const WHITELISTED_PROVIDERS = new Set(['across', 'relay']);
 
 export interface Selection {
   inputChainId: number;
@@ -23,18 +29,18 @@ export interface RouteConfig {
   tokenInfo: TokenInfoByChain;
 }
 
-function passesAcrossFilter(token: UITokenInfo): boolean {
-  const isAcrossToken = token.providers.includes('across');
-  if (!isAcrossToken) return true;
-  return ACROSS_WHITELISTED_SYMBOLS.has(token.symbol);
+function passesBridgeFilter(token: UITokenInfo): boolean {
+  const isFromWhitelistedProvider = token.providers.some((p) => WHITELISTED_PROVIDERS.has(p));
+  if (!isFromWhitelistedProvider) return true;
+  return BRIDGE_WHITELISTED_SYMBOLS.has(token.symbol);
 }
 
-/** Tokens on a chain that pass the Across whitelist filter. */
+/** Tokens on a chain that pass the bridge whitelist filter. */
 function availableTokens(addresses: readonly string[], tokenInfo: Record<string, UITokenInfo>): string[] {
   return addresses.filter((addr) => {
     const meta = tokenInfo[addr];
     if (!meta) return true; // Not yet discovered — keep visible until metadata loads
-    return passesAcrossFilter(meta);
+    return passesBridgeFilter(meta);
   });
 }
 
@@ -47,7 +53,7 @@ function compatibleTokens(
 ): string[] {
   return addresses.filter((addr) => {
     const meta = tokenInfo[addr];
-    if (!meta || !passesAcrossFilter(meta)) return false;
+    if (!meta || !passesBridgeFilter(meta)) return false;
 
     const sharedProviders = meta.providers.filter((p) => inputProviders.includes(p));
     if (sharedProviders.length === 0) return false;

--- a/packages/cross-chain/README.md
+++ b/packages/cross-chain/README.md
@@ -60,15 +60,24 @@ const acrossProvider = createCrossChainProvider("across");
 // Across with testnet config
 const testnetProvider = createCrossChainProvider("across", { isTestnet: true });
 
+// Relay - config optional (defaults to mainnet: https://api.relay.link)
+const relayProvider = createCrossChainProvider("relay");
+
+// Relay with API key
+const relayWithKey = createCrossChainProvider("relay", {
+    apiKey: "your-api-key",
+    source: "my-app",
+});
+
 // OIF - config required
 const oifProvider = createCrossChainProvider("oif", {
     solverId: "my-solver",
     url: "https://...",
 });
 
-// Create executor with providers (can mix Across, OIF, etc.)
+// Create executor with providers (can mix Across, Relay, OIF, etc.)
 const executor = createProviderExecutor({
-    providers: [acrossProvider, oifProvider],
+    providers: [acrossProvider, relayProvider, oifProvider],
 });
 
 // Get quotes — addresses use readable { chainId, address } objects
@@ -115,13 +124,19 @@ if (step.kind === "signature") {
 
 ### Providers
 
--   `createCrossChainProvider(protocolName, config?)` – Create a provider for a supported protocol. Config is optional for Across (defaults to mainnet), required for OIF.
+-   `createCrossChainProvider(protocolName, config?)` – Create a provider for a supported protocol. Config is optional for Across and Relay (defaults to mainnet), required for OIF.
 -   `CrossChainProvider` (abstract class)
     -   `.getProtocolName()` – Returns the protocol name.
     -   `.getProviderId()` – Returns the provider identifier.
     -   `.getQuotes(params)` – Fetch quotes using SDK-friendly `QuoteRequest`. Returns `Quote[]`.
     -   `.submitOrder(quote, signature)` – Submit a signed order to the provider. Throws `ProviderExecuteNotImplemented` by default (only OIF implements this).
     -   `.getTrackingConfig()` – Get configuration for order tracking.
+
+### Tracking Notes (Relay)
+
+-   **Tracking by requestId**: Relay orders are tracked via `requestId` (from the quote metadata), not by transaction hash.
+-   **API polling**: Status is polled from `GET /intents/status/v3?requestId=<requestId>` every 5 seconds.
+-   Status mapping: `"success"` → Finalized, `"failure"` → Failed, `"refunded"/"refund"` → Refunded, all others → Pending.
 
 ### Tracking Notes (Across)
 
@@ -203,6 +218,75 @@ const ethTokens = discovered.tokensByChain[toChainIdentifier(1)];
 -   `getTransactionSteps(order)` – Get all transaction steps from an order.
 -   `isSignatureOnlyOrder(order)` – Check if an order only requires signatures.
 -   `isTransactionOnlyOrder(order)` – Check if an order only requires transactions.
+
+## Relay Provider
+
+The Relay Provider enables cross-chain token transfers and swaps using the [Relay](https://relay.link) bridge infrastructure.
+
+### Usage
+
+```typescript
+import { createCrossChainProvider, createProviderExecutor } from "@wonderland/interop-cross-chain";
+
+// Create Relay provider (config optional — defaults to mainnet)
+const provider = createCrossChainProvider("relay");
+
+// With API key and source
+const authedProvider = createCrossChainProvider("relay", {
+    apiKey: "your-api-key",
+    source: "my-app",
+});
+
+// Get quotes via the executor
+const executor = createProviderExecutor({ providers: [provider] });
+
+const response = await executor.getQuotes({
+    user: { chainId: 1, address: "0xYourAddress..." },
+    intent: {
+        inputs: [
+            {
+                asset: { chainId: 1, address: "0xInputToken..." },
+                amount: "1000000",
+            },
+        ],
+        outputs: [
+            {
+                asset: { chainId: 8453, address: "0xOutputToken..." },
+            },
+        ],
+        swapType: "exact-input",
+    },
+});
+
+const quote = response.quotes[0];
+
+// Relay returns transaction steps — send directly
+for (const step of quote.order.steps) {
+    if (step.kind === "transaction") {
+        await walletClient.sendTransaction({
+            to: step.transaction.to,
+            data: step.transaction.data,
+            ...(step.transaction.value && { value: BigInt(step.transaction.value) }),
+        });
+    }
+}
+```
+
+### Configuration
+
+| Field        | Type    | Required | Description                                 |
+| ------------ | ------- | -------- | ------------------------------------------- |
+| `isTestnet`  | boolean | No       | Use testnet API (default: false)            |
+| `apiUrl`     | string  | No       | Custom API endpoint URL                     |
+| `apiKey`     | string  | No       | Relay API key for authenticated requests    |
+| `source`     | string  | No       | Source identifier sent via `x-relay-source` |
+| `providerId` | string  | No       | Custom provider identifier                  |
+
+### Current Limitations (POC)
+
+-   Only transaction-based quotes are supported (signature steps are excluded)
+-   No asset discovery — `getDiscoveryConfig()` returns `null`
+-   No calldata validation
 
 ## OIF Provider
 

--- a/packages/cross-chain/src/core/types/providers.ts
+++ b/packages/cross-chain/src/core/types/providers.ts
@@ -3,11 +3,14 @@ import type {
     AcrossProvider,
     OifProvider,
     OifProviderConfig,
+    RelayConfigs,
+    RelayProvider,
 } from "../../internal.js";
 
 export const PROTOCOLS = {
     ACROSS: "across",
     OIF: "oif",
+    RELAY: "relay",
 } as const;
 
 export type SupportedProtocols = (typeof PROTOCOLS)[keyof typeof PROTOCOLS];
@@ -15,9 +18,11 @@ export type SupportedProtocols = (typeof PROTOCOLS)[keyof typeof PROTOCOLS];
 export type SupportedProtocolProviders = {
     [PROTOCOLS.ACROSS]: AcrossProvider;
     [PROTOCOLS.OIF]: OifProvider;
+    [PROTOCOLS.RELAY]: RelayProvider;
 };
 
 export type SupportedProtocolsConfigs<Protocol extends SupportedProtocols> = {
     [PROTOCOLS.ACROSS]: AcrossConfigs;
     [PROTOCOLS.OIF]: OifProviderConfig;
+    [PROTOCOLS.RELAY]: RelayConfigs;
 }[Protocol];

--- a/packages/cross-chain/src/external.ts
+++ b/packages/cross-chain/src/external.ts
@@ -9,6 +9,7 @@ export { PERMIT2_TYPES, EIP3009_TYPES } from "./protocols/oif/constants.js";
 export {
     AcrossProvider,
     OifProvider,
+    RelayProvider,
     createCrossChainProvider,
     createProviderExecutor,
     ProviderExecutor,

--- a/packages/cross-chain/src/factories/crossChainProviderFactory.ts
+++ b/packages/cross-chain/src/factories/crossChainProviderFactory.ts
@@ -1,5 +1,16 @@
-import type { AcrossConfigs, CrossChainProvider, OifProviderConfig } from "../internal.js";
-import { AcrossProvider, OifProvider, PROTOCOLS, UnsupportedProtocol } from "../internal.js";
+import type {
+    AcrossConfigs,
+    CrossChainProvider,
+    OifProviderConfig,
+    RelayConfigs,
+} from "../internal.js";
+import {
+    AcrossProvider,
+    OifProvider,
+    PROTOCOLS,
+    RelayProvider,
+    UnsupportedProtocol,
+} from "../internal.js";
 
 /**
  * Creates a CrossChainProvider for Across protocol
@@ -20,6 +31,15 @@ export function createCrossChainProvider(
     config: OifProviderConfig,
 ): CrossChainProvider;
 /**
+ * Creates a CrossChainProvider for Relay protocol
+ * @param protocolName - "relay"
+ * @param config - Optional configuration (defaults to mainnet)
+ */
+export function createCrossChainProvider(
+    protocolName: typeof PROTOCOLS.RELAY,
+    config?: RelayConfigs,
+): CrossChainProvider;
+/**
  * Creates a CrossChainProvider for the specified protocol
  * @param protocolName - The name of the protocol
  * @param config - The configuration for the provider
@@ -33,5 +53,6 @@ export function createCrossChainProvider(
     if (protocolName === PROTOCOLS.ACROSS)
         return new AcrossProvider((config as AcrossConfigs) ?? {});
     if (protocolName === PROTOCOLS.OIF) return new OifProvider(config as OifProviderConfig);
+    if (protocolName === PROTOCOLS.RELAY) return new RelayProvider((config as RelayConfigs) ?? {});
     throw new UnsupportedProtocol(protocolName);
 }

--- a/packages/cross-chain/src/internal.ts
+++ b/packages/cross-chain/src/internal.ts
@@ -13,6 +13,7 @@ export * from "./core/validators/index.js";
 // Protocols
 export * from "./protocols/oif/index.js";
 export * from "./protocols/across/index.js";
+export * from "./protocols/relay/index.js";
 export * from "./protocols/sample/index.js";
 
 // Factories (depend on both core and protocols)

--- a/packages/cross-chain/src/protocols/index.ts
+++ b/packages/cross-chain/src/protocols/index.ts
@@ -1,3 +1,4 @@
 export * from "./oif/index.js";
 export * from "./across/index.js";
+export * from "./relay/index.js";
 export * from "./sample/index.js";

--- a/packages/cross-chain/src/protocols/relay/constants.ts
+++ b/packages/cross-chain/src/protocols/relay/constants.ts
@@ -1,0 +1,19 @@
+/**
+ * Relay Protocol API URLs
+ * @see https://docs.relay.link/
+ */
+const RELAY_API_URLS = {
+    mainnet: "https://api.relay.link",
+    testnet: "https://api.testnets.relay.link",
+} as const;
+
+/**
+ * Get Relay API URL based on network configuration
+ * @param isTestnet - Whether to use testnet (defaults to false for mainnet)
+ * @returns The appropriate API URL
+ */
+export function getRelayApiUrl(isTestnet: boolean = false): string {
+    return isTestnet ? RELAY_API_URLS.testnet : RELAY_API_URLS.mainnet;
+}
+
+export { RELAY_API_URLS };

--- a/packages/cross-chain/src/protocols/relay/index.ts
+++ b/packages/cross-chain/src/protocols/relay/index.ts
@@ -1,0 +1,5 @@
+export * from "./provider.js";
+export * from "./constants.js";
+export * from "./interfaces.js";
+export * from "./schemas.js";
+export * from "./types.js";

--- a/packages/cross-chain/src/protocols/relay/interfaces.ts
+++ b/packages/cross-chain/src/protocols/relay/interfaces.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+import {
+    RelayConfigSchema,
+    RelayQuoteRequestSchema,
+    RelayQuoteResponseSchema,
+    RelayStepItemDataSchema,
+    RelayStepItemSchema,
+    RelayStepSchema,
+} from "../../internal.js";
+
+/** Relay provider configuration (input type, before defaults applied) */
+export type RelayConfigs = z.input<typeof RelayConfigSchema>;
+
+/** Validated Relay quote request body */
+export type RelayQuoteRequest = z.infer<typeof RelayQuoteRequestSchema>;
+
+/** Validated Relay quote response */
+export type RelayQuoteResponse = z.infer<typeof RelayQuoteResponseSchema>;
+
+/** A single step in the Relay response */
+export type RelayStep = z.infer<typeof RelayStepSchema>;
+
+/** A single item within a Relay step */
+export type RelayStepItem = z.infer<typeof RelayStepItemSchema>;
+
+/** Transaction data within a step item */
+export type RelayStepItemData = z.infer<typeof RelayStepItemDataSchema>;

--- a/packages/cross-chain/src/protocols/relay/provider.ts
+++ b/packages/cross-chain/src/protocols/relay/provider.ts
@@ -300,7 +300,7 @@ export class RelayProvider extends CrossChainProvider {
      * Get API-based fill watcher config for Relay
      * Uses Relay API to track intent status via requestId
      *
-     * @see https://docs.relay.link/references/api/get-intent-status-v2
+     * @see https://docs.relay.link/references/api/get-intents-status-v3
      */
     static getFillWatcherConfigAPI(
         apiUrl: string,

--- a/packages/cross-chain/src/protocols/relay/provider.ts
+++ b/packages/cross-chain/src/protocols/relay/provider.ts
@@ -1,0 +1,429 @@
+import axios, { AxiosError } from "axios";
+import { Address, Hex } from "viem";
+import { ZodError } from "zod";
+
+import type { TransactionStep } from "../../core/types/order.js";
+import type { Quote } from "../../core/types/quote.js";
+import type { QuoteRequest } from "../../core/types/quoteRequest.js";
+import {
+    APIBasedFillWatcherConfig,
+    CrossChainProvider,
+    FillEvent,
+    FillWatcherConfig,
+    GetFillParams,
+    OpenedIntentParserConfig,
+    OrderFailureReason,
+    OrderStatus,
+    ProviderConfigFailure,
+    ProviderGetQuoteFailure,
+} from "../../internal.js";
+import { getRelayApiUrl } from "./constants.js";
+import { RelayConfigs, RelayQuoteResponse, RelayStep } from "./interfaces.js";
+import { RelayConfigSchema, RelayQuoteResponseSchema } from "./schemas.js";
+import { RelayIntentStatusResponse, RelayMetadata } from "./types.js";
+
+/**
+ * An implementation of the CrossChainProvider interface for the Relay protocol.
+ *
+ * Relay is a cross-chain bridge/swap protocol with a REST API.
+ * Relay supports both transaction-based and signature-based flows,
+ * but this integration only handles transaction-based intents for now.
+ * A quote can return multi-step flows (e.g. approve + deposit).
+ *
+ * @see https://docs.relay.link/
+ */
+export class RelayProvider extends CrossChainProvider {
+    static readonly PROTOCOL_NAME = "relay" as const;
+
+    readonly protocolName = RelayProvider.PROTOCOL_NAME;
+    readonly providerId: string;
+    private readonly apiUrl: string;
+    private readonly apiKey?: string;
+    private readonly source?: string;
+    private readonly isTestnet: boolean;
+
+    constructor(config: RelayConfigs) {
+        super();
+
+        try {
+            const configParsed = RelayConfigSchema.parse(config);
+            this.isTestnet = configParsed.isTestnet ?? false;
+            this.apiUrl = configParsed.apiUrl || getRelayApiUrl(this.isTestnet);
+            this.apiKey = configParsed.apiKey;
+            this.source = configParsed.source;
+            this.providerId = configParsed.providerId;
+        } catch (error) {
+            if (error instanceof ZodError) {
+                throw new ProviderConfigFailure(
+                    "Failed to parse Relay config",
+                    error.message,
+                    error.stack,
+                );
+            }
+            throw new ProviderConfigFailure(
+                "Failed to configure Relay provider",
+                String(error),
+                error instanceof Error ? error.stack : undefined,
+            );
+        }
+    }
+
+    /**
+     * Build HTTP headers for Relay API requests
+     */
+    private buildHeaders(): Record<string, string> {
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+        if (this.apiKey) {
+            headers["Authorization"] = `Bearer ${this.apiKey}`;
+        }
+        if (this.source) {
+            headers["x-relay-source"] = this.source;
+        }
+        return headers;
+    }
+
+    /**
+     * Get a quote from the Relay API
+     */
+    private async getRelayQuote(body: Record<string, unknown>): Promise<RelayQuoteResponse> {
+        try {
+            const response = await axios.post(`${this.apiUrl}/quote/v2`, body, {
+                headers: this.buildHeaders(),
+            });
+
+            if (response.status !== 200) {
+                throw new ProviderGetQuoteFailure("Failed to get Relay quote");
+            }
+
+            return RelayQuoteResponseSchema.parse(response.data);
+        } catch (error) {
+            if (error instanceof AxiosError) {
+                const errorData = error.response?.data as { message?: string } | undefined;
+
+                const message =
+                    errorData?.message ||
+                    (error.cause as Error | undefined)?.message ||
+                    error.message ||
+                    "Failed to get Relay quote";
+
+                throw new ProviderGetQuoteFailure(
+                    "Failed to get Relay quote",
+                    message,
+                    error.stack,
+                );
+            } else if (error instanceof ZodError) {
+                throw new ProviderGetQuoteFailure(
+                    "Failed to parse Relay quote",
+                    error.message,
+                    error.stack,
+                );
+            }
+            if (error instanceof ProviderGetQuoteFailure) {
+                throw error;
+            }
+            throw new ProviderGetQuoteFailure(
+                "Failed to get Relay quote",
+                String(error),
+                error instanceof Error ? error.stack : undefined,
+            );
+        }
+    }
+
+    /**
+     * Extract the requestId from the Relay response steps.
+     * Typically found on the deposit (last) step.
+     */
+    private static extractRequestId(steps: RelayStep[]): string | undefined {
+        // Walk backwards — the deposit step usually has the requestId
+        for (let i = steps.length - 1; i >= 0; i--) {
+            if (steps[i]!.requestId) {
+                return steps[i]!.requestId;
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    async getQuotes(params: QuoteRequest): Promise<Quote[]> {
+        try {
+            // Read SDK types directly — same pattern as AcrossProvider
+            const input = params.intent.inputs[0]!;
+            const output = params.intent.outputs[0]!;
+            const recipient = output.recipient ?? {
+                chainId: output.asset.chainId,
+                address: params.user.address,
+            };
+
+            const swapType = params.intent.swapType || "exact-input";
+
+            if (swapType === "exact-output" && !output.amount) {
+                throw new ProviderGetQuoteFailure(
+                    "exact-output swap requires output.amount to be specified",
+                );
+            }
+            if (swapType === "exact-input" && !input.amount) {
+                throw new ProviderGetQuoteFailure(
+                    "exact-input swap requires input.amount to be specified",
+                );
+            }
+
+            // Build Relay API request body
+            const body: Record<string, unknown> = {
+                user: params.user.address,
+                originChainId: input.asset.chainId,
+                destinationChainId: output.asset.chainId,
+                originCurrency: input.asset.address,
+                destinationCurrency: output.asset.address,
+                amount: swapType === "exact-output" ? output.amount! : input.amount!,
+                tradeType: swapType === "exact-output" ? "EXACT_OUTPUT" : "EXACT_INPUT",
+            };
+
+            // Only include recipient if different from user
+            if (recipient.address !== params.user.address) {
+                body.recipient = recipient.address;
+            }
+
+            const relayResponse = await this.getRelayQuote(body);
+
+            // We only integrate transaction-based steps for now.
+            // Relay also supports signature steps (e.g. permits),
+            // which could be mapped to SDK SignatureSteps in a future iteration.
+            // If any step is non-transaction, skip this quote entirely.
+            const hasUnsupportedSteps = relayResponse.steps.some(
+                (relayStep) => relayStep.kind !== "transaction",
+            );
+            if (hasUnsupportedSteps) {
+                return [];
+            }
+
+            const steps: TransactionStep[] = relayResponse.steps.flatMap((relayStep) =>
+                relayStep.items
+                    .filter((item) => item.status === "incomplete")
+                    .map(
+                        (item): TransactionStep => ({
+                            kind: "transaction" as const,
+                            chainId: item.data.chainId,
+                            description: relayStep.id,
+                            transaction: {
+                                to: item.data.to as string,
+                                data: item.data.data,
+                                ...(item.data.value && { value: item.data.value }),
+                                ...(item.data.maxFeePerGas && {
+                                    maxFeePerGas: item.data.maxFeePerGas,
+                                }),
+                                ...(item.data.maxPriorityFeePerGas && {
+                                    maxPriorityFeePerGas: item.data.maxPriorityFeePerGas,
+                                }),
+                            },
+                        }),
+                    ),
+            );
+
+            const requestId = RelayProvider.extractRequestId(relayResponse.steps);
+
+            // Build preview from details (with request params as fallback)
+            const inputAmount =
+                relayResponse.details?.currencyIn?.amount ??
+                (swapType === "exact-input" ? input.amount! : (input.amount ?? "0"));
+            const outputAmount =
+                relayResponse.details?.currencyOut?.amount ??
+                (swapType === "exact-output" ? output.amount! : (output.amount ?? "0"));
+
+            const quote: Quote = {
+                order: {
+                    steps,
+                    metadata: {
+                        requestId,
+                    },
+                },
+                preview: {
+                    inputs: [
+                        {
+                            account: {
+                                chainId: input.asset.chainId,
+                                address: params.user.address,
+                            },
+                            asset: {
+                                chainId: input.asset.chainId,
+                                address: input.asset.address,
+                            },
+                            amount: inputAmount,
+                        },
+                    ],
+                    outputs: [
+                        {
+                            account: recipient,
+                            asset: {
+                                chainId: output.asset.chainId,
+                                address: output.asset.address,
+                            },
+                            amount: outputAmount,
+                        },
+                    ],
+                },
+                provider: this.providerId,
+                quoteId: requestId,
+                eta: relayResponse.details?.timeEstimate,
+                partialFill: false,
+                failureHandling: "refund-automatic",
+                metadata: {
+                    requestId,
+                    relayFees: relayResponse.fees,
+                },
+            };
+
+            return [quote];
+        } catch (error) {
+            if (error instanceof ZodError) {
+                throw new ProviderGetQuoteFailure(
+                    "Failed to parse Relay quote request",
+                    error.message,
+                    error.stack,
+                );
+            }
+            if (error instanceof ProviderGetQuoteFailure) {
+                throw error;
+            }
+            throw new ProviderGetQuoteFailure(
+                "Failed to get Relay quotes",
+                String(error),
+                error instanceof Error ? error.stack : undefined,
+            );
+        }
+    }
+
+    /**
+     * Get API-based fill watcher config for Relay
+     * Uses Relay API to track intent status via requestId
+     *
+     * @see https://docs.relay.link/references/api/get-intent-status-v2
+     */
+    static getFillWatcherConfigAPI(
+        apiUrl: string,
+        apiKey?: string,
+        source?: string,
+    ): APIBasedFillWatcherConfig<RelayIntentStatusResponse, RelayMetadata> {
+        const headers: Record<string, string> = {};
+        if (apiKey) {
+            headers["Authorization"] = `Bearer ${apiKey}`;
+        }
+        if (source) {
+            headers["x-relay-source"] = source;
+        }
+
+        return {
+            type: "api-based",
+            baseUrl: apiUrl,
+            ...(apiKey && { apiKey }),
+            ...(Object.keys(headers).length > 0 && { headers }),
+            pollingInterval: 5000,
+            retry: {
+                maxAttempts: 3,
+                initialDelay: 2000,
+                maxDelay: 15000,
+                backoffMultiplier: 2,
+            },
+            buildEndpoint: (params: GetFillParams): string => {
+                // Relay tracks by requestId, passed as orderId
+                return `/intents/status/v3?requestId=${params.orderId}`;
+            },
+            extractFillEvent: (
+                response: RelayIntentStatusResponse,
+                params: GetFillParams,
+            ): {
+                event: FillEvent | null;
+                status: OrderStatus;
+                failureReason?: OrderFailureReason;
+                metadata?: RelayMetadata;
+            } => {
+                let status: OrderStatus;
+                let failureReason: OrderFailureReason | undefined;
+
+                switch (response.status) {
+                    case "success":
+                        status = OrderStatus.Finalized;
+                        break;
+                    case "failure":
+                        status = OrderStatus.Failed;
+                        failureReason = OrderFailureReason.Unknown;
+                        break;
+                    case "refunded":
+                    case "refund":
+                        status = OrderStatus.Refunded;
+                        break;
+                    case "waiting":
+                    case "pending":
+                    case "submitted":
+                    case "delayed":
+                    default:
+                        status = OrderStatus.Pending;
+                        break;
+                }
+
+                const metadata: RelayMetadata = {
+                    requestId: params.orderId,
+                    inTxHashes: response.inTxHashes,
+                    txHashes: response.txHashes,
+                };
+
+                // Only extract fill event when status is "success" and we have destination tx hashes
+                if (response.status !== "success" || !response.txHashes?.length) {
+                    return { event: null, status, failureReason, metadata };
+                }
+
+                const event: FillEvent = {
+                    fillTxHash: response.txHashes[0] as Hex,
+                    blockNumber: 0n,
+                    timestamp: 0,
+                    originChainId: params.originChainId,
+                    orderId: params.orderId,
+                    relayer: "0x0000000000000000000000000000000000000000" as Address,
+                    recipient: "0x0000000000000000000000000000000000000000" as Address,
+                };
+
+                return { event, status, failureReason, metadata };
+            },
+        };
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * Relay tracks orders by requestId via its REST API.
+     * The opened intent parser is a stub because Relay uses requestId-based
+     * tracking (watchOrderByOrderId path) rather than on-chain event parsing.
+     */
+    getTrackingConfig(): {
+        openedIntentParserConfig: OpenedIntentParserConfig;
+        fillWatcherConfig: FillWatcherConfig;
+    } {
+        return {
+            openedIntentParserConfig: {
+                type: "custom-event",
+                config: {
+                    protocolName: RelayProvider.PROTOCOL_NAME,
+                    // Stub event signature — Relay uses requestId-based tracking,
+                    // not on-chain event parsing. The watchOrderByOrderId path
+                    // skips the parser entirely.
+                    eventSignature:
+                        "0x0000000000000000000000000000000000000000000000000000000000000000" as Hex,
+                    extractOpenedIntent: (): never => {
+                        throw new Error(
+                            "Relay does not support on-chain event parsing. " +
+                                "Use watchOrder({ orderId: requestId, ... }) instead.",
+                        );
+                    },
+                },
+            },
+            fillWatcherConfig: RelayProvider.getFillWatcherConfigAPI(
+                this.apiUrl,
+                this.apiKey,
+                this.source,
+            ) as FillWatcherConfig,
+        };
+    }
+}

--- a/packages/cross-chain/src/protocols/relay/schemas.ts
+++ b/packages/cross-chain/src/protocols/relay/schemas.ts
@@ -1,0 +1,100 @@
+import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
+
+import { HexAddressSchema } from "../../core/schemas/address.js";
+
+/**
+ * Configuration schema for the Relay provider
+ */
+export const RelayConfigSchema = z
+    .object({
+        isTestnet: z.boolean().optional().default(false),
+        apiUrl: z.string().optional(),
+        apiKey: z.string().optional(),
+        source: z.string().optional(),
+        providerId: z.string().default(`relay_${uuidv4()}`),
+    })
+    .describe("Configuration for the Relay provider");
+
+/**
+ * Schema for Relay quote request body sent to POST /quote/v2
+ */
+export const RelayQuoteRequestSchema = z.object({
+    user: HexAddressSchema,
+    originChainId: z.number(),
+    destinationChainId: z.number(),
+    originCurrency: HexAddressSchema,
+    destinationCurrency: HexAddressSchema,
+    amount: z.string(),
+    tradeType: z.enum(["EXACT_INPUT", "EXACT_OUTPUT"]),
+    recipient: HexAddressSchema.optional(),
+});
+
+/**
+ * Schema for individual step item transaction data
+ */
+export const RelayStepItemDataSchema = z.object({
+    from: HexAddressSchema,
+    to: HexAddressSchema,
+    data: z.string(),
+    value: z.string().optional(),
+    chainId: z.number(),
+    maxFeePerGas: z.string().optional(),
+    maxPriorityFeePerGas: z.string().optional(),
+});
+
+/**
+ * Schema for a step item (individual action within a step)
+ */
+export const RelayStepItemSchema = z.object({
+    status: z.string(),
+    data: RelayStepItemDataSchema,
+    check: z
+        .object({
+            endpoint: z.string(),
+            method: z.string(),
+        })
+        .optional(),
+});
+
+/**
+ * Schema for a step (group of related actions)
+ */
+export const RelayStepSchema = z.object({
+    id: z.string(),
+    kind: z.string(),
+    requestId: z.string().optional(),
+    action: z.string().optional(),
+    description: z.string().optional(),
+    items: z.array(RelayStepItemSchema),
+});
+
+/**
+ * Schema for the full Relay quote response from POST /quote/v2
+ * Uses passthrough on fees/details for resilience against API changes
+ */
+export const RelayQuoteResponseSchema = z.object({
+    steps: z.array(RelayStepSchema),
+    fees: z.record(z.unknown()).optional(),
+    details: z
+        .object({
+            currencyIn: z
+                .object({
+                    amount: z.string().optional(),
+                    amountFormatted: z.string().optional(),
+                    currency: z.record(z.unknown()).optional(),
+                })
+                .optional(),
+            currencyOut: z
+                .object({
+                    amount: z.string().optional(),
+                    amountFormatted: z.string().optional(),
+                    currency: z.record(z.unknown()).optional(),
+                })
+                .optional(),
+            timeEstimate: z.number().optional(),
+            rate: z.string().optional(),
+        })
+        .passthrough()
+        .optional(),
+});

--- a/packages/cross-chain/src/protocols/relay/schemas.ts
+++ b/packages/cross-chain/src/protocols/relay/schemas.ts
@@ -12,7 +12,7 @@ export const RelayConfigSchema = z
         apiUrl: z.string().optional(),
         apiKey: z.string().optional(),
         source: z.string().optional(),
-        providerId: z.string().default(`relay_${uuidv4()}`),
+        providerId: z.string().default(() => `relay_${uuidv4()}`),
     })
     .describe("Configuration for the Relay provider");
 

--- a/packages/cross-chain/src/protocols/relay/types.ts
+++ b/packages/cross-chain/src/protocols/relay/types.ts
@@ -18,7 +18,7 @@ export type RelayIntentStatus =
 /**
  * Relay Intent Status Response
  * From: GET https://api.relay.link/intents/status/v3
- * @see https://docs.relay.link/references/api/get-intent-status-v2
+ * @see https://docs.relay.link/references/api/get-intent-status-v3
  */
 export interface RelayIntentStatusResponse {
     /** Intent status */

--- a/packages/cross-chain/src/protocols/relay/types.ts
+++ b/packages/cross-chain/src/protocols/relay/types.ts
@@ -18,7 +18,7 @@ export type RelayIntentStatus =
 /**
  * Relay Intent Status Response
  * From: GET https://api.relay.link/intents/status/v3
- * @see https://docs.relay.link/references/api/get-intent-status-v3
+ * @see https://docs.relay.link/references/api/get-intents-status-v3
  */
 export interface RelayIntentStatusResponse {
     /** Intent status */

--- a/packages/cross-chain/src/protocols/relay/types.ts
+++ b/packages/cross-chain/src/protocols/relay/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Relay Protocol API Type Definitions
+ * Types for interacting with Relay Protocol's REST API
+ * @see https://docs.relay.link/
+ */
+
+/** Possible statuses returned by Relay's /intents/status/v3 endpoint */
+export type RelayIntentStatus =
+    | "waiting"
+    | "pending"
+    | "submitted"
+    | "success"
+    | "delayed"
+    | "refunded"
+    | "failure"
+    | "refund";
+
+/**
+ * Relay Intent Status Response
+ * From: GET https://api.relay.link/intents/status/v3
+ * @see https://docs.relay.link/references/api/get-intent-status-v2
+ */
+export interface RelayIntentStatusResponse {
+    /** Intent status */
+    status: RelayIntentStatus;
+    /** Status details */
+    details?: Record<string, unknown>;
+    /** Origin transaction hashes */
+    inTxHashes?: string[];
+    /** Destination transaction hashes */
+    txHashes?: string[];
+    /** Last updated timestamp */
+    updatedAt?: string;
+    /** Origin chain ID */
+    originChainId?: number;
+    /** Destination chain ID */
+    destinationChainId?: number;
+}
+
+/**
+ * Extended metadata for Relay API responses
+ * Captures tracking data beyond basic FillEvent
+ */
+export interface RelayMetadata {
+    /** Relay request ID for tracking */
+    requestId?: string;
+    /** Origin transaction hashes */
+    inTxHashes?: string[];
+    /** Destination transaction hashes */
+    txHashes?: string[];
+}

--- a/packages/cross-chain/test/mocks/relayApi.ts
+++ b/packages/cross-chain/test/mocks/relayApi.ts
@@ -1,0 +1,120 @@
+import { RelayQuoteResponse } from "../../src/internal.js";
+import { CHAIN_IDS, TEST_ADDRESSES, TEST_AMOUNTS, TESTNET_TOKENS } from "./fixtures.js";
+
+/**
+ * Factory for mock Relay API responses
+ * Mirrors the pattern from acrossApi.ts
+ */
+export const getMockedRelayQuoteResponse = (
+    override?: Partial<RelayQuoteResponse>,
+): RelayQuoteResponse => {
+    return {
+        steps: [
+            {
+                id: "deposit",
+                kind: "transaction",
+                action: "deposit",
+                description: "Deposit funds for cross-chain transfer",
+                requestId: "0xabc123def456",
+                items: [
+                    {
+                        status: "incomplete",
+                        data: {
+                            from: TEST_ADDRESSES.USER,
+                            to: "0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC",
+                            data: "0x1234567890abcdef",
+                            value: TEST_AMOUNTS.ONE_ETHER.toString(),
+                            chainId: CHAIN_IDS.SEPOLIA,
+                            maxFeePerGas: "100000000000",
+                            maxPriorityFeePerGas: "2000000000",
+                        },
+                    },
+                ],
+            },
+        ],
+        fees: {
+            gas: { amount: "1000000000000000", currency: "eth" },
+            relayer: { amount: "5000000000000000", currency: "eth" },
+        },
+        details: {
+            currencyIn: {
+                amount: TEST_AMOUNTS.ONE_ETHER.toString(),
+                amountFormatted: "1.0",
+                currency: {
+                    chainId: CHAIN_IDS.SEPOLIA,
+                    address: TESTNET_TOKENS.WETH_SEPOLIA,
+                    symbol: "WETH",
+                    decimals: 18,
+                },
+            },
+            currencyOut: {
+                amount: "990000000000000000",
+                amountFormatted: "0.99",
+                currency: {
+                    chainId: CHAIN_IDS.BASE_SEPOLIA,
+                    address: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                    symbol: "WETH",
+                    decimals: 18,
+                },
+            },
+            timeEstimate: 30,
+            rate: "0.99",
+        },
+        ...override,
+    };
+};
+
+/**
+ * Factory for multi-step Relay response (approve + deposit)
+ */
+export const getMockedRelayMultiStepResponse = (): RelayQuoteResponse => {
+    return {
+        steps: [
+            {
+                id: "approve",
+                kind: "transaction",
+                action: "approve",
+                description: "Approve token spending",
+                items: [
+                    {
+                        status: "incomplete",
+                        data: {
+                            from: TEST_ADDRESSES.USER,
+                            to: TESTNET_TOKENS.WETH_SEPOLIA,
+                            data: "0x095ea7b3000000000000000000000000000000000000000000000000000000000000dead0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+                            chainId: CHAIN_IDS.SEPOLIA,
+                        },
+                    },
+                ],
+            },
+            {
+                id: "deposit",
+                kind: "transaction",
+                action: "deposit",
+                description: "Deposit funds for cross-chain transfer",
+                requestId: "0xrequest123",
+                items: [
+                    {
+                        status: "incomplete",
+                        data: {
+                            from: TEST_ADDRESSES.USER,
+                            to: "0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC",
+                            data: "0xdeadbeef",
+                            value: TEST_AMOUNTS.ONE_ETHER.toString(),
+                            chainId: CHAIN_IDS.SEPOLIA,
+                        },
+                    },
+                ],
+            },
+        ],
+        details: {
+            currencyIn: {
+                amount: TEST_AMOUNTS.ONE_ETHER.toString(),
+            },
+            currencyOut: {
+                amount: "990000000000000000",
+            },
+            timeEstimate: 45,
+        },
+    };
+};

--- a/packages/cross-chain/test/providers/RelayProvider.spec.ts
+++ b/packages/cross-chain/test/providers/RelayProvider.spec.ts
@@ -32,13 +32,19 @@ describe("RelayProvider", () => {
     });
 
     describe("constructor", () => {
-        it("should create provider with default config", () => {
+        it("creates provider with default config", () => {
             const p = new RelayProvider({});
             expect(p.protocolName).toBe("relay");
             expect(p.providerId).toMatch(/^relay_/);
         });
 
-        it("should create provider with custom config", () => {
+        it("generates unique providerId per instance when not specified", () => {
+            const p1 = new RelayProvider({});
+            const p2 = new RelayProvider({});
+            expect(p1.providerId).not.toBe(p2.providerId);
+        });
+
+        it("creates provider with custom config", () => {
             const p = new RelayProvider({
                 apiUrl: "https://custom.relay.url",
                 apiKey: "test-key",
@@ -49,7 +55,7 @@ describe("RelayProvider", () => {
             expect(p.providerId).toBe("custom-relay");
         });
 
-        it("should throw ProviderConfigFailure for invalid config", () => {
+        it("throws ProviderConfigFailure for invalid config", () => {
             expect(() => {
                 // @ts-expect-error - Testing invalid config
                 new RelayProvider({ isTestnet: "not-a-boolean" });
@@ -86,7 +92,7 @@ describe("RelayProvider", () => {
             },
         };
 
-        it("should call Relay API with correct parameters", async () => {
+        it("calls Relay API with correct parameters", async () => {
             await provider.getQuotes(baseRequest);
 
             expect(axios.post).toHaveBeenCalledWith(
@@ -109,7 +115,7 @@ describe("RelayProvider", () => {
             );
         });
 
-        it("should not include recipient when same as user", async () => {
+        it("omits recipient when same as user", async () => {
             const request: QuoteRequest = {
                 user: { chainId: CHAIN_IDS.SEPOLIA, address: TEST_ADDRESSES.USER },
                 intent: {
@@ -142,7 +148,7 @@ describe("RelayProvider", () => {
             expect(body.recipient).toBeUndefined();
         });
 
-        it("should handle exact-output swap type", async () => {
+        it("sends EXACT_OUTPUT trade type for exact-output swaps", async () => {
             const request: QuoteRequest = {
                 user: { chainId: CHAIN_IDS.SEPOLIA, address: TEST_ADDRESSES.USER },
                 intent: {
@@ -179,29 +185,35 @@ describe("RelayProvider", () => {
             expect(body.amount).toBe(TEST_AMOUNTS.ONE_ETHER.toString());
         });
 
-        it("should return SDK Quote with transaction step", async () => {
+        it("returns a transaction step", async () => {
             const quotes = await provider.getQuotes(baseRequest);
 
             expect(quotes).toHaveLength(1);
             const quote = quotes[0]!;
-
-            // Should have a transaction step
             expect(quote.order.steps.length).toBeGreaterThanOrEqual(1);
             expect(quote.order.steps[0]!.kind).toBe("transaction");
+        });
 
-            // Preview should have InteropAccountId format
+        it("formats preview with InteropAccountId accounts", async () => {
+            const quotes = await provider.getQuotes(baseRequest);
+            const quote = quotes[0]!;
+
             expect(quote.preview.inputs[0]!.account).toHaveProperty("chainId");
             expect(quote.preview.inputs[0]!.account).toHaveProperty("address");
             expect(quote.preview.outputs[0]!.account).toHaveProperty("chainId");
             expect(quote.preview.outputs[0]!.account).toHaveProperty("address");
+        });
 
-            // Should have quote metadata
+        it("sets correct provider metadata on quote", async () => {
+            const quotes = await provider.getQuotes(baseRequest);
+            const quote = quotes[0]!;
+
             expect(quote.provider).toBe("mocked");
             expect(quote.failureHandling).toBe("refund-automatic");
             expect(quote.partialFill).toBe(false);
         });
 
-        it("should extract requestId from response and include in metadata", async () => {
+        it("extracts requestId into quoteId and metadata", async () => {
             const quotes = await provider.getQuotes(baseRequest);
             const quote = quotes[0]!;
 
@@ -210,14 +222,14 @@ describe("RelayProvider", () => {
             expect(quote.metadata!.requestId).toBe("0xabc123def456");
         });
 
-        it("should extract eta from details.timeEstimate", async () => {
+        it("extracts eta from details.timeEstimate", async () => {
             const quotes = await provider.getQuotes(baseRequest);
             const quote = quotes[0]!;
 
             expect(quote.eta).toBe(30);
         });
 
-        it("should handle multi-step response (approve + deposit)", async () => {
+        it("produces two transaction steps for approve + deposit response", async () => {
             const multiStepResponse = getMockedRelayMultiStepResponse();
             vi.mocked(axios.post).mockResolvedValueOnce({
                 status: 200,
@@ -227,18 +239,27 @@ describe("RelayProvider", () => {
             const quotes = await provider.getQuotes(baseRequest);
             const quote = quotes[0]!;
 
-            // Should have 2 steps: approve + deposit
             expect(quote.order.steps).toHaveLength(2);
             expect(quote.order.steps[0]!.kind).toBe("transaction");
             expect(quote.order.steps[0]!.description).toBe("approve");
             expect(quote.order.steps[1]!.kind).toBe("transaction");
             expect(quote.order.steps[1]!.description).toBe("deposit");
+        });
 
-            // requestId should come from the deposit step
+        it("extracts requestId from the deposit step in multi-step response", async () => {
+            const multiStepResponse = getMockedRelayMultiStepResponse();
+            vi.mocked(axios.post).mockResolvedValueOnce({
+                status: 200,
+                data: multiStepResponse,
+            });
+
+            const quotes = await provider.getQuotes(baseRequest);
+            const quote = quotes[0]!;
+
             expect(quote.quoteId).toBe("0xrequest123");
         });
 
-        it("should return empty array when response contains signature steps", async () => {
+        it("returns empty array when response contains signature steps", async () => {
             const signatureResponse = getMockedRelayQuoteResponse({
                 steps: [
                     {
@@ -286,7 +307,7 @@ describe("RelayProvider", () => {
             expect(quotes).toHaveLength(0);
         });
 
-        it("should include auth headers when apiKey and source are set", async () => {
+        it("includes auth headers when apiKey and source are set", async () => {
             const authProvider = new RelayProvider({
                 apiUrl: MOCK_API_URL,
                 providerId: "auth-mocked",
@@ -302,7 +323,7 @@ describe("RelayProvider", () => {
             expect(config.headers["x-relay-source"]).toBe("test-dapp");
         });
 
-        it("should throw ProviderGetQuoteFailure on API error", async () => {
+        it("throws ProviderGetQuoteFailure on API error", async () => {
             vi.mocked(axios.post).mockRejectedValueOnce(
                 Object.assign(new Error("Request failed"), {
                     isAxiosError: true,
@@ -315,7 +336,7 @@ describe("RelayProvider", () => {
             await expect(provider.getQuotes(baseRequest)).rejects.toThrow(ProviderGetQuoteFailure);
         });
 
-        it("should throw ProviderGetQuoteFailure when exact-input has no input amount", async () => {
+        it("throws ProviderGetQuoteFailure when exact-input has no input amount", async () => {
             const request: QuoteRequest = {
                 user: { chainId: CHAIN_IDS.SEPOLIA, address: TEST_ADDRESSES.USER },
                 intent: {
@@ -343,7 +364,7 @@ describe("RelayProvider", () => {
             await expect(provider.getQuotes(request)).rejects.toThrow(ProviderGetQuoteFailure);
         });
 
-        it("should use preview amounts from details when available", async () => {
+        it("uses preview amounts from details when available", async () => {
             const quotes = await provider.getQuotes(baseRequest);
             const quote = quotes[0]!;
 
@@ -352,7 +373,7 @@ describe("RelayProvider", () => {
             expect(quote.preview.outputs[0]!.amount).toBe("990000000000000000");
         });
 
-        it("should include relay fees in metadata", async () => {
+        it("includes relay fees in metadata", async () => {
             const quotes = await provider.getQuotes(baseRequest);
             const quote = quotes[0]!;
 
@@ -361,7 +382,7 @@ describe("RelayProvider", () => {
     });
 
     describe("getTrackingConfig", () => {
-        it("should return valid tracking configuration", () => {
+        it("returns valid tracking configuration", () => {
             const config = provider.getTrackingConfig();
 
             expect(config.openedIntentParserConfig).toBeDefined();
@@ -370,104 +391,110 @@ describe("RelayProvider", () => {
             expect(config.fillWatcherConfig.type).toBe("api-based");
         });
 
-        it("should configure API-based fill watcher with correct polling interval", () => {
+        it("configures API-based fill watcher with correct polling interval", () => {
             const config = provider.getTrackingConfig();
 
-            if (config.fillWatcherConfig.type === "api-based") {
-                expect(config.fillWatcherConfig.pollingInterval).toBe(5000);
-                expect(typeof config.fillWatcherConfig.buildEndpoint).toBe("function");
-                expect(typeof config.fillWatcherConfig.extractFillEvent).toBe("function");
-            }
+            expect(config.fillWatcherConfig.type).toBe("api-based");
+            if (config.fillWatcherConfig.type !== "api-based") return;
+
+            expect(config.fillWatcherConfig.pollingInterval).toBe(5000);
+            expect(typeof config.fillWatcherConfig.buildEndpoint).toBe("function");
+            expect(typeof config.fillWatcherConfig.extractFillEvent).toBe("function");
         });
 
-        it("should build correct status endpoint with requestId", () => {
+        it("builds correct status endpoint with requestId", () => {
             const config = provider.getTrackingConfig();
 
-            if (config.fillWatcherConfig.type === "api-based") {
-                const endpoint = config.fillWatcherConfig.buildEndpoint({
+            expect(config.fillWatcherConfig.type).toBe("api-based");
+            if (config.fillWatcherConfig.type !== "api-based") return;
+
+            const endpoint = config.fillWatcherConfig.buildEndpoint({
+                orderId: "0xrequest123" as `0x${string}`,
+                originChainId: CHAIN_IDS.SEPOLIA,
+                destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
+            });
+            expect(endpoint).toBe("/intents/status/v3?requestId=0xrequest123");
+        });
+
+        it("maps success status to Finalized with fill event", () => {
+            const config = provider.getTrackingConfig();
+
+            expect(config.fillWatcherConfig.type).toBe("api-based");
+            if (config.fillWatcherConfig.type !== "api-based") return;
+
+            const result = config.fillWatcherConfig.extractFillEvent(
+                {
+                    status: "success",
+                    txHashes: ["0xfill123"],
+                },
+                {
                     orderId: "0xrequest123" as `0x${string}`,
                     originChainId: CHAIN_IDS.SEPOLIA,
                     destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
-                });
-                expect(endpoint).toBe("/intents/status/v3?requestId=0xrequest123");
-            }
+                },
+            );
+            expect(result.status).toBe(OrderStatus.Finalized);
+            expect(result.event).not.toBeNull();
+            expect(result.event!.fillTxHash).toBe("0xfill123");
         });
 
-        it("should map success status to Finalized", () => {
+        it("maps failure status to Failed", () => {
             const config = provider.getTrackingConfig();
 
-            if (config.fillWatcherConfig.type === "api-based") {
+            expect(config.fillWatcherConfig.type).toBe("api-based");
+            if (config.fillWatcherConfig.type !== "api-based") return;
+
+            const result = config.fillWatcherConfig.extractFillEvent(
+                { status: "failure" },
+                {
+                    orderId: "0xrequest123" as `0x${string}`,
+                    originChainId: CHAIN_IDS.SEPOLIA,
+                    destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
+                },
+            );
+            expect(result.status).toBe(OrderStatus.Failed);
+            expect(result.failureReason).toBe(OrderFailureReason.Unknown);
+            expect(result.event).toBeNull();
+        });
+
+        it("maps refunded status to Refunded", () => {
+            const config = provider.getTrackingConfig();
+
+            expect(config.fillWatcherConfig.type).toBe("api-based");
+            if (config.fillWatcherConfig.type !== "api-based") return;
+
+            const result = config.fillWatcherConfig.extractFillEvent(
+                { status: "refunded" },
+                {
+                    orderId: "0xrequest123" as `0x${string}`,
+                    originChainId: CHAIN_IDS.SEPOLIA,
+                    destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
+                },
+            );
+            expect(result.status).toBe(OrderStatus.Refunded);
+        });
+
+        it("maps pending/waiting statuses to Pending", () => {
+            const config = provider.getTrackingConfig();
+
+            expect(config.fillWatcherConfig.type).toBe("api-based");
+            if (config.fillWatcherConfig.type !== "api-based") return;
+
+            for (const status of ["waiting", "pending", "submitted", "delayed"] as const) {
                 const result = config.fillWatcherConfig.extractFillEvent(
-                    {
-                        status: "success",
-                        txHashes: ["0xfill123"],
-                    },
+                    { status },
                     {
                         orderId: "0xrequest123" as `0x${string}`,
                         originChainId: CHAIN_IDS.SEPOLIA,
                         destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
                     },
                 );
-                expect(result.status).toBe(OrderStatus.Finalized);
-                expect(result.event).not.toBeNull();
-                expect(result.event!.fillTxHash).toBe("0xfill123");
-            }
-        });
-
-        it("should map failure status to Failed", () => {
-            const config = provider.getTrackingConfig();
-
-            if (config.fillWatcherConfig.type === "api-based") {
-                const result = config.fillWatcherConfig.extractFillEvent(
-                    { status: "failure" },
-                    {
-                        orderId: "0xrequest123" as `0x${string}`,
-                        originChainId: CHAIN_IDS.SEPOLIA,
-                        destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
-                    },
-                );
-                expect(result.status).toBe(OrderStatus.Failed);
-                expect(result.failureReason).toBe(OrderFailureReason.Unknown);
+                expect(result.status).toBe(OrderStatus.Pending);
                 expect(result.event).toBeNull();
             }
         });
 
-        it("should map refunded status to Refunded", () => {
-            const config = provider.getTrackingConfig();
-
-            if (config.fillWatcherConfig.type === "api-based") {
-                const result = config.fillWatcherConfig.extractFillEvent(
-                    { status: "refunded" },
-                    {
-                        orderId: "0xrequest123" as `0x${string}`,
-                        originChainId: CHAIN_IDS.SEPOLIA,
-                        destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
-                    },
-                );
-                expect(result.status).toBe(OrderStatus.Refunded);
-            }
-        });
-
-        it("should map pending/waiting statuses to Pending", () => {
-            const config = provider.getTrackingConfig();
-
-            if (config.fillWatcherConfig.type === "api-based") {
-                for (const status of ["waiting", "pending", "submitted", "delayed"] as const) {
-                    const result = config.fillWatcherConfig.extractFillEvent(
-                        { status },
-                        {
-                            orderId: "0xrequest123" as `0x${string}`,
-                            originChainId: CHAIN_IDS.SEPOLIA,
-                            destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
-                        },
-                    );
-                    expect(result.status).toBe(OrderStatus.Pending);
-                    expect(result.event).toBeNull();
-                }
-            }
-        });
-
-        it("should pass auth headers to fill watcher config", () => {
+        it("passes auth headers to fill watcher config", () => {
             const authProvider = new RelayProvider({
                 apiUrl: MOCK_API_URL,
                 providerId: "auth-mocked",
@@ -477,13 +504,14 @@ describe("RelayProvider", () => {
 
             const config = authProvider.getTrackingConfig();
 
-            if (config.fillWatcherConfig.type === "api-based") {
-                expect(config.fillWatcherConfig.apiKey).toBe("test-key");
-                expect(config.fillWatcherConfig.headers).toEqual({
-                    Authorization: "Bearer test-key",
-                    "x-relay-source": "test-dapp",
-                });
-            }
+            expect(config.fillWatcherConfig.type).toBe("api-based");
+            if (config.fillWatcherConfig.type !== "api-based") return;
+
+            expect(config.fillWatcherConfig.apiKey).toBe("test-key");
+            expect(config.fillWatcherConfig.headers).toEqual({
+                Authorization: "Bearer test-key",
+                "x-relay-source": "test-dapp",
+            });
         });
     });
 });

--- a/packages/cross-chain/test/providers/RelayProvider.spec.ts
+++ b/packages/cross-chain/test/providers/RelayProvider.spec.ts
@@ -1,0 +1,489 @@
+import axios from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { QuoteRequest } from "../../src/core/types/quoteRequest.js";
+import {
+    ProviderConfigFailure,
+    ProviderGetQuoteFailure,
+    RelayProvider,
+} from "../../src/external.js";
+import { OrderFailureReason, OrderStatus } from "../../src/internal.js";
+import { CHAIN_IDS, TEST_ADDRESSES, TEST_AMOUNTS, TESTNET_TOKENS } from "../mocks/fixtures.js";
+import { getMockedRelayMultiStepResponse, getMockedRelayQuoteResponse } from "../mocks/relayApi.js";
+
+const MOCK_API_URL = "https://mocked.relay.url";
+
+vi.mock("axios");
+
+describe("RelayProvider", () => {
+    const provider = new RelayProvider({
+        apiUrl: MOCK_API_URL,
+        providerId: "mocked",
+    });
+
+    const mockRelayResponse = getMockedRelayQuoteResponse();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(axios.post).mockResolvedValue({
+            status: 200,
+            data: mockRelayResponse,
+        });
+    });
+
+    describe("constructor", () => {
+        it("should create provider with default config", () => {
+            const p = new RelayProvider({});
+            expect(p.protocolName).toBe("relay");
+            expect(p.providerId).toMatch(/^relay_/);
+        });
+
+        it("should create provider with custom config", () => {
+            const p = new RelayProvider({
+                apiUrl: "https://custom.relay.url",
+                apiKey: "test-key",
+                source: "test-source",
+                providerId: "custom-relay",
+            });
+            expect(p.protocolName).toBe("relay");
+            expect(p.providerId).toBe("custom-relay");
+        });
+
+        it("should throw ProviderConfigFailure for invalid config", () => {
+            expect(() => {
+                // @ts-expect-error - Testing invalid config
+                new RelayProvider({ isTestnet: "not-a-boolean" });
+            }).toThrow(ProviderConfigFailure);
+        });
+    });
+
+    describe("getQuotes", () => {
+        const baseRequest: QuoteRequest = {
+            user: { chainId: CHAIN_IDS.SEPOLIA, address: TEST_ADDRESSES.USER },
+            intent: {
+                inputs: [
+                    {
+                        asset: {
+                            chainId: CHAIN_IDS.SEPOLIA,
+                            address: TESTNET_TOKENS.WETH_SEPOLIA,
+                        },
+                        amount: TEST_AMOUNTS.ONE_ETHER.toString(),
+                    },
+                ],
+                outputs: [
+                    {
+                        asset: {
+                            chainId: CHAIN_IDS.BASE_SEPOLIA,
+                            address: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                        },
+                        recipient: {
+                            chainId: CHAIN_IDS.BASE_SEPOLIA,
+                            address: TEST_ADDRESSES.RECEIVER,
+                        },
+                    },
+                ],
+                swapType: "exact-input",
+            },
+        };
+
+        it("should call Relay API with correct parameters", async () => {
+            await provider.getQuotes(baseRequest);
+
+            expect(axios.post).toHaveBeenCalledWith(
+                `${MOCK_API_URL}/quote/v2`,
+                {
+                    user: TEST_ADDRESSES.USER,
+                    originChainId: CHAIN_IDS.SEPOLIA,
+                    destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
+                    originCurrency: TESTNET_TOKENS.WETH_SEPOLIA,
+                    destinationCurrency: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                    amount: TEST_AMOUNTS.ONE_ETHER.toString(),
+                    tradeType: "EXACT_INPUT",
+                    recipient: TEST_ADDRESSES.RECEIVER,
+                },
+                {
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                },
+            );
+        });
+
+        it("should not include recipient when same as user", async () => {
+            const request: QuoteRequest = {
+                user: { chainId: CHAIN_IDS.SEPOLIA, address: TEST_ADDRESSES.USER },
+                intent: {
+                    inputs: [
+                        {
+                            asset: {
+                                chainId: CHAIN_IDS.SEPOLIA,
+                                address: TESTNET_TOKENS.WETH_SEPOLIA,
+                            },
+                            amount: TEST_AMOUNTS.ONE_ETHER.toString(),
+                        },
+                    ],
+                    outputs: [
+                        {
+                            asset: {
+                                chainId: CHAIN_IDS.BASE_SEPOLIA,
+                                address: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                            },
+                            // No explicit recipient — defaults to user
+                        },
+                    ],
+                    swapType: "exact-input",
+                },
+            };
+
+            await provider.getQuotes(request);
+
+            const callArgs = vi.mocked(axios.post).mock.calls[0]!;
+            const body = callArgs[1] as Record<string, unknown>;
+            expect(body.recipient).toBeUndefined();
+        });
+
+        it("should handle exact-output swap type", async () => {
+            const request: QuoteRequest = {
+                user: { chainId: CHAIN_IDS.SEPOLIA, address: TEST_ADDRESSES.USER },
+                intent: {
+                    inputs: [
+                        {
+                            asset: {
+                                chainId: CHAIN_IDS.SEPOLIA,
+                                address: TESTNET_TOKENS.WETH_SEPOLIA,
+                            },
+                        },
+                    ],
+                    outputs: [
+                        {
+                            asset: {
+                                chainId: CHAIN_IDS.BASE_SEPOLIA,
+                                address: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                            },
+                            recipient: {
+                                chainId: CHAIN_IDS.BASE_SEPOLIA,
+                                address: TEST_ADDRESSES.RECEIVER,
+                            },
+                            amount: TEST_AMOUNTS.ONE_ETHER.toString(),
+                        },
+                    ],
+                    swapType: "exact-output",
+                },
+            };
+
+            await provider.getQuotes(request);
+
+            const callArgs = vi.mocked(axios.post).mock.calls[0]!;
+            const body = callArgs[1] as Record<string, unknown>;
+            expect(body.tradeType).toBe("EXACT_OUTPUT");
+            expect(body.amount).toBe(TEST_AMOUNTS.ONE_ETHER.toString());
+        });
+
+        it("should return SDK Quote with transaction step", async () => {
+            const quotes = await provider.getQuotes(baseRequest);
+
+            expect(quotes).toHaveLength(1);
+            const quote = quotes[0]!;
+
+            // Should have a transaction step
+            expect(quote.order.steps.length).toBeGreaterThanOrEqual(1);
+            expect(quote.order.steps[0]!.kind).toBe("transaction");
+
+            // Preview should have InteropAccountId format
+            expect(quote.preview.inputs[0]!.account).toHaveProperty("chainId");
+            expect(quote.preview.inputs[0]!.account).toHaveProperty("address");
+            expect(quote.preview.outputs[0]!.account).toHaveProperty("chainId");
+            expect(quote.preview.outputs[0]!.account).toHaveProperty("address");
+
+            // Should have quote metadata
+            expect(quote.provider).toBe("mocked");
+            expect(quote.failureHandling).toBe("refund-automatic");
+            expect(quote.partialFill).toBe(false);
+        });
+
+        it("should extract requestId from response and include in metadata", async () => {
+            const quotes = await provider.getQuotes(baseRequest);
+            const quote = quotes[0]!;
+
+            expect(quote.quoteId).toBe("0xabc123def456");
+            expect(quote.metadata).toBeDefined();
+            expect(quote.metadata!.requestId).toBe("0xabc123def456");
+        });
+
+        it("should extract eta from details.timeEstimate", async () => {
+            const quotes = await provider.getQuotes(baseRequest);
+            const quote = quotes[0]!;
+
+            expect(quote.eta).toBe(30);
+        });
+
+        it("should handle multi-step response (approve + deposit)", async () => {
+            const multiStepResponse = getMockedRelayMultiStepResponse();
+            vi.mocked(axios.post).mockResolvedValueOnce({
+                status: 200,
+                data: multiStepResponse,
+            });
+
+            const quotes = await provider.getQuotes(baseRequest);
+            const quote = quotes[0]!;
+
+            // Should have 2 steps: approve + deposit
+            expect(quote.order.steps).toHaveLength(2);
+            expect(quote.order.steps[0]!.kind).toBe("transaction");
+            expect(quote.order.steps[0]!.description).toBe("approve");
+            expect(quote.order.steps[1]!.kind).toBe("transaction");
+            expect(quote.order.steps[1]!.description).toBe("deposit");
+
+            // requestId should come from the deposit step
+            expect(quote.quoteId).toBe("0xrequest123");
+        });
+
+        it("should return empty array when response contains signature steps", async () => {
+            const signatureResponse = getMockedRelayQuoteResponse({
+                steps: [
+                    {
+                        id: "permit",
+                        kind: "signature",
+                        action: "permit",
+                        description: "Sign permit",
+                        items: [
+                            {
+                                status: "incomplete",
+                                data: {
+                                    from: TEST_ADDRESSES.USER,
+                                    to: TESTNET_TOKENS.WETH_SEPOLIA,
+                                    data: "0xabcdef",
+                                    chainId: CHAIN_IDS.SEPOLIA,
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        id: "deposit",
+                        kind: "transaction",
+                        requestId: "0xrequest456",
+                        items: [
+                            {
+                                status: "incomplete",
+                                data: {
+                                    from: TEST_ADDRESSES.USER,
+                                    to: "0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC",
+                                    data: "0xdeadbeef",
+                                    value: TEST_AMOUNTS.ONE_ETHER.toString(),
+                                    chainId: CHAIN_IDS.SEPOLIA,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
+            vi.mocked(axios.post).mockResolvedValueOnce({
+                status: 200,
+                data: signatureResponse,
+            });
+
+            const quotes = await provider.getQuotes(baseRequest);
+            expect(quotes).toHaveLength(0);
+        });
+
+        it("should include auth headers when apiKey and source are set", async () => {
+            const authProvider = new RelayProvider({
+                apiUrl: MOCK_API_URL,
+                providerId: "auth-mocked",
+                apiKey: "test-api-key",
+                source: "test-dapp",
+            });
+
+            await authProvider.getQuotes(baseRequest);
+
+            const callArgs = vi.mocked(axios.post).mock.calls[0]!;
+            const config = callArgs[2] as { headers: Record<string, string> };
+            expect(config.headers["Authorization"]).toBe("Bearer test-api-key");
+            expect(config.headers["x-relay-source"]).toBe("test-dapp");
+        });
+
+        it("should throw ProviderGetQuoteFailure on API error", async () => {
+            vi.mocked(axios.post).mockRejectedValueOnce(
+                Object.assign(new Error("Request failed"), {
+                    isAxiosError: true,
+                    response: { data: { message: "Invalid request" } },
+                    name: "AxiosError",
+                    toJSON: () => ({}),
+                }),
+            );
+
+            await expect(provider.getQuotes(baseRequest)).rejects.toThrow(ProviderGetQuoteFailure);
+        });
+
+        it("should throw ProviderGetQuoteFailure when exact-input has no input amount", async () => {
+            const request: QuoteRequest = {
+                user: { chainId: CHAIN_IDS.SEPOLIA, address: TEST_ADDRESSES.USER },
+                intent: {
+                    inputs: [
+                        {
+                            asset: {
+                                chainId: CHAIN_IDS.SEPOLIA,
+                                address: TESTNET_TOKENS.WETH_SEPOLIA,
+                            },
+                            // No amount
+                        },
+                    ],
+                    outputs: [
+                        {
+                            asset: {
+                                chainId: CHAIN_IDS.BASE_SEPOLIA,
+                                address: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                            },
+                        },
+                    ],
+                    swapType: "exact-input",
+                },
+            };
+
+            await expect(provider.getQuotes(request)).rejects.toThrow(ProviderGetQuoteFailure);
+        });
+
+        it("should use preview amounts from details when available", async () => {
+            const quotes = await provider.getQuotes(baseRequest);
+            const quote = quotes[0]!;
+
+            // Should use the amounts from details.currencyIn/currencyOut
+            expect(quote.preview.inputs[0]!.amount).toBe(TEST_AMOUNTS.ONE_ETHER.toString());
+            expect(quote.preview.outputs[0]!.amount).toBe("990000000000000000");
+        });
+
+        it("should include relay fees in metadata", async () => {
+            const quotes = await provider.getQuotes(baseRequest);
+            const quote = quotes[0]!;
+
+            expect(quote.metadata!.relayFees).toBeDefined();
+        });
+    });
+
+    describe("getTrackingConfig", () => {
+        it("should return valid tracking configuration", () => {
+            const config = provider.getTrackingConfig();
+
+            expect(config.openedIntentParserConfig).toBeDefined();
+            expect(config.openedIntentParserConfig.type).toBe("custom-event");
+            expect(config.fillWatcherConfig).toBeDefined();
+            expect(config.fillWatcherConfig.type).toBe("api-based");
+        });
+
+        it("should configure API-based fill watcher with correct polling interval", () => {
+            const config = provider.getTrackingConfig();
+
+            if (config.fillWatcherConfig.type === "api-based") {
+                expect(config.fillWatcherConfig.pollingInterval).toBe(5000);
+                expect(typeof config.fillWatcherConfig.buildEndpoint).toBe("function");
+                expect(typeof config.fillWatcherConfig.extractFillEvent).toBe("function");
+            }
+        });
+
+        it("should build correct status endpoint with requestId", () => {
+            const config = provider.getTrackingConfig();
+
+            if (config.fillWatcherConfig.type === "api-based") {
+                const endpoint = config.fillWatcherConfig.buildEndpoint({
+                    orderId: "0xrequest123" as `0x${string}`,
+                    originChainId: CHAIN_IDS.SEPOLIA,
+                    destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
+                });
+                expect(endpoint).toBe("/intents/status/v3?requestId=0xrequest123");
+            }
+        });
+
+        it("should map success status to Finalized", () => {
+            const config = provider.getTrackingConfig();
+
+            if (config.fillWatcherConfig.type === "api-based") {
+                const result = config.fillWatcherConfig.extractFillEvent(
+                    {
+                        status: "success",
+                        txHashes: ["0xfill123"],
+                    },
+                    {
+                        orderId: "0xrequest123" as `0x${string}`,
+                        originChainId: CHAIN_IDS.SEPOLIA,
+                        destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
+                    },
+                );
+                expect(result.status).toBe(OrderStatus.Finalized);
+                expect(result.event).not.toBeNull();
+                expect(result.event!.fillTxHash).toBe("0xfill123");
+            }
+        });
+
+        it("should map failure status to Failed", () => {
+            const config = provider.getTrackingConfig();
+
+            if (config.fillWatcherConfig.type === "api-based") {
+                const result = config.fillWatcherConfig.extractFillEvent(
+                    { status: "failure" },
+                    {
+                        orderId: "0xrequest123" as `0x${string}`,
+                        originChainId: CHAIN_IDS.SEPOLIA,
+                        destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
+                    },
+                );
+                expect(result.status).toBe(OrderStatus.Failed);
+                expect(result.failureReason).toBe(OrderFailureReason.Unknown);
+                expect(result.event).toBeNull();
+            }
+        });
+
+        it("should map refunded status to Refunded", () => {
+            const config = provider.getTrackingConfig();
+
+            if (config.fillWatcherConfig.type === "api-based") {
+                const result = config.fillWatcherConfig.extractFillEvent(
+                    { status: "refunded" },
+                    {
+                        orderId: "0xrequest123" as `0x${string}`,
+                        originChainId: CHAIN_IDS.SEPOLIA,
+                        destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
+                    },
+                );
+                expect(result.status).toBe(OrderStatus.Refunded);
+            }
+        });
+
+        it("should map pending/waiting statuses to Pending", () => {
+            const config = provider.getTrackingConfig();
+
+            if (config.fillWatcherConfig.type === "api-based") {
+                for (const status of ["waiting", "pending", "submitted", "delayed"] as const) {
+                    const result = config.fillWatcherConfig.extractFillEvent(
+                        { status },
+                        {
+                            orderId: "0xrequest123" as `0x${string}`,
+                            originChainId: CHAIN_IDS.SEPOLIA,
+                            destinationChainId: CHAIN_IDS.BASE_SEPOLIA,
+                        },
+                    );
+                    expect(result.status).toBe(OrderStatus.Pending);
+                    expect(result.event).toBeNull();
+                }
+            }
+        });
+
+        it("should pass auth headers to fill watcher config", () => {
+            const authProvider = new RelayProvider({
+                apiUrl: MOCK_API_URL,
+                providerId: "auth-mocked",
+                apiKey: "test-key",
+                source: "test-dapp",
+            });
+
+            const config = authProvider.getTrackingConfig();
+
+            if (config.fillWatcherConfig.type === "api-based") {
+                expect(config.fillWatcherConfig.apiKey).toBe("test-key");
+                expect(config.fillWatcherConfig.headers).toEqual({
+                    Authorization: "Bearer test-key",
+                    "x-relay-source": "test-dapp",
+                });
+            }
+        });
+    });
+});

--- a/packages/cross-chain/test/services/crossChainProviderFactory.spec.ts
+++ b/packages/cross-chain/test/services/crossChainProviderFactory.spec.ts
@@ -1,11 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createCrossChainProvider } from "../../src/factories/crossChainProviderFactory.js";
-import { AcrossProvider, CrossChainProvider, UnsupportedProtocol } from "../../src/internal.js";
+import {
+    AcrossProvider,
+    CrossChainProvider,
+    RelayProvider,
+    UnsupportedProtocol,
+} from "../../src/internal.js";
 
 const MOCK_ACROSS_CONFIG = {
     apiUrl: "https://across.to/api",
     providerId: "test-across-provider",
+};
+
+const MOCK_RELAY_CONFIG = {
+    apiUrl: "https://relay.link/api",
+    providerId: "test-relay-provider",
 };
 
 describe("createCrossChainProvider", () => {
@@ -29,6 +39,18 @@ describe("createCrossChainProvider", () => {
         const provider = createCrossChainProvider("across");
 
         expect(provider).toBeInstanceOf(AcrossProvider);
+    });
+
+    it("creates a CrossChainProvider with the relay provider", () => {
+        const provider = createCrossChainProvider("relay", MOCK_RELAY_CONFIG);
+
+        expect(provider).toBeInstanceOf(RelayProvider);
+    });
+
+    it("creates a relay provider without config (defaults to mainnet)", () => {
+        const provider = createCrossChainProvider("relay");
+
+        expect(provider).toBeInstanceOf(RelayProvider);
     });
 
     it("throws an UnsupportedProtocol error for unsupported protocols", () => {


### PR DESCRIPTION
## Summary

- Add `RelayProvider` as a new cross-chain protocol provider (POC), validating the Part 7 `core/protocols/factories` architecture for adding new protocols
- Relay supports both transaction and signature flows; this POC integrates transaction-based intents only
- Wire up Relay in the factory, exports, docs, example UI, and provider factory tests

## Details

### New protocol: `protocols/relay/`

Self-contained under `packages/cross-chain/src/protocols/relay/`:

| File | Purpose |
|------|---------|
| `provider.ts` | `RelayProvider extends CrossChainProvider` — quotes via `POST /quote/v2`, tracking via `GET /intents/status/v3` |
| `constants.ts` | API URLs (mainnet/testnet) |
| `schemas.ts` | Zod schemas for config, quote request/response, steps |
| `interfaces.ts` | Types inferred from Zod schemas |
| `types.ts` | Intent status types, metadata |
| `index.ts` | Barrel exports |

### Integration points

- **Factory**: `createCrossChainProvider("relay", config?)` — config is optional (defaults to mainnet)
- **Exports**: `RelayProvider` added to `external.ts`
- **Types**: `PROTOCOLS.RELAY`, `RelayProvider`, `RelayConfigs` registered in `providers.ts`
- **Docs**: New `relay-provider.md` page, updated `providers.md` table, sidebar entry, README section
- **Example UI**: Relay added to provider list, route selection whitelist extended, multi-step order handling (use last step), requestId-based tracking

### Key design decisions

1. **Transaction-only integration**: Relay supports signature flows (e.g. permits), but this POC only handles transaction steps. Quotes with non-transaction steps return `[]`.
2. **Tracking by requestId**: Relay tracks via `requestId` (stored in `quote.quoteId` and `quote.metadata.requestId`), not txHash. The fill watcher polls `/intents/status/v3`.
3. **Multi-step handling**: Relay can return approve + deposit steps. The UI uses the last step (deposit) since it handles ERC-20 approvals independently.
4. **No asset discovery / no payload validation**: Deferred for POC. Can be added via Relay's `/currencies` and `/config` endpoints.

### Tests

- 24 new tests in `test/providers/RelayProvider.spec.ts` (constructor, getQuotes, getTrackingConfig)
- Mock factories in `test/mocks/relayApi.ts`
- 2 new factory tests in `test/services/crossChainProviderFactory.spec.ts`

## Test plan

- [ ] `pnpm --filter @wonderland/interop-cross-chain test` — all cross-chain tests pass
- [ ] `pnpm build` — full project build passes
- [ ] Verify Relay provider is accessible via `createCrossChainProvider("relay")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)