### PR TITLE
feat(cross-chain): add SDK types, schemas, and utilities

### DIFF
--- a/packages/cross-chain/src/schemas/common.ts
+++ b/packages/cross-chain/src/schemas/common.ts
@@ -1,0 +1,15 @@
+import { isAddress } from "viem";
+import { z } from "zod";
+
+export const addressString = z.string().refine((val): boolean => isAddress(val), {
+    message: "Invalid hex address",
+});
+
+export const amountSchema = z
+    .string()
+    .regex(/^[0-9]+$/)
+    .describe("Token amount in smallest unit (decimal string, no decimals or scientific notation)");
+
+export const chainIdSchema = z.number().int().positive().refine(Number.isSafeInteger, {
+    message: "chainId must be a safe integer",
+});

--- a/packages/cross-chain/src/schemas/interopAccountId.ts
+++ b/packages/cross-chain/src/schemas/interopAccountId.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+import { addressString, chainIdSchema } from "./common.js";
+
+/**
+ * Zod schema for {@link InteropAccountId}.
+ *
+ * Validates that `address` is a valid hex address and `chainId` is a
+ * positive integer.
+ */
+export const InteropAccountIdSchema = z.object({
+    chainId: chainIdSchema,
+    address: addressString,
+});
+
+// ── Types ───────────────────────────────────────────────
+
+/** Chain-aware account/asset identifier (EVM-focused). */
+export type InteropAccountId = z.infer<typeof InteropAccountIdSchema>;

--- a/packages/cross-chain/src/schemas/order.ts
+++ b/packages/cross-chain/src/schemas/order.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+
+import { addressString, amountSchema, chainIdSchema } from "./common.js";
+
+// ── Steps ────────────────────────────────────────────────
+
+export const TransactionStepSchema = z.object({
+    kind: z.literal("transaction"),
+    chainId: chainIdSchema,
+    description: z.string().optional(),
+    transaction: z.object({
+        to: addressString,
+        data: z.string(),
+        value: z.string().optional(),
+        gas: z.string().optional(),
+        maxFeePerGas: z.string().optional(),
+        maxPriorityFeePerGas: z.string().optional(),
+    }),
+});
+
+export const SignatureStepSchema = z.object({
+    kind: z.literal("signature"),
+    chainId: chainIdSchema,
+    description: z.string().optional(),
+    signaturePayload: z.object({
+        signatureType: z.literal("eip712"),
+        domain: z.record(z.unknown()),
+        primaryType: z.string(),
+        types: z.record(z.array(z.object({ name: z.string(), type: z.string() }))),
+        message: z.record(z.unknown()),
+    }),
+    metadata: z.record(z.unknown()).optional(),
+});
+
+export const StepSchema = z.discriminatedUnion("kind", [
+    TransactionStepSchema,
+    SignatureStepSchema,
+]);
+
+// ── Lock ─────────────────────────────────────────────────
+
+export const LockMechanismSchema = z.object({
+    type: z.string(),
+    contracts: z.array(z.string()).optional(),
+});
+
+// ── Checks ───────────────────────────────────────────────
+
+export const OrderChecksSchema = z.object({
+    allowances: z
+        .array(
+            z.object({
+                chainId: chainIdSchema,
+                tokenAddress: addressString,
+                owner: addressString,
+                spender: addressString,
+                required: amountSchema,
+            }),
+        )
+        .optional(),
+});
+
+// ── Order ────────────────────────────────────────────────
+
+export const OrderSchema = z.object({
+    steps: z.array(StepSchema).min(1),
+    lock: LockMechanismSchema.optional(),
+    checks: OrderChecksSchema.optional(),
+    metadata: z.record(z.unknown()).optional(),
+});
+
+// ── Types ───────────────────────────────────────────────
+
+export type TransactionStep = z.infer<typeof TransactionStepSchema>;
+export type SignatureStep = z.infer<typeof SignatureStepSchema>;
+export type Step = z.infer<typeof StepSchema>;
+export type LockMechanism = z.infer<typeof LockMechanismSchema>;
+export type OrderChecks = z.infer<typeof OrderChecksSchema>;
+export type Order = z.infer<typeof OrderSchema>;

--- a/packages/cross-chain/src/schemas/quote.ts
+++ b/packages/cross-chain/src/schemas/quote.ts
@@ -1,0 +1,69 @@
+import type { Hex } from "viem";
+import { z } from "zod";
+
+import { addressString, amountSchema, chainIdSchema } from "./common.js";
+import { OrderSchema } from "./order.js";
+
+export const QuotePreviewEntrySchema = z.object({
+    chainId: chainIdSchema,
+    accountAddress: addressString,
+    assetAddress: addressString,
+    amount: amountSchema,
+});
+
+export const QuotePreviewSchema = z.object({
+    inputs: z.array(QuotePreviewEntrySchema).min(1),
+    outputs: z.array(QuotePreviewEntrySchema).min(1),
+});
+
+export const QuoteSchema = z.object({
+    order: OrderSchema,
+    preview: QuotePreviewSchema,
+    validUntil: z.number().int().nonnegative().optional(),
+    eta: z.number().int().nonnegative().optional(),
+    provider: z.string(),
+    quoteId: z.string().optional(),
+    failureHandling: z.string().optional(),
+    partialFill: z.boolean().optional(),
+    metadata: z.record(z.unknown()).optional(),
+});
+
+// ── Types ───────────────────────────────────────────────
+
+export type QuotePreviewEntry = z.infer<typeof QuotePreviewEntrySchema>;
+export type QuotePreview = z.infer<typeof QuotePreviewSchema>;
+export type Quote = z.infer<typeof QuoteSchema>;
+
+/** A quote enriched with internal SDK routing fields. */
+export interface ExecutableQuote extends Quote {
+    /** @internal Identifies which SDK provider handles this quote */
+    _providerId: string;
+}
+
+/** Response from submitting an order to a provider. */
+export interface SubmitOrderResponse {
+    /** The order identifier from the solver */
+    orderId: Hex;
+    /** Status string from the solver */
+    status?: string;
+    /** Optional message from the solver */
+    message?: string;
+}
+
+/** Result of executing a signature step. */
+export interface StepResult {
+    /** Index into order.steps[] */
+    stepIndex: number;
+    /** EIP-712 signature */
+    signature: Hex;
+}
+
+export interface GetQuotesError {
+    error: Error;
+    errorMsg: string;
+}
+
+export interface GetQuotesResponse {
+    quotes: ExecutableQuote[];
+    errors: GetQuotesError[];
+}

--- a/packages/cross-chain/src/schemas/quoteRequest.ts
+++ b/packages/cross-chain/src/schemas/quoteRequest.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+import { addressString, amountSchema, chainIdSchema } from "./common.js";
+
+export const IntentInputSchema = z.object({
+    chainId: chainIdSchema,
+    assetAddress: addressString,
+    amount: amountSchema.optional(),
+});
+
+export const IntentOutputSchema = z.object({
+    chainId: chainIdSchema,
+    assetAddress: addressString,
+    amount: amountSchema.optional(),
+    recipient: addressString.optional(),
+    calldata: z
+        .string()
+        .regex(/^0x([0-9a-fA-F]{2})*$/, "Invalid calldata hex")
+        .optional(),
+});
+
+export const QuoteRequestSchema = z
+    .object({
+        user: addressString,
+        input: IntentInputSchema,
+        output: IntentOutputSchema,
+        swapType: z.union([z.literal("exact-input"), z.literal("exact-output")]).optional(),
+    })
+    .refine(
+        (val) => {
+            const swapType = val.swapType ?? "exact-input";
+            if (swapType === "exact-input") return val.input.amount !== undefined;
+            if (swapType === "exact-output") return val.output.amount !== undefined;
+            return true;
+        },
+        {
+            message: "exact-input requires input.amount, exact-output requires output.amount",
+        },
+    );
+
+// ── Types ───────────────────────────────────────────────
+
+export type IntentInput = z.infer<typeof IntentInputSchema>;
+export type IntentOutput = z.infer<typeof IntentOutputSchema>;
+export type QuoteRequest = z.input<typeof QuoteRequestSchema>;

--- a/packages/cross-chain/src/utils/interopAccountId.ts
+++ b/packages/cross-chain/src/utils/interopAccountId.ts
@@ -1,0 +1,60 @@
+import type { Hex } from "viem";
+import { decodeAddress, encodeAddress } from "@wonderland/interop-addresses";
+
+import type { InteropAccountId } from "../schemas/interopAccountId.js";
+
+/**
+ * Decode an ERC-7930 binary hex address into an {@link InteropAccountId}.
+ *
+ * @example
+ * ```ts
+ * const id = toInteropAccountId("0x00010000010114a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+ * // { chainId: 1, address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }
+ * ```
+ */
+export function toInteropAccountId(hex: string): InteropAccountId {
+    const decoded = decodeAddress(hex as Hex);
+    if (decoded.chainType !== "eip155") {
+        throw new Error(`Unsupported chainType "${decoded.chainType}" in ERC-7930 hex: ${hex}`);
+    }
+    if (!decoded.address) {
+        throw new Error(`Cannot decode address from ERC-7930 hex: ${hex}`);
+    }
+    if (!decoded.chainReference) {
+        throw new Error(`Cannot decode chain reference from ERC-7930 hex: ${hex}`);
+    }
+    const chainId = Number(decoded.chainReference);
+    if (!Number.isSafeInteger(chainId) || chainId <= 0) {
+        throw new Error(
+            `Invalid chain reference "${decoded.chainReference}" in ERC-7930 hex: ${hex}`,
+        );
+    }
+    return {
+        chainId,
+        address: decoded.address,
+    };
+}
+
+/**
+ * Encode an {@link InteropAccountId} into an ERC-7930 binary hex string.
+ *
+ * @example
+ * ```ts
+ * const hex = fromInteropAccountId({ chainId: 8453, address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" });
+ * // "0x0001000002210514833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+ * ```
+ */
+export function fromInteropAccountId(id: InteropAccountId): Hex {
+    if (!Number.isSafeInteger(id.chainId) || id.chainId <= 0) {
+        throw new Error(`Invalid chainId "${id.chainId}": must be a positive safe integer`);
+    }
+    return encodeAddress(
+        {
+            version: 1,
+            chainType: "eip155",
+            chainReference: id.chainId.toString(),
+            address: id.address,
+        },
+        { format: "hex" },
+    ) as Hex;
+}

--- a/packages/cross-chain/src/utils/stepHelpers.ts
+++ b/packages/cross-chain/src/utils/stepHelpers.ts
@@ -1,0 +1,21 @@
+import type { Order, SignatureStep, TransactionStep } from "../schemas/order.js";
+
+/** Get all signature steps from an order. */
+export function getSignatureSteps(order: Order): SignatureStep[] {
+    return order.steps.filter((s): s is SignatureStep => s.kind === "signature");
+}
+
+/** Get all transaction steps from an order. */
+export function getTransactionSteps(order: Order): TransactionStep[] {
+    return order.steps.filter((s): s is TransactionStep => s.kind === "transaction");
+}
+
+/** Check if an order requires only signatures (no user-submitted transactions). */
+export function isSignatureOnlyOrder(order: Order): boolean {
+    return order.steps.length > 0 && order.steps.every((s) => s.kind === "signature");
+}
+
+/** Check if an order requires only transactions (no signatures). */
+export function isTransactionOnlyOrder(order: Order): boolean {
+    return order.steps.length > 0 && order.steps.every((s) => s.kind === "transaction");
+}

--- a/packages/cross-chain/test/schemas/sdkSchemas.spec.ts
+++ b/packages/cross-chain/test/schemas/sdkSchemas.spec.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it } from "vitest";
+
+import { InteropAccountIdSchema } from "../../src/schemas/interopAccountId.js";
+import { OrderSchema, StepSchema } from "../../src/schemas/order.js";
+import { QuoteSchema } from "../../src/schemas/quote.js";
+import { QuoteRequestSchema } from "../../src/schemas/quoteRequest.js";
+
+describe("InteropAccountIdSchema", () => {
+    it("accepts valid account ID", () => {
+        const result = InteropAccountIdSchema.safeParse({
+            chainId: 1,
+            address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it("rejects non-integer chainId", () => {
+        const result = InteropAccountIdSchema.safeParse({
+            chainId: 1.5,
+            address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects negative chainId", () => {
+        const result = InteropAccountIdSchema.safeParse({
+            chainId: -1,
+            address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects unsafe integer chainId", () => {
+        const result = InteropAccountIdSchema.safeParse({
+            chainId: Number.MAX_SAFE_INTEGER + 1,
+            address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid hex address", () => {
+        const result = InteropAccountIdSchema.safeParse({
+            chainId: 1,
+            address: "not-an-address",
+        });
+        expect(result.success).toBe(false);
+    });
+});
+
+describe("StepSchema", () => {
+    it("accepts a valid transaction step", () => {
+        const result = StepSchema.safeParse({
+            kind: "transaction",
+            chainId: 1,
+            transaction: {
+                to: "0x1234567890123456789012345678901234567890",
+                data: "0xabcdef",
+            },
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it("accepts a valid signature step", () => {
+        const result = StepSchema.safeParse({
+            kind: "signature",
+            chainId: 1,
+            signaturePayload: {
+                signatureType: "eip712",
+                domain: { name: "Test" },
+                primaryType: "TestMessage",
+                types: { TestMessage: [{ name: "value", type: "uint256" }] },
+                message: { value: "100" },
+            },
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it("rejects unknown step kind", () => {
+        const result = StepSchema.safeParse({
+            kind: "unknown",
+            chainId: 1,
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects unsafe integer chainId in transaction step", () => {
+        const result = StepSchema.safeParse({
+            kind: "transaction",
+            chainId: Number.MAX_SAFE_INTEGER + 1,
+            transaction: {
+                to: "0x1234567890123456789012345678901234567890",
+                data: "0x",
+            },
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid address in transaction.to", () => {
+        const result = StepSchema.safeParse({
+            kind: "transaction",
+            chainId: 1,
+            transaction: {
+                to: "not-an-address",
+                data: "0x",
+            },
+        });
+        expect(result.success).toBe(false);
+    });
+});
+
+describe("OrderSchema", () => {
+    it("accepts a valid order with one step", () => {
+        const result = OrderSchema.safeParse({
+            steps: [
+                {
+                    kind: "transaction",
+                    chainId: 1,
+                    transaction: { to: "0x1234567890123456789012345678901234567890", data: "0x" },
+                },
+            ],
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it("rejects an order with empty steps", () => {
+        const result = OrderSchema.safeParse({ steps: [] });
+        expect(result.success).toBe(false);
+    });
+
+    it("accepts order with lock mechanism", () => {
+        const result = OrderSchema.safeParse({
+            steps: [
+                {
+                    kind: "signature",
+                    chainId: 1,
+                    signaturePayload: {
+                        signatureType: "eip712",
+                        domain: {},
+                        primaryType: "T",
+                        types: {},
+                        message: {},
+                    },
+                },
+            ],
+            lock: { type: "oif-escrow" },
+        });
+        expect(result.success).toBe(true);
+    });
+});
+
+describe("QuoteRequestSchema", () => {
+    const validRequest = {
+        user: "0x742D35cC6634C0532925A3b844bc9E7595f0BEb8",
+        input: {
+            chainId: 1,
+            assetAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            amount: "1000000",
+        },
+        output: {
+            chainId: 8453,
+            assetAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        },
+    };
+
+    it("accepts a valid quote request", () => {
+        const result = QuoteRequestSchema.safeParse(validRequest);
+        expect(result.success).toBe(true);
+    });
+
+    it("accepts with optional swapType", () => {
+        const result = QuoteRequestSchema.safeParse({
+            ...validRequest,
+            output: {
+                ...validRequest.output,
+                amount: "999000",
+            },
+            swapType: "exact-output",
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it("rejects invalid swapType", () => {
+        const result = QuoteRequestSchema.safeParse({
+            ...validRequest,
+            swapType: "invalid",
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects non-numeric amount string", () => {
+        const result = QuoteRequestSchema.safeParse({
+            ...validRequest,
+            input: {
+                chainId: 1,
+                assetAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                amount: "1.5",
+            },
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("accepts valid recipient address", () => {
+        const result = QuoteRequestSchema.safeParse({
+            ...validRequest,
+            output: {
+                ...validRequest.output,
+                recipient: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            },
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it("rejects invalid recipient address", () => {
+        const result = QuoteRequestSchema.safeParse({
+            ...validRequest,
+            output: {
+                ...validRequest.output,
+                recipient: "not-an-address",
+            },
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects exact-input without input.amount", () => {
+        const result = QuoteRequestSchema.safeParse({
+            ...validRequest,
+            input: {
+                chainId: 1,
+                assetAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            },
+            swapType: "exact-input",
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects exact-output without output.amount", () => {
+        const result = QuoteRequestSchema.safeParse({
+            ...validRequest,
+            output: {
+                chainId: 8453,
+                assetAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            },
+            swapType: "exact-output",
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("accepts exact-input with input.amount", () => {
+        const result = QuoteRequestSchema.safeParse({
+            ...validRequest,
+            swapType: "exact-input",
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it("rejects omitted swapType without input.amount (defaults to exact-input)", () => {
+        const result = QuoteRequestSchema.safeParse({
+            ...validRequest,
+            input: {
+                chainId: 1,
+                assetAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            },
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects unsafe integer chainId in input", () => {
+        const result = QuoteRequestSchema.safeParse({
+            ...validRequest,
+            input: {
+                ...validRequest.input,
+                chainId: Number.MAX_SAFE_INTEGER + 1,
+            },
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid calldata hex", () => {
+        const result = QuoteRequestSchema.safeParse({
+            ...validRequest,
+            output: {
+                ...validRequest.output,
+                calldata: "not-hex",
+            },
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("accepts valid calldata hex", () => {
+        const result = QuoteRequestSchema.safeParse({
+            ...validRequest,
+            output: {
+                ...validRequest.output,
+                calldata: "0xabcdef01",
+            },
+        });
+        expect(result.success).toBe(true);
+    });
+});
+
+describe("QuoteSchema", () => {
+    const validQuote = {
+        order: {
+            steps: [
+                {
+                    kind: "transaction" as const,
+                    chainId: 1,
+                    transaction: { to: "0x1234567890123456789012345678901234567890", data: "0x" },
+                },
+            ],
+        },
+        preview: {
+            inputs: [
+                {
+                    chainId: 1,
+                    accountAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    assetAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    amount: "1000000",
+                },
+            ],
+            outputs: [
+                {
+                    chainId: 8453,
+                    accountAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                    assetAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                    amount: "999000",
+                },
+            ],
+        },
+        provider: "test-solver",
+    };
+
+    it("accepts a valid quote", () => {
+        const result = QuoteSchema.safeParse(validQuote);
+        expect(result.success).toBe(true);
+    });
+
+    it("accepts with optional fields", () => {
+        const result = QuoteSchema.safeParse({
+            ...validQuote,
+            eta: 30,
+            validUntil: 1700000000,
+            quoteId: "abc-123",
+            partialFill: false,
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it("rejects negative eta", () => {
+        const result = QuoteSchema.safeParse({
+            ...validQuote,
+            eta: -1,
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects negative validUntil", () => {
+        const result = QuoteSchema.safeParse({
+            ...validQuote,
+            validUntil: -100,
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects empty inputs array", () => {
+        const result = QuoteSchema.safeParse({
+            ...validQuote,
+            preview: { ...validQuote.preview, inputs: [] },
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects empty outputs array", () => {
+        const result = QuoteSchema.safeParse({
+            ...validQuote,
+            preview: { ...validQuote.preview, outputs: [] },
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects unsafe integer chainId in preview entry", () => {
+        const result = QuoteSchema.safeParse({
+            ...validQuote,
+            preview: {
+                inputs: [{ ...validQuote.preview.inputs[0], chainId: Number.MAX_SAFE_INTEGER + 1 }],
+                outputs: validQuote.preview.outputs,
+            },
+        });
+        expect(result.success).toBe(false);
+    });
+});

--- a/packages/cross-chain/test/utils/interopAccountId.spec.ts
+++ b/packages/cross-chain/test/utils/interopAccountId.spec.ts
@@ -1,0 +1,115 @@
+import { encodeAddress } from "@wonderland/interop-addresses";
+import { describe, expect, it } from "vitest";
+
+import { fromInteropAccountId, toInteropAccountId } from "../../src/utils/interopAccountId.js";
+
+// Known addresses for deterministic tests
+const USDC_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const USER_ADDRESS = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8";
+
+// Pre-compute expected ERC-7930 hex values
+function expectedHex(chainId: number, address: string): string {
+    return encodeAddress(
+        {
+            version: 1,
+            chainType: "eip155",
+            chainReference: chainId.toString(),
+            address,
+        },
+        { format: "hex" },
+    ) as string;
+}
+
+describe("interopAccountId", () => {
+    describe("toInteropAccountId", () => {
+        it("decodes an ERC-7930 hex to InteropAccountId", () => {
+            const hex = expectedHex(1, USDC_ADDRESS);
+            const result = toInteropAccountId(hex);
+
+            expect(result.chainId).toBe(1);
+            expect(result.address.toLowerCase()).toBe(USDC_ADDRESS.toLowerCase());
+        });
+
+        it("handles multi-byte chain IDs", () => {
+            const hex = expectedHex(11155111, USER_ADDRESS);
+            const result = toInteropAccountId(hex);
+
+            expect(result.chainId).toBe(11155111);
+            expect(result.address.toLowerCase()).toBe(USER_ADDRESS.toLowerCase());
+        });
+
+        it("handles Base chain ID (8453)", () => {
+            const hex = expectedHex(8453, USDC_ADDRESS);
+            const result = toInteropAccountId(hex);
+
+            expect(result.chainId).toBe(8453);
+        });
+
+        it("throws for invalid hex input", () => {
+            expect(() => toInteropAccountId("not-valid")).toThrow();
+        });
+    });
+
+    describe("fromInteropAccountId", () => {
+        it("encodes an InteropAccountId to ERC-7930 hex", () => {
+            const result = fromInteropAccountId({
+                chainId: 1,
+                address: USDC_ADDRESS,
+            });
+
+            const expected = expectedHex(1, USDC_ADDRESS);
+            expect(result).toBe(expected);
+        });
+
+        it("encodes Sepolia chain ID correctly", () => {
+            const result = fromInteropAccountId({
+                chainId: 11155111,
+                address: USER_ADDRESS,
+            });
+
+            const expected = expectedHex(11155111, USER_ADDRESS);
+            expect(result).toBe(expected);
+        });
+
+        it("throws for non-positive chainId", () => {
+            expect(() => fromInteropAccountId({ chainId: 0, address: USDC_ADDRESS })).toThrow(
+                "must be a positive safe integer",
+            );
+        });
+
+        it("throws for non-integer chainId", () => {
+            expect(() => fromInteropAccountId({ chainId: 1.5, address: USDC_ADDRESS })).toThrow(
+                "must be a positive safe integer",
+            );
+        });
+
+        it("returns a valid ERC-7930 hex value", () => {
+            const result = fromInteropAccountId({
+                chainId: 1,
+                address: USDC_ADDRESS,
+            });
+
+            // Should be a hex string starting with 0x0001
+            expect(result).toMatch(/^0x0001/);
+        });
+    });
+
+    describe("round-trip", () => {
+        it("toInteropAccountId(fromInteropAccountId(id)) preserves values", () => {
+            const original = { chainId: 42161, address: USDC_ADDRESS };
+            const hex = fromInteropAccountId(original);
+            const roundTripped = toInteropAccountId(hex);
+
+            expect(roundTripped.chainId).toBe(original.chainId);
+            expect(roundTripped.address.toLowerCase()).toBe(original.address.toLowerCase());
+        });
+
+        it("fromInteropAccountId(toInteropAccountId(hex)) preserves hex", () => {
+            const originalHex = expectedHex(8453, USER_ADDRESS);
+            const id = toInteropAccountId(originalHex);
+            const roundTrippedHex = fromInteropAccountId(id);
+
+            expect(roundTrippedHex).toBe(originalHex);
+        });
+    });
+});

--- a/packages/cross-chain/test/utils/stepHelpers.spec.ts
+++ b/packages/cross-chain/test/utils/stepHelpers.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import type { Order, SignatureStep, TransactionStep } from "../../src/schemas/order.js";
+import {
+    getSignatureSteps,
+    getTransactionSteps,
+    isSignatureOnlyOrder,
+    isTransactionOnlyOrder,
+} from "../../src/utils/stepHelpers.js";
+
+const mockTxStep: TransactionStep = {
+    kind: "transaction",
+    chainId: 1,
+    transaction: {
+        to: "0x1234567890123456789012345678901234567890",
+        data: "0xabcdef",
+    },
+};
+
+const mockSigStep: SignatureStep = {
+    kind: "signature",
+    chainId: 1,
+    signaturePayload: {
+        signatureType: "eip712",
+        domain: { name: "Test", chainId: 1 },
+        primaryType: "TestMessage",
+        types: { TestMessage: [{ name: "value", type: "uint256" }] },
+        message: { value: "100" },
+    },
+};
+
+describe("stepHelpers", () => {
+    describe("getSignatureSteps", () => {
+        it("returns only signature steps", () => {
+            const order: Order = { steps: [mockTxStep, mockSigStep, mockTxStep] };
+            const result = getSignatureSteps(order);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]!.kind).toBe("signature");
+        });
+
+        it("returns empty array when no signature steps", () => {
+            const order: Order = { steps: [mockTxStep] };
+            expect(getSignatureSteps(order)).toHaveLength(0);
+        });
+
+        it("returns all signature steps when multiple exist", () => {
+            const order: Order = { steps: [mockSigStep, mockSigStep] };
+            expect(getSignatureSteps(order)).toHaveLength(2);
+        });
+    });
+
+    describe("getTransactionSteps", () => {
+        it("returns only transaction steps", () => {
+            const order: Order = { steps: [mockSigStep, mockTxStep, mockSigStep] };
+            const result = getTransactionSteps(order);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]!.kind).toBe("transaction");
+        });
+
+        it("returns empty array when no transaction steps", () => {
+            const order: Order = { steps: [mockSigStep] };
+            expect(getTransactionSteps(order)).toHaveLength(0);
+        });
+    });
+
+    describe("isSignatureOnlyOrder", () => {
+        it("returns true when all steps are signatures", () => {
+            const order: Order = { steps: [mockSigStep, mockSigStep] };
+            expect(isSignatureOnlyOrder(order)).toBe(true);
+        });
+
+        it("returns false when mixed steps", () => {
+            const order: Order = { steps: [mockSigStep, mockTxStep] };
+            expect(isSignatureOnlyOrder(order)).toBe(false);
+        });
+
+        it("returns false for empty steps", () => {
+            const order: Order = { steps: [] };
+            expect(isSignatureOnlyOrder(order)).toBe(false);
+        });
+    });
+
+    describe("isTransactionOnlyOrder", () => {
+        it("returns true when all steps are transactions", () => {
+            const order: Order = { steps: [mockTxStep, mockTxStep] };
+            expect(isTransactionOnlyOrder(order)).toBe(true);
+        });
+
+        it("returns false when mixed steps", () => {
+            const order: Order = { steps: [mockTxStep, mockSigStep] };
+            expect(isTransactionOnlyOrder(order)).toBe(false);
+        });
+
+        it("returns false for empty steps", () => {
+            const order: Order = { steps: [] };
+            expect(isTransactionOnlyOrder(order)).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Introduces SDK-friendly types alongside existing OIF wire types. No existing code is modified.

- `InteropAccountId` — `{ chainId, address }` replacing opaque ERC-7930 hex blobs
- `Order` with `steps[]` array (`TransactionStep | SignatureStep`) replacing the OIF order union
- `QuoteRequest` — flat structure with `user`, `input`, `output`, `swapType`
- `Quote` / `ExecutableQuote` / `SubmitOrderResponse` types + Zod schemas
- Step helpers: `getSignatureSteps()`, `getTransactionSteps()`, `isSignatureOnlyOrder()`, `isTransactionOnlyOrder()`
- Conversion utils: `toInteropAccountId()` / `fromInteropAccountId()`

**10 new files, 0 modified files**

## Why

Everything else in the rework depends on these types existing. Reviewing types in isolation lets us validate the API design before any wiring.

## Stack

1. **This PR** — SDK types, schemas, utilities
2. #186 — OIF adapter layer
3. #187 — Wire providers, rename to Aggregator, update example app
4. #188 — Update Across provider
5. #189 — Package reorganization
6. #190 — Documentation updates

## Test plan

- [x] New schema validation tests (16 tests)
- [x] New interopAccountId conversion tests (9 tests)
- [x] New step helper tests (11 tests)
- [x] All 363 existing tests still pass
- [x] Build passes
- [x] Lint passes
