### PR TITLE
feat(cross-chain): update Across provider to build SDK types directly

### DIFF
--- a/examples/ui/app/cross-chain/utils/quoteFormatter.ts
+++ b/examples/ui/app/cross-chain/utils/quoteFormatter.ts
@@ -150,15 +150,9 @@ export function formatQuoteData(
   // Check if gas simulation failed (affects whether gas estimates are reliable)
   let gasSimulationFailed = false;
 
-  // Across-specific: check simulationSuccess from stashed provider quote metadata
-  const acrossProviderQuote = metadata?._acrossProviderQuote as
-    | { order?: { payload?: { simulationSuccess?: boolean } } }
-    | undefined;
-  if (acrossProviderQuote?.order?.payload) {
-    const simulationSuccess = acrossProviderQuote.order.payload.simulationSuccess !== false;
-    if (!simulationSuccess) {
-      gasSimulationFailed = true;
-    }
+  // Across-specific: check simulationSuccess from metadata
+  if (metadata?.simulationSuccess === false) {
+    gasSimulationFailed = true;
   }
 
   const feeNum = feeTotalUsd ? parseFloat(feeTotalUsd.replace('$', '')) : 0;

--- a/examples/ui/tests/cross-chain.spec.ts
+++ b/examples/ui/tests/cross-chain.spec.ts
@@ -11,45 +11,69 @@ const MOCK_TOKENS = [
 ];
 
 /**
- * Mock quote response from Across API (matches AcrossGetQuoteResponseSchema)
+ * Builds a mock Across API quote response with calldata that matches the requested amount.
+ * The calldata is ABI-encoded for the SpokePool deposit(bytes32,...) function.
  */
-const MOCK_QUOTE_RESPONSE = {
-  id: 'e2e-test-quote-id',
-  inputToken: {
-    address: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238',
-    chainId: 11155111,
-    decimals: 6,
-    symbol: 'USDC',
-    name: 'USD Coin',
-  },
-  outputToken: {
-    address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
-    chainId: 84532,
-    decimals: 6,
-    symbol: 'USDC',
-    name: 'USD Coin',
-  },
-  inputAmount: '200000',
-  expectedOutputAmount: '199000',
-  minOutputAmount: '198000',
-  fees: {
-    total: {
-      amount: '1000',
-      amountUsd: '0.001',
-      pct: '500000000000000',
+function buildMockQuoteResponse(inputAmount: string) {
+  const input = BigInt(inputAmount);
+  const output = input - 1000n;
+  const inputHex = input.toString(16).padStart(64, '0');
+  const outputHex = output.toString(16).padStart(64, '0');
+
+  const data =
+    '0xad5425c6' + // deposit selector
+    '000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266' + // depositor
+    '000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266' + // recipient
+    '0000000000000000000000001c7d4b196cb0c7b01d743fbc6116a902379c7238' + // inputToken
+    '000000000000000000000000036cbd53842c5426634e7929541ec2318f3dcf7e' + // outputToken
+    inputHex + // inputAmount
+    outputHex + // outputAmount
+    '0000000000000000000000000000000000000000000000000000000000014a34' + // destinationChainId (84532)
+    '0000000000000000000000000000000000000000000000000000000000000000' + // exclusiveRelayer
+    '0000000000000000000000000000000000000000000000000000000000000000' + // quoteTimestamp
+    '0000000000000000000000000000000000000000000000000000000000000000' + // fillDeadline
+    '0000000000000000000000000000000000000000000000000000000000000000' + // exclusivityParameter
+    '0000000000000000000000000000000000000000000000000000000000000180' + // message offset
+    '0000000000000000000000000000000000000000000000000000000000000000'; // message length (empty)
+
+  return {
+    id: 'e2e-test-quote-id',
+    inputToken: {
+      address: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238',
+      chainId: 11155111,
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USD Coin',
     },
-  },
-  swapTx: {
-    simulationSuccess: true,
-    chainId: 11155111,
-    to: '0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662',
-    data: '0xad5425c6000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000001c7d4b196cb0c7b01d743fbc6116a902379c7238000000000000000000000000036cbd53842c5426634e7929541ec2318f3dcf7e0000000000000000000000000000000000000000000000000000000000030d400000000000000000000000000000000000000000000000000000000000030718000000000000000000000000000000000000000000000000000000000001499400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000000000',
-    gas: '250000',
-    maxFeePerGas: '1000000000',
-    maxPriorityFeePerGas: '1000000000',
-  },
-  expectedFillTime: 60,
-};
+    outputToken: {
+      address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+      chainId: 84532,
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USD Coin',
+    },
+    inputAmount,
+    expectedOutputAmount: output.toString(),
+    minOutputAmount: (output - 1000n).toString(),
+    fees: {
+      total: {
+        amount: '1000',
+        amountUsd: '0.001',
+        pct: '500000000000000',
+      },
+    },
+    swapTx: {
+      simulationSuccess: true,
+      chainId: 11155111,
+      to: '0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662',
+      data,
+      gas: '250000',
+      maxFeePerGas: '1000000000',
+      maxPriorityFeePerGas: '1000000000',
+    },
+    expectedFillTime: 60,
+  };
+}
 
 test.beforeEach(async ({ page, context }) => {
   // Mock Across asset discovery
@@ -61,12 +85,14 @@ test.beforeEach(async ({ page, context }) => {
     });
   });
 
-  // Mock Across quote
+  // Mock Across quote — build response with calldata matching the requested amount
   await context.route('**/api/swap/approval**', async (route) => {
+    const url = new URL(route.request().url());
+    const amount = url.searchParams.get('amount') || '200000';
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(MOCK_QUOTE_RESPONSE),
+      body: JSON.stringify(buildMockQuoteResponse(amount)),
     });
   });
 

--- a/packages/cross-chain/src/adapters/postOrderAdapter.ts
+++ b/packages/cross-chain/src/adapters/postOrderAdapter.ts
@@ -17,7 +17,7 @@ import { prefixSignatureForOrderType } from "./signaturePrefixAdapter.js";
  * Will be replaced by oif-specs PostOrderRequest when solver is updated
  */
 interface OifSolverPostOrderRequest {
-    quoteResponse: Omit<ProviderExecutableQuote, "preparedTransaction" | "_providerId">;
+    quoteResponse: Omit<ProviderExecutableQuote, "_providerId">;
     signature: Hex;
 }
 
@@ -32,7 +32,7 @@ export function adaptPostOrderRequest(
     const prefixedSignature = prefixSignatureForOrderType(signatureHex, request.order.type);
 
     // #109: OIF expects { quoteResponse, signature } not { order, signature, quoteId }
-    const { preparedTransaction, _providerId, ...quoteForSolver } = originalQuote;
+    const { _providerId, ...quoteForSolver } = originalQuote;
 
     return {
         quoteResponse: quoteForSolver,

--- a/packages/cross-chain/src/adapters/quoteAdapter.ts
+++ b/packages/cross-chain/src/adapters/quoteAdapter.ts
@@ -7,39 +7,12 @@
 
 import type { Order as OifOrder } from "@openintentsframework/oif-specs";
 
-import type { AcrossOrder, ProviderQuote } from "../interfaces/quotes.interface.js";
-import type { Order } from "../schemas/order.js";
+import type { ProviderQuote } from "../interfaces/quotes.interface.js";
 import type { Quote, QuotePreviewEntry } from "../schemas/quote.js";
 import { toInteropAccountId } from "../utils/interopAccountId.js";
 import { adaptOifOrder } from "./orderAdapter.js";
 
 // ── Helpers ──────────────────────────────────────────────
-
-function adaptAcrossOrder(order: AcrossOrder): Order {
-    return {
-        steps: [
-            {
-                kind: "transaction",
-                chainId: order.payload.chainId,
-                transaction: {
-                    to: order.payload.to,
-                    data: order.payload.data,
-                    gas: order.payload.gas,
-                    ...(order.payload.maxFeePerGas && {
-                        maxFeePerGas: order.payload.maxFeePerGas,
-                    }),
-                    ...(order.payload.maxPriorityFeePerGas && {
-                        maxPriorityFeePerGas: order.payload.maxPriorityFeePerGas,
-                    }),
-                },
-            },
-        ],
-        ...(order.metadata &&
-            Object.keys(order.metadata).length > 0 && {
-                metadata: order.metadata as Record<string, unknown>,
-            }),
-    };
-}
 
 function adaptPreviewEntry(entry: {
     account: string;
@@ -71,10 +44,7 @@ function adaptPreviewEntry(entry: {
  * - Preserves all other quote fields
  */
 export function adaptQuote(providerQuote: ProviderQuote): Quote {
-    const order =
-        (providerQuote.order as AcrossOrder).type === "across"
-            ? adaptAcrossOrder(providerQuote.order as AcrossOrder)
-            : adaptOifOrder(providerQuote.order as OifOrder);
+    const order = adaptOifOrder(providerQuote.order as OifOrder);
 
     const preview = {
         inputs: providerQuote.preview.inputs

--- a/packages/cross-chain/src/interfaces/quotes.interface.ts
+++ b/packages/cross-chain/src/interfaces/quotes.interface.ts
@@ -1,28 +1,11 @@
 import type { Order, Quote } from "@openintentsframework/oif-specs";
-import type { Address, PrepareTransactionRequestReturnType } from "viem";
-
-export interface AcrossOrder {
-    type: "across";
-    payload: {
-        simulationSuccess: boolean;
-        chainId: number;
-        to: Address;
-        data: string;
-        gas: string;
-        maxFeePerGas?: string;
-        maxPriorityFeePerGas?: string;
-    };
-    metadata: object;
-}
 
 /**
  * A quote returned by a provider, before the executor enriches it.
  * @internal Used by OifProvider and adapters for intermediate OIF wire-format data.
- * Extends the OIF Quote type to also accept Across orders.
  */
 export interface ProviderQuote extends Omit<Quote, "order"> {
-    order: Order | AcrossOrder;
-    preparedTransaction?: PrepareTransactionRequestReturnType;
+    order: Order;
 }
 
 /**

--- a/packages/cross-chain/src/providers/AcrossProvider.ts
+++ b/packages/cross-chain/src/providers/AcrossProvider.ts
@@ -1,22 +1,10 @@
-import { decodeAddress, encodeAddress } from "@wonderland/interop-addresses";
+import { encodeAddress } from "@wonderland/interop-addresses";
 import axios, { AxiosError } from "axios";
-import {
-    AbiEvent,
-    Address,
-    Chain,
-    Hex,
-    Log,
-    numberToHex,
-    pad,
-    PrepareTransactionRequestReturnType,
-    PublicClient,
-} from "viem";
+import { AbiEvent, Address, Hex, isAddressEqual, Log, numberToHex, pad } from "viem";
 import { ZodError } from "zod";
 
 import type { Quote } from "../schemas/quote.js";
 import type { QuoteRequest } from "../schemas/quoteRequest.js";
-import { adaptQuote } from "../adapters/quoteAdapter.js";
-import { adaptQuoteRequest } from "../adapters/quoteRequestAdapter.js";
 import {
     ACROSS_FILLED_RELAY_EVENT_ABI,
     ACROSS_SPOKE_POOL_ADDRESSES,
@@ -31,8 +19,6 @@ import {
     AcrossGetQuoteResponse,
     AcrossGetQuoteResponseSchema,
     AcrossMetadata,
-    AcrossOIFGetQuoteParams,
-    AcrossOIFGetQuoteParamsSchema,
     AcrossToken,
     acrossTokensResponseSchema,
     APIBasedFillWatcherConfig,
@@ -45,7 +31,6 @@ import {
     FillEvent,
     FillWatcherConfig,
     getAcrossApiUrl,
-    getChainById,
     GetFillParams,
     InvalidOpenEventError,
     NetworkAssets,
@@ -56,9 +41,8 @@ import {
     parseAbiEncodedFields,
     ProviderConfigFailure,
     ProviderGetQuoteFailure,
-    ProviderQuote,
-    PublicClientManager,
 } from "../internal.js";
+import { decodeAcrossCalldata } from "../utils/acrossCalldataDecoder.js";
 
 /**
  * An implementation of the CrossChainProvider interface for the Across protocol
@@ -74,7 +58,6 @@ export class AcrossProvider extends CrossChainProvider {
     readonly providerId: string;
     private readonly apiUrl: string;
     private readonly isTestnet: boolean;
-    private readonly clientManager = new PublicClientManager();
 
     constructor(config: AcrossConfigs) {
         super();
@@ -100,51 +83,8 @@ export class AcrossProvider extends CrossChainProvider {
         }
     }
 
-    private getPublicClient(chain: Chain): PublicClient {
-        return this.clientManager.getClient(chain);
-    }
-
-    /**
-     * Parse an interop address to a viem address and chain id
-     * @param address - The binary interop address (hex string) to parse
-     * @returns The viem address and chain id
-     */
-    private parseInteropAddress(address: string): { address: Address; chain: number } {
-        const decoded = decodeAddress(address as Hex);
-        if (!decoded.address) {
-            throw new Error("Address field is required");
-        }
-        if (!decoded.chainReference) {
-            throw new Error("Chain reference is required");
-        }
-        return {
-            address: decoded.address as Address,
-            chain: Number(decoded.chainReference),
-        };
-    }
-
-    /**
-     * Generate an interop address from a viem address and chain id
-     * @param address - The viem address
-     * @param chain - The chain id
-     * @returns The interop address
-     */
-    private generateInteropAddress(address: Address, chain: number): string {
-        return encodeAddress(
-            {
-                version: 1,
-                chainType: "eip155",
-                chainReference: chain.toString(),
-                address,
-            },
-            { format: "hex" },
-        ) as string;
-    }
-
     /**
      * Get a quote for an Across cross-chain transfer calling to the Across API
-     * @param params - The parameters for the action
-     * @returns A quote for the action
      */
     private async getAcrossQuote(params: AcrossGetQuoteParams): Promise<AcrossGetQuoteResponse> {
         try {
@@ -190,143 +130,143 @@ export class AcrossProvider extends CrossChainProvider {
         }
     }
 
-    private async convertOifParamsToAcrossParams(
-        params: AcrossOIFGetQuoteParams,
-    ): Promise<AcrossGetQuoteParams> {
-        try {
-            const userParsed = this.parseInteropAddress(params.user);
+    /**
+     * Convert SDK QuoteRequest directly to Across API parameters.
+     */
+    private toAcrossParams(params: QuoteRequest): AcrossGetQuoteParams {
+        const { input, output } = params;
+        const swapType = params.swapType ?? "exact-input";
+        const amount = swapType === "exact-input" ? input.amount : output.amount;
 
-            const { inputs, outputs } = params.intent;
-            const inputParsed = this.parseInteropAddress(inputs[0].asset);
-            const outputParsed = this.parseInteropAddress(outputs[0].asset);
-            const recipientParsed = this.parseInteropAddress(outputs[0].receiver);
-            const swapType = params.intent.swapType || "exact-input";
-            const amount = swapType === "exact-input" ? inputs[0].amount : outputs[0].amount;
-
-            return AcrossGetQuoteParamsSchema.parse({
-                tradeType: params.intent.swapType || "exact-input",
-                inputToken: inputParsed.address,
-                amount,
-                outputToken: outputParsed.address,
-                originChainId: inputParsed.chain,
-                destinationChainId: outputParsed.chain,
-                depositor: userParsed.address,
-                recipient: recipientParsed.address,
-            });
-        } catch (error) {
-            if (error instanceof ZodError) {
-                throw new ProviderGetQuoteFailure(
-                    "Failed to parse Across OIF quote request",
-                    error.message,
-                    error.stack,
-                );
-            }
-            throw new ProviderGetQuoteFailure(
-                "Failed to convert Across OIF quote request to Across params",
-                String(error),
-                error instanceof Error ? error.stack : undefined,
-            );
-        }
+        return AcrossGetQuoteParamsSchema.parse({
+            tradeType: swapType,
+            inputToken: input.assetAddress,
+            amount,
+            outputToken: output.assetAddress,
+            originChainId: input.chainId,
+            destinationChainId: output.chainId,
+            depositor: params.user,
+            recipient: output.recipient ?? params.user,
+        });
     }
 
-    private async convertAcrossSwapToOifQuote(
-        request: AcrossOIFGetQuoteParams,
-        response: AcrossGetQuoteResponse,
-    ): Promise<Omit<ProviderQuote, "preparedTransaction">> {
-        const { inputs, outputs } = request.intent;
-
+    /**
+     * Build an SDK Quote directly from Across API response.
+     */
+    private toSdkQuote(params: QuoteRequest, response: AcrossGetQuoteResponse): Quote {
         return {
             order: {
-                type: "across",
-                payload: response.swapTx,
-                metadata: {},
+                steps: [
+                    {
+                        kind: "transaction" as const,
+                        chainId: response.swapTx.chainId,
+                        transaction: {
+                            to: response.swapTx.to,
+                            data: response.swapTx.data,
+                            ...(response.swapTx.gas &&
+                                response.swapTx.gas !== "0" && {
+                                    gas: response.swapTx.gas,
+                                }),
+                            ...(response.swapTx.maxFeePerGas && {
+                                maxFeePerGas: response.swapTx.maxFeePerGas,
+                            }),
+                            ...(response.swapTx.maxPriorityFeePerGas && {
+                                maxPriorityFeePerGas: response.swapTx.maxPriorityFeePerGas,
+                            }),
+                        },
+                    },
+                ],
             },
             preview: {
                 inputs: [
                     {
-                        user: inputs[0].user,
-                        asset: this.generateInteropAddress(
-                            response.inputToken.address,
-                            response.inputToken.chainId,
-                        ),
+                        chainId: response.inputToken.chainId,
+                        accountAddress: params.user,
+                        assetAddress: response.inputToken.address,
                         amount: response.inputAmount,
                     },
                 ],
                 outputs: [
                     {
-                        receiver: outputs[0].receiver,
-                        asset: this.generateInteropAddress(
-                            response.outputToken.address,
-                            response.outputToken.chainId,
-                        ),
+                        chainId: response.outputToken.chainId,
+                        accountAddress: params.output.recipient ?? params.user,
+                        assetAddress: response.outputToken.address,
                         amount: response.expectedOutputAmount,
                     },
                 ],
             },
             quoteId: response.id,
             eta: response.expectedFillTime,
+            provider: this.providerId,
             partialFill: false,
             failureHandling: "refund-automatic",
             metadata: {
                 acrossResponse: response,
+                simulationSuccess: response.swapTx.simulationSuccess,
             },
         };
     }
 
     /**
-     * Prepare the transaction using the swapTx from the Across API
+     * Validate that Across calldata matches the user's QuoteRequest.
+     * Reuses the existing calldata decoder but compares against SDK types directly.
      */
-    private async prepareTransaction(
-        quote: AcrossGetQuoteResponse,
-    ): Promise<PrepareTransactionRequestReturnType | undefined> {
-        try {
-            const chain = getChainById(quote.swapTx.chainId);
-            const publicClient = this.getPublicClient(chain);
-            const preparedTransaction = await publicClient.prepareTransactionRequest({
-                to: quote.swapTx.to,
-                data: quote.swapTx.data,
-                chain,
-            });
-
-            return preparedTransaction;
-        } catch {
-            return undefined;
+    private validateCalldata(params: QuoteRequest, data: Hex): boolean {
+        const result = decodeAcrossCalldata(data);
+        if (!result.success) {
+            // "unsupported" selector (e.g. complex swap) — can't validate, allow through
+            // "invalid" calldata — reject
+            return result.reason === "unsupported";
         }
+
+        const decoded = result.params;
+        const { input, output } = params;
+        const recipient = output.recipient ?? params.user;
+
+        if (!isAddressEqual(decoded.depositor as Address, params.user as Address)) return false;
+        if (!isAddressEqual(decoded.inputToken as Address, input.assetAddress as Address))
+            return false;
+        if (!isAddressEqual(decoded.outputToken as Address, output.assetAddress as Address))
+            return false;
+        if (!isAddressEqual(decoded.recipient as Address, recipient as Address)) return false;
+        if (decoded.destinationChainId !== BigInt(output.chainId)) return false;
+
+        if (input.amount !== undefined) {
+            if (decoded.inputAmount !== BigInt(input.amount)) return false;
+        }
+
+        return true;
     }
 
     /**
      * @inheritdoc
      *
-     * Accepts SDK QuoteRequest, converts internally to OIF wire format
-     * for backward-compatible Across API integration.
+     * Builds SDK Quote types directly from Across API response.
      */
     async getQuotes(params: QuoteRequest): Promise<Quote[]> {
         try {
-            // Convert SDK QuoteRequest → OIF GetQuoteRequest for existing Across logic
-            const oifRequest = adaptQuoteRequest(params);
-            const parsedParams = AcrossOIFGetQuoteParamsSchema.parse(oifRequest);
+            const acrossParams = this.toAcrossParams(params);
+            const acrossResponse = await this.getAcrossQuote(acrossParams);
+            const quote = this.toSdkQuote(params, acrossResponse);
 
-            const acrossGetQuote = await this.convertOifParamsToAcrossParams(parsedParams);
-            const acrossQuote = await this.getAcrossQuote(acrossGetQuote);
-            const oifQuote = await this.convertAcrossSwapToOifQuote(parsedParams, acrossQuote);
+            if (!this.validateCalldata(params, acrossResponse.swapTx.data as Hex)) {
+                throw new ProviderGetQuoteFailure(
+                    "Across calldata validation failed",
+                    "Decoded deposit calldata does not match the requested intent",
+                );
+            }
 
-            const preparedTransaction = await this.prepareTransaction(acrossQuote);
-
-            const providerQuote: ProviderQuote = {
-                ...oifQuote,
-                preparedTransaction,
-            };
-
-            const sdkQuote = adaptQuote(providerQuote);
-            sdkQuote.metadata = {
-                ...sdkQuote.metadata,
-                _acrossProviderQuote: providerQuote,
-            };
-            return [sdkQuote];
+            return [quote];
         } catch (error) {
+            if (
+                error instanceof ProviderGetQuoteFailure ||
+                error instanceof ProviderConfigFailure
+            ) {
+                throw error;
+            }
             if (error instanceof ZodError) {
                 throw new ProviderGetQuoteFailure(
-                    "Failed to parse Across OIF quote request",
+                    "Failed to parse Across quote request",
                     error.message,
                     error.stack,
                 );
@@ -338,6 +278,8 @@ export class AcrossProvider extends CrossChainProvider {
             );
         }
     }
+
+    // submitOrder uses default implementation from CrossChainProvider (throws ProviderExecuteNotImplemented)
 
     /**
      * Get the opened intent parser configuration for Across

--- a/packages/cross-chain/src/providers/OifProvider.ts
+++ b/packages/cross-chain/src/providers/OifProvider.ts
@@ -65,7 +65,7 @@ export class OifProvider extends CrossChainProvider {
             this.headers = configParsed.headers;
             this.adapterMetadata = configParsed.adapterMetadata;
             this.providerId = configParsed.providerId ?? configParsed.solverId;
-            this.supportedLocks = configParsed.supportedLocks;
+            this.supportedLocks = configParsed.supportedLocks ?? ["oif-escrow"];
             this.submissionModes = configParsed.submissionModes;
         } catch (error) {
             if (error instanceof ZodError) {

--- a/packages/cross-chain/src/utils/orderTypeHelpers.ts
+++ b/packages/cross-chain/src/utils/orderTypeHelpers.ts
@@ -5,11 +5,9 @@ import type {
     Order,
 } from "@openintentsframework/oif-specs";
 
-import type { AcrossOrder } from "../interfaces/quotes.interface.js";
-
 export type SignableOifOrder = OifEscrowOrder | Oif3009Order | OifResourceLockOrder;
 
-export function isSignableOifOrder(order: Order | AcrossOrder): order is SignableOifOrder {
+export function isSignableOifOrder(order: Order): order is SignableOifOrder {
     return (
         order.type === "oif-escrow-v0" ||
         order.type === "oif-3009-v0" ||

--- a/packages/cross-chain/src/validators/payloadIntentValidator.ts
+++ b/packages/cross-chain/src/validators/payloadIntentValidator.ts
@@ -1,22 +1,21 @@
 import type { GetQuoteRequest } from "@openintentsframework/oif-specs";
-import type { Hex } from "viem";
 
 import type { IntentValidator, ProviderExecutableQuote } from "../internal.js";
 import { OIF_ORDER_TYPES } from "../constants/openIntentFramework.js";
-import { validateAcrossPayload } from "./acrossPayloadValidator.js";
 import { validateOifPayload } from "./oifPayloadValidator.js";
 
-/** Validates that calldata from external APIs matches the user's intent before signing */
+/**
+ * Validates that calldata from external APIs matches the user's intent before signing.
+ *
+ * Note: Across calldata validation is handled directly inside AcrossProvider.getQuotes()
+ * using the same decodeAcrossCalldata utility but comparing against SDK QuoteRequest types.
+ */
 export class PayloadIntentValidator implements IntentValidator {
     async validateIntent(
         userIntent: GetQuoteRequest,
         quote: ProviderExecutableQuote,
     ): Promise<boolean> {
         const order = quote.order;
-
-        if (order.type === "across") {
-            return validateAcrossPayload(userIntent, order.payload.data as Hex);
-        }
 
         if (OIF_ORDER_TYPES.includes(order.type)) {
             return validateOifPayload(userIntent, order);

--- a/packages/cross-chain/src/validators/settlerIntentValidator.ts
+++ b/packages/cross-chain/src/validators/settlerIntentValidator.ts
@@ -9,6 +9,16 @@ export class SettlerIntentValidator implements IntentValidator {
         _userIntent: GetQuoteRequest,
         quote: ProviderExecutableQuote,
     ): Promise<boolean> {
-        return this.validSettlers.includes(quote.preparedTransaction?.to ?? "");
+        // For user-open orders, check the openIntentTx.to address
+        const order = quote.order as {
+            type: string;
+            openIntentTx?: { to: string };
+        };
+        if (order.type === "oif-user-open-v0" && order.openIntentTx?.to) {
+            return this.validSettlers.some(
+                (settler) => settler.toLowerCase() === order.openIntentTx!.to.toLowerCase(),
+            );
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

Brings the Across provider in line with the new SDK types introduced in PRs 1-3.

- `AcrossProvider.getQuotes()` returns `Quote[]` with SDK types
- Builds SDK `Order` directly from Across response (`TransactionStep`)
- Uses flat `QuotePreview` with `chainId`/`accountAddress`/`assetAddress`
- Removes `AcrossOrder` escape hatch type
- Updates Across tests

Note: this removes the Across Order validation -> this is noted as a TODO, and can be addressed in a fix after the refactor

## Why

Across is a distinct protocol with its own logic. Isolating it makes review straightforward and avoids conflating OIF + Across changes.

## Stack

1. #185 — SDK types, schemas, utilities
2. #186 — OIF adapter layer
3. #187 — Wire providers, rename to Aggregator, update example app
4. **This PR** — Update Across provider
5. #189 — Package reorganization
6. #190 — Documentation updates

## Test plan

- [x] Across provider tests pass
- [x] Full cross-chain test suite (363 tests) passes
- [x] `pnpm build` succeeds (full monorepo)
