### PR TITLE
docs(cross-chain): update documentation for new SDK types and API

### DIFF
--- a/apps/docs/docs/cross-chain.md
+++ b/apps/docs/docs/cross-chain.md
@@ -15,7 +15,12 @@ The cross-chain package provides a standardized interface for interacting with c
 ## Quick Start
 
 ```typescript
-import { createCrossChainProvider } from "@wonderland/interop-cross-chain";
+import {
+    createCrossChainProvider,
+    getSignatureSteps,
+    getTransactionSteps,
+    isSignatureOnlyOrder,
+} from "@wonderland/interop-cross-chain";
 
 // Create an OIF provider
 const provider = createCrossChainProvider("oif", {
@@ -25,21 +30,37 @@ const provider = createCrossChainProvider("oif", {
 
 // Get quotes for a cross-chain transfer
 const quotes = await provider.getQuotes({
-    user: USER_INTEROP_ADDRESS, // user's interop address (binary format)
-    intent: {
-        intentType: "oif-swap",
-        inputs: [
-            {
-                user: USER_INTEROP_ADDRESS,
-                asset: INPUT_TOKEN_ADDRESS,
-                amount: "1000000000000000000",
-            },
-        ],
-        outputs: [{ receiver: RECEIVER_INTEROP_ADDRESS, asset: OUTPUT_TOKEN_ADDRESS }],
-        swapType: "exact-input",
+    user: "0xYourAddress",
+    input: {
+        chainId: 1,
+        assetAddress: "0xInputTokenAddress",
+        amount: "1000000000000000000",
     },
-    supportedTypes: ["oif-escrow-v0"],
+    output: {
+        chainId: 42161,
+        assetAddress: "0xOutputTokenAddress",
+        recipient: "0xRecipientAddress",
+    },
+    swapType: "exact-input",
 });
+
+const quote = quotes[0];
+
+if (isSignatureOnlyOrder(quote.order)) {
+    // Protocol mode: sign EIP-712 typed data (gasless for user)
+    const step = getSignatureSteps(quote.order)[0];
+    const { signatureType, ...typedData } = step.signaturePayload;
+    const signature = await walletClient.signTypedData(typedData);
+    await provider.submitOrder(quote, signature);
+} else {
+    // User mode: send transaction directly
+    const step = getTransactionSteps(quote.order)[0];
+    await walletClient.sendTransaction({
+        to: step.transaction.to,
+        data: step.transaction.data,
+        value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
+    });
+}
 ```
 
 For Across Protocol integration, see the [Across Provider](./cross-chain/across-provider.md) guide.

--- a/apps/docs/docs/cross-chain/across-provider.md
+++ b/apps/docs/docs/cross-chain/across-provider.md
@@ -34,26 +34,18 @@ const acrossProvider = createCrossChainProvider("across", { isTestnet: true });
 
 ```typescript
 const quotes = await acrossProvider.getQuotes({
-    user: USER_INTEROP_ADDRESS, // user's interop address (binary format)
-    intent: {
-        intentType: "oif-swap",
-        inputs: [
-            // Across only supports single input/output
-            {
-                user: USER_INTEROP_ADDRESS, // sender's interop address (binary format)
-                asset: INPUT_TOKEN_INTEROP_ADDRESS, // input token interop address (binary format)
-                amount: "1000000000000000000", // 1 token (in wei)
-            },
-        ],
-        outputs: [
-            {
-                receiver: RECEIVER_INTEROP_ADDRESS, // recipient's interop address (binary format)
-                asset: OUTPUT_TOKEN_INTEROP_ADDRESS, // output token interop address (binary format)
-            },
-        ],
-        swapType: "exact-input",
+    user: "0xYourAddress",
+    input: {
+        chainId: 11155111,
+        assetAddress: "0xInputTokenAddress",
+        amount: "1000000000000000000", // 1 token (in wei)
     },
-    supportedTypes: ["across"], // Required by OIF interface, value is ignored by Across
+    output: {
+        chainId: 84532,
+        assetAddress: "0xOutputTokenAddress",
+        recipient: "0xRecipientAddress",
+    },
+    swapType: "exact-input",
 });
 
 const quote = quotes[0]; // Select the first quote
@@ -61,9 +53,10 @@ const quote = quotes[0]; // Select the first quote
 
 ## Executing Transactions
 
-After getting a quote, execute the transaction using the prepared transaction:
+Across quotes always contain transaction steps. After getting a quote, execute the transaction:
 
 ```typescript
+import { getTransactionSteps } from "@wonderland/interop-cross-chain";
 import { createWalletClient, http } from "viem";
 import { sepolia } from "viem/chains";
 
@@ -73,10 +66,13 @@ const walletClient = createWalletClient({
     account: yourAccount,
 });
 
-if (quote.preparedTransaction) {
-    const hash = await walletClient.sendTransaction(quote.preparedTransaction);
-    console.log("Transaction sent:", hash);
-}
+const step = getTransactionSteps(quote.order)[0];
+const hash = await walletClient.sendTransaction({
+    to: step.transaction.to,
+    data: step.transaction.data,
+    value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
+});
+console.log("Transaction sent:", hash);
 ```
 
 ## Features

--- a/apps/docs/docs/cross-chain/advanced-usage.md
+++ b/apps/docs/docs/cross-chain/advanced-usage.md
@@ -2,18 +2,18 @@
 title: Advanced Usage
 ---
 
-## Provider Executor
+## Aggregator
 
-For complex scenarios, use the ProviderExecutor to manage multiple providers with sorting, timeout handling, and built-in order tracking.
+For complex scenarios, use the Aggregator to manage multiple providers with sorting, timeout handling, and built-in order tracking.
 
 ### Minimal Setup
 
 ```typescript
-import { createCrossChainProvider, createProviderExecutor } from "@wonderland/interop-cross-chain";
+import { createAggregator, createCrossChainProvider } from "@wonderland/interop-cross-chain";
 
 const acrossProvider = createCrossChainProvider("across", { isTestnet: true });
 
-const executor = createProviderExecutor({
+const aggregator = createAggregator({
     providers: [acrossProvider],
 });
 ```
@@ -21,16 +21,17 @@ const executor = createProviderExecutor({
 ### Full Configuration
 
 ```typescript
+import type { QuoteRequest } from "@wonderland/interop-cross-chain";
 import {
+    createAggregator,
     createCrossChainProvider,
-    createProviderExecutor,
     OrderTrackerFactory,
     SortingStrategyFactory,
 } from "@wonderland/interop-cross-chain";
 
 const acrossProvider = createCrossChainProvider("across", { isTestnet: true });
 
-const executor = createProviderExecutor({
+const aggregator = createAggregator({
     providers: [acrossProvider],
     sortingStrategy: SortingStrategyFactory.createStrategy("bestOutput"),
     timeoutMs: 15000,
@@ -43,26 +44,19 @@ const executor = createProviderExecutor({
 });
 
 // Get quotes from all providers
-const response = await executor.getQuotes({
-    user: USER_INTEROP_ADDRESS, // user's interop address (binary format)
-    intent: {
-        intentType: "oif-swap",
-        inputs: [
-            {
-                user: USER_INTEROP_ADDRESS, // sender's interop address (binary format)
-                asset: INPUT_TOKEN_INTEROP_ADDRESS, // input token interop address (binary format)
-                amount: "1000000000000000000",
-            },
-        ],
-        outputs: [
-            {
-                receiver: RECEIVER_INTEROP_ADDRESS, // recipient's interop address (binary format)
-                asset: OUTPUT_TOKEN_INTEROP_ADDRESS, // output token interop address (binary format)
-            },
-        ],
-        swapType: "exact-input",
+const response = await aggregator.getQuotes({
+    user: "0xYourAddress",
+    input: {
+        chainId: 11155111,
+        assetAddress: "0xInputToken",
+        amount: "1000000000000000000",
     },
-    supportedTypes: ["across"],
+    output: {
+        chainId: 84532,
+        assetAddress: "0xOutputToken",
+        recipient: "0xRecipient",
+    },
+    swapType: "exact-input",
 });
 
 // Handle results
@@ -76,21 +70,30 @@ response.errors.forEach((error) => {
 });
 ```
 
-For more details on the Provider Executor configuration, see the [API Reference](./api.md#provider-executor).
+For more details on the Aggregator configuration, see the [API Reference](./api.md#aggregator).
 
 ## Order Tracking
 
-The executor includes built-in order tracking when configured with a `trackerFactory`. After executing a transaction, use `executor.track()` to monitor the cross-chain transfer:
+The aggregator includes built-in order tracking when configured with a `trackerFactory`. After executing a transaction, use `aggregator.track()` to monitor the cross-chain transfer:
 
 ```typescript
-import { OrderStatus, OrderTrackerEvent } from "@wonderland/interop-cross-chain";
+import {
+    getTransactionSteps,
+    OrderStatus,
+    OrderTrackerEvent,
+} from "@wonderland/interop-cross-chain";
 
 // Execute the transaction
 const quote = response.quotes[0];
-const hash = await walletClient.sendTransaction(quote.preparedTransaction);
+const step = getTransactionSteps(quote.order)[0];
+const hash = await walletClient.sendTransaction({
+    to: step.transaction.to,
+    data: step.transaction.data,
+    value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
+});
 
 // Track with real-time events
-const tracker = executor.track({
+const tracker = aggregator.track({
     txHash: hash,
     providerId: quote.provider, // e.g., "across"
     originChainId: 11155111,
@@ -110,7 +113,7 @@ tracker.on(OrderTrackerEvent.Error, (error) => console.error("Tracking error:", 
 For a simple status check without event-based tracking:
 
 ```typescript
-const status = await executor.getOrderStatus({
+const status = await aggregator.getOrderStatus({
     txHash: "0x...",
     providerId: "across",
     originChainId: 11155111,
@@ -139,7 +142,7 @@ import {
 } from "@wonderland/interop-cross-chain";
 
 try {
-    const response = await executor.getQuotes({
+    const response = await aggregator.getQuotes({
         /* ... */
     });
 } catch (error) {
@@ -159,7 +162,7 @@ try {
 
 ## Best Practices
 
-1. Always check both `quotes` and `errors` in the executor response
+1. Always check both `quotes` and `errors` in the aggregator response
 2. Use sorting strategies to get the best quotes first
 3. Use `OrderTracker` to monitor cross-chain transfers
 4. Handle errors appropriately using the provided error types

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -32,56 +32,49 @@ A set of classes and utilities for handling cross-chain operations through vario
 
 An abstract class that defines the interface for cross-chain protocol providers.
 
--   **getProtocolName**(): string
+-   **protocolName**: string
 
-    Returns the name of the protocol this provider implements.
-
-    ```typescript
-    const protocolName = provider.getProtocolName(); // e.g., "across"
-    ```
-
--   **getProviderId**(): string
-
-    Returns the unique provider instance ID.
+    The name of the protocol this provider implements.
 
     ```typescript
-    const providerId = provider.getProviderId(); // e.g., "across-1"
+    const protocolName = provider.protocolName; // e.g., "across"
     ```
 
--   **getQuotes**(params: GetQuoteRequest): Promise\<ExecutableQuote[]\>
+-   **providerId**: string
+
+    The unique provider instance ID.
+
+    ```typescript
+    const providerId = provider.providerId; // e.g., "across-1"
+    ```
+
+-   **getQuotes**(params: QuoteRequest): Promise\<Quote[]\>
 
     Fetches quotes for a cross-chain operation.
 
     ```typescript
     const quotes = await provider.getQuotes({
-        user: USER_INTEROP_ADDRESS, // user's interop address (binary format)
-        intent: {
-            intentType: "oif-swap",
-            inputs: [
-                {
-                    user: USER_INTEROP_ADDRESS, // sender's interop address (binary format)
-                    asset: INPUT_TOKEN_INTEROP_ADDRESS, // input token interop address (binary format)
-                    amount: "1000000000000000000",
-                },
-            ],
-            outputs: [
-                {
-                    receiver: RECEIVER_INTEROP_ADDRESS, // recipient's interop address (binary format)
-                    asset: OUTPUT_TOKEN_INTEROP_ADDRESS, // output token interop address (binary format)
-                },
-            ],
-            swapType: "exact-input",
+        user: "0xYourAddress",
+        input: {
+            chainId: 1,
+            assetAddress: "0xTokenAddress",
+            amount: "1000000000000000000",
         },
-        supportedTypes: ["across"], // provider-specific: "across", "oif-escrow-v0", "oif-user-open-v0"
+        output: {
+            chainId: 42161,
+            assetAddress: "0xOutputTokenAddress",
+            recipient: "0xRecipientAddress",
+        },
+        swapType: "exact-input",
     });
     ```
 
--   **submitSignedOrder**(quote: ExecutableQuote, signature: Hex): Promise\<PostOrderResponse\>
+-   **submitOrder**(quote: Quote, signature: Hex): Promise\<SubmitOrderResponse\>
 
     Submits a signed order for gasless execution.
 
     ```typescript
-    const response = await provider.submitSignedOrder(quote, signature);
+    const response = await provider.submitOrder(quote, signature);
     ```
 
 -   **getTrackingConfig**(): TrackingConfig
@@ -92,60 +85,55 @@ An abstract class that defines the interface for cross-chain protocol providers.
     const config = provider.getTrackingConfig();
     ```
 
-### Provider Executor
+### Aggregator
 
 A utility for managing multiple cross-chain providers and executing operations across them.
 
 #### Methods
 
--   **createProviderExecutor**(config: ProviderExecutorConfig): ProviderExecutor
+-   **createAggregator**(config: AggregatorConfig): Aggregator
 
-    Creates an executor instance for managing multiple providers.
+    Creates an aggregator instance for managing multiple providers.
 
     ```typescript
     import {
-        createProviderExecutor,
+        AssetDiscoveryFactory,
+        createAggregator,
         OrderTrackerFactory,
         SortingStrategyFactory,
     } from "@wonderland/interop-cross-chain";
 
-    const executor = createProviderExecutor({
+    const aggregator = createAggregator({
         providers: [acrossProvider],
         sortingStrategy: SortingStrategyFactory.createStrategy("bestOutput"), // optional
         timeoutMs: 15000, // optional
         trackerFactory: new OrderTrackerFactory({ rpcUrls }), // optional
+        discoveryFactory: new AssetDiscoveryFactory(), // optional (default)
     });
     ```
 
-#### ProviderExecutor Class
+#### Aggregator Class
 
 A class that manages multiple cross-chain providers and coordinates their operations.
 
--   **getQuotes**(params: GetQuoteRequest): Promise\<GetQuotesResponse\>
+-   **getQuotes**(params: QuoteRequest): Promise\<GetQuotesResponse\>
 
     Retrieves quotes from all available providers for a given operation.
 
     ```typescript
-    const response = await executor.getQuotes({
-        user: USER_INTEROP_ADDRESS, // user's interop address (binary format)
-        intent: {
-            intentType: "oif-swap",
-            inputs: [
-                {
-                    user: USER_INTEROP_ADDRESS, // sender's interop address (binary format)
-                    asset: INPUT_TOKEN_INTEROP_ADDRESS, // input token interop address (binary format)
-                    amount: "1000000000000000000",
-                },
-            ],
-            outputs: [
-                {
-                    receiver: RECEIVER_INTEROP_ADDRESS, // recipient's interop address (binary format)
-                    asset: OUTPUT_TOKEN_INTEROP_ADDRESS, // output token interop address (binary format)
-                },
-            ],
-            swapType: "exact-input",
+    const response = await aggregator.getQuotes({
+        user: "0xYourAddress",
+        input: {
+            chainId: 1,
+            assetAddress: "0xInputToken",
+            amount: "1000000000000000000",
         },
-        supportedTypes: ["across"], // provider-specific: "across", "oif-escrow-v0", "oif-user-open-v0"
+        output: {
+            chainId: 42161,
+            assetAddress: "0xOutputToken",
+            recipient: "0xRecipient",
+        },
+        swapType: "exact-input",
     });
 
     // Handle results
@@ -155,6 +143,19 @@ A class that manages multiple cross-chain providers and coordinates their operat
     response.errors.forEach((error) => console.error(error.errorMsg));
     ```
 
+-   **submitOrder**(quote: ExecutableQuote, signatureOrResults: Hex | StepResult[]): Promise\<SubmitOrderResponse\>
+
+    Submits an order for execution. Pass a single `Hex` signature for single-step orders, or an array of `StepResult` for multi-step orders.
+
+    ```typescript
+    // Single signature
+    const response = await aggregator.submitOrder(quote, signature);
+
+    // Multi-step results
+    const results: StepResult[] = [{ stepIndex: 0, signature: "0x..." }];
+    const response = await aggregator.submitOrder(quote, results);
+    ```
+
 -   **track**(params: TrackParams): OrderTracker
 
     Starts tracking an executed transaction with real-time events.
@@ -162,7 +163,7 @@ A class that manages multiple cross-chain providers and coordinates their operat
     ```typescript
     import { OrderStatus } from "@wonderland/interop-cross-chain";
 
-    const tracker = executor.track({
+    const tracker = aggregator.track({
         txHash: hash,
         providerId: quote.provider,
         originChainId: 11155111,
@@ -178,12 +179,43 @@ A class that manages multiple cross-chain providers and coordinates their operat
     Gets the current status of an order without watching.
 
     ```typescript
-    const status = await executor.getOrderStatus({
+    const status = await aggregator.getOrderStatus({
         txHash: "0x...",
         providerId: "across",
         originChainId: 11155111,
     });
     console.log(status.status); // OrderStatus
+    ```
+
+-   **prepareTracking**(providerId: string): OrderTracker
+
+    Returns an OrderTracker instance for a provider. Use this to set up event listeners _before_ sending a transaction.
+
+    ```typescript
+    const tracker = aggregator.prepareTracking(quote._providerId);
+    tracker.on(OrderStatus.Finalized, (update) => console.log("Done!", update.fillTxHash));
+    // ...then send the transaction and call tracker.startTracking(...)
+    ```
+
+-   **discoverAssets**(options?: AssetDiscoveryOptions): Promise\<DiscoveredAssets\>
+
+    Discovers supported assets from all configured providers.
+
+    ```typescript
+    const discovered = await aggregator.discoverAssets({ chainIds: [1, 42161] });
+    // discovered.tokensByChain — token addresses grouped by CAIP-350 chain identifier
+    // discovered.tokenMetadata — token metadata keyed by interop address
+    ```
+
+-   **getProvidersForRoute**(query: RouteQuery): Promise\<string[]\>
+
+    Returns provider IDs that support a given origin/destination asset pair. Both addresses use EIP-7930 interop format.
+
+    ```typescript
+    const providers = await aggregator.getProvidersForRoute({
+        originAsset: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        destinationAsset: "0x00010001490833d0aef5f930c0015f8baa4e30d8f9ced...",
+    });
     ```
 
 ### Sorting Strategies
@@ -262,13 +294,77 @@ A class that tracks cross-chain orders through their lifecycle.
 
 ### Types
 
+#### QuoteRequest
+
+```typescript
+interface QuoteRequest {
+    user: string;
+    input: {
+        chainId: number;
+        assetAddress: string;
+        amount?: string;
+    };
+    output: {
+        chainId: number;
+        assetAddress: string;
+        amount?: string;
+        recipient?: string;
+        calldata?: string;
+    };
+    swapType?: "exact-input" | "exact-output"; // default: "exact-input"
+}
+```
+
+#### Quote
+
+```typescript
+interface Quote {
+    order: Order;
+    preview: {
+        inputs: { chainId: number; accountAddress: string; assetAddress: string; amount: string }[];
+        outputs: {
+            chainId: number;
+            accountAddress: string;
+            assetAddress: string;
+            amount: string;
+        }[];
+    };
+    provider: string;
+    validUntil?: number; // quote validity (unix timestamp)
+    eta?: number; // estimated time to completion (seconds)
+    quoteId?: string;
+    failureHandling?: string;
+    partialFill?: boolean;
+    metadata?: Record<string, unknown>;
+}
+```
+
+#### Order
+
+```typescript
+interface Order {
+    steps: (SignatureStep | TransactionStep)[];
+    lock?: LockMechanism;
+    checks?: OrderChecks;
+    metadata?: Record<string, unknown>;
+}
+```
+
 #### ExecutableQuote
 
 ```typescript
-interface ExecutableQuote {
-    order: Quote["order"];
-    provider?: string;
-    preparedTransaction?: PrepareTransactionRequestReturnType;
+interface ExecutableQuote extends Quote {
+    /** @internal SDK routing field — identifies which provider handles this quote */
+    _providerId: string;
+}
+```
+
+#### StepResult
+
+```typescript
+interface StepResult {
+    stepIndex: number; // Index into order.steps[]
+    signature: Hex; // EIP-712 signature
 }
 ```
 
@@ -278,6 +374,31 @@ interface ExecutableQuote {
 interface GetQuotesResponse {
     quotes: ExecutableQuote[];
     errors: { errorMsg: string; error: Error }[];
+}
+```
+
+#### TokenTransfer
+
+ERC-7683 token transfer structure used in `OrderTrackingInfo`.
+
+```typescript
+interface TokenTransfer {
+    token: Hex;
+    amount: bigint;
+    recipient: Hex;
+    chainId: number;
+}
+```
+
+#### FillInstruction
+
+ERC-7683 fill instruction for destination chain.
+
+```typescript
+interface FillInstruction {
+    destinationChainId: number;
+    destinationSettler: Hex;
+    originData: Hex;
 }
 ```
 
@@ -292,6 +413,9 @@ interface OrderTrackingInfo {
     originChainId: number;
     openDeadline: number;
     fillDeadline: number;
+    maxSpent: TokenTransfer[];
+    minReceived: TokenTransfer[];
+    fillInstructions: FillInstruction[];
     fillEvent?: FillEvent;
     failureReason?: OrderFailureReason;
 }
@@ -303,7 +427,7 @@ interface OrderTrackingInfo {
 interface OrderTrackingUpdate {
     status: OrderStatus;
     orderId?: Hex;
-    openTxHash: Hex;
+    openTxHash?: Hex;
     fillTxHash?: Hex;
     timestamp: number;
     message: string;
@@ -316,12 +440,13 @@ interface OrderTrackingUpdate {
 ```typescript
 interface FillEvent {
     fillTxHash: Hex;
-    blockNumber: bigint;
+    blockNumber?: bigint;
     timestamp: number;
     originChainId: number;
     orderId: Hex;
-    relayer: Address;
-    recipient: Address;
+    relayer?: Address;
+    recipient?: Address;
+    metadata?: unknown;
 }
 ```
 

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -354,8 +354,7 @@ interface Order {
 
 ```typescript
 interface ExecutableQuote extends Quote {
-    /** @internal SDK routing field — identifies which provider handles this quote */
-    _providerId: string;
+    // Use quote.provider for provider identification
 }
 ```
 

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -192,7 +192,7 @@ A class that manages multiple cross-chain providers and coordinates their operat
     Returns an OrderTracker instance for a provider. Use this to set up event listeners _before_ sending a transaction.
 
     ```typescript
-    const tracker = aggregator.prepareTracking(quote._providerId);
+    const tracker = aggregator.prepareTracking(quote.provider);
     tracker.on(OrderStatus.Finalized, (update) => console.log("Done!", update.fillTxHash));
     // ...then send the transaction and call tracker.startTracking(...)
     ```

--- a/apps/docs/docs/cross-chain/example.md
+++ b/apps/docs/docs/cross-chain/example.md
@@ -11,7 +11,13 @@ This guide demonstrates how to execute a cross-chain intent using the SDK. The p
 First, import the required libraries and set up your environment variables, such as your private key and a generic RPC URL.
 
 ```js
-import { createCrossChainProvider, createProviderExecutor } from "@wonderland/interop-cross-chain";
+import {
+    createAggregator,
+    createCrossChainProvider,
+    getSignatureSteps,
+    getTransactionSteps,
+    isSignatureOnlyOrder,
+} from "@wonderland/interop-cross-chain";
 import { createPublicClient, createWalletClient, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
@@ -42,43 +48,36 @@ const walletClient = createWalletClient({
 });
 ```
 
-## 3. Set Up Cross-Chain Provider and Executor
+## 3. Set Up Cross-Chain Provider and Aggregator
 
-Initialize the cross-chain provider and executor, which will handle quoting and executing cross-chain transfers.
+Initialize the cross-chain provider and aggregator, which will handle quoting and executing cross-chain transfers.
 
 ```js
 const acrossProvider = createCrossChainProvider("across", { isTestnet: true });
 
-const executor = createProviderExecutor({
+const aggregator = createAggregator({
     providers: [acrossProvider],
 });
 ```
 
 ## 4. Retrieve a Cross-Chain Quote
 
-Request a quote for a cross-chain transfer using OIF GetQuoteRequest format.
+Request a quote for a cross-chain transfer using the SDK `QuoteRequest` format.
 
 ```js
-const response = await executor.getQuotes({
-    user: USER_INTEROP_ADDRESS, // user's interop address (binary format)
-    intent: {
-        intentType: "oif-swap",
-        inputs: [
-            {
-                user: USER_INTEROP_ADDRESS, // sender's interop address (binary format)
-                asset: INPUT_TOKEN_INTEROP_ADDRESS, // input token interop address (binary format)
-                amount: "100000000000000000", // 0.1 in wei
-            },
-        ],
-        outputs: [
-            {
-                receiver: RECEIVER_INTEROP_ADDRESS, // recipient's interop address (binary format)
-                asset: OUTPUT_TOKEN_INTEROP_ADDRESS, // output token interop address (binary format)
-            },
-        ],
-        swapType: "exact-input",
+const response = await aggregator.getQuotes({
+    user: "0xYourAddress",
+    input: {
+        chainId: 11155111,
+        assetAddress: "0xInputTokenAddress",
+        amount: "100000000000000000", // 0.1 in wei
     },
-    supportedTypes: ["across"],
+    output: {
+        chainId: 84532,
+        assetAddress: "0xOutputTokenAddress",
+        recipient: "0xRecipientAddress",
+    },
+    swapType: "exact-input",
 });
 
 // Check for errors
@@ -95,21 +94,31 @@ if (response.quotes.length === 0) {
 
 ## 5. Execute the Cross-Chain Transaction
 
-Execute the quote using your wallet client:
+Execute the quote based on its order step type:
 
 ```js
-// Select the quote you prefer (e.g., first one)
 const quote = response.quotes[0];
 
-if (quote.preparedTransaction) {
+if (isSignatureOnlyOrder(quote.order)) {
+    // Protocol mode: sign and submit (gasless for user)
+    const step = getSignatureSteps(quote.order)[0];
+    const { signatureType, ...typedData } = step.signaturePayload;
+    const signature = await walletClient.signTypedData(typedData);
+    await aggregator.submitOrder(quote, signature);
+    console.log("Order submitted via signature");
+} else {
+    // User mode: send transaction directly
+    const step = getTransactionSteps(quote.order)[0];
     console.log("Sending transaction...");
-    const hash = await walletClient.sendTransaction(quote.preparedTransaction);
+    const hash = await walletClient.sendTransaction({
+        to: step.transaction.to,
+        data: step.transaction.data,
+        value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
+    });
     console.log("Transaction sent:", hash);
 
     const receipt = await publicClient.waitForTransactionReceipt({ hash });
     console.log("Transaction confirmed:", receipt.status === "success" ? "Success" : "Failed");
-} else {
-    console.error("No prepared transaction in quote");
 }
 ```
 

--- a/apps/docs/docs/cross-chain/example.md
+++ b/apps/docs/docs/cross-chain/example.md
@@ -101,6 +101,7 @@ const quote = response.quotes[0];
 
 if (isSignatureOnlyOrder(quote.order)) {
     // Protocol mode: sign and submit (gasless for user)
+    // Note: production code should handle all steps, not just the first
     const step = getSignatureSteps(quote.order)[0];
     const { signatureType, ...typedData } = step.signaturePayload;
     const signature = await walletClient.signTypedData(typedData);
@@ -108,12 +109,17 @@ if (isSignatureOnlyOrder(quote.order)) {
     console.log("Order submitted via signature");
 } else {
     // User mode: send transaction directly
+    // Note: production code should handle all steps, not just the first
     const step = getTransactionSteps(quote.order)[0];
+    const { to, data, value, gas, maxFeePerGas, maxPriorityFeePerGas } = step.transaction;
     console.log("Sending transaction...");
     const hash = await walletClient.sendTransaction({
-        to: step.transaction.to,
-        data: step.transaction.data,
-        value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
+        to,
+        data,
+        value: value ? BigInt(value) : undefined,
+        gas: gas ? BigInt(gas) : undefined,
+        maxFeePerGas: maxFeePerGas ? BigInt(maxFeePerGas) : undefined,
+        maxPriorityFeePerGas: maxPriorityFeePerGas ? BigInt(maxPriorityFeePerGas) : undefined,
     });
     console.log("Transaction sent:", hash);
 

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -11,6 +11,7 @@ The `cross-chain` package provides a standardized interface for interacting with
 -   Quote fetching for cross-chain operations
 -   Order tracking from initiation to completion
 -   Multi-provider quote aggregation and comparison
+-   Step-based order model (signature and transaction steps)
 -   Standardized provider interface for integrating different bridge protocols
 -   Type-safe interactions with comprehensive TypeScript support
 
@@ -60,58 +61,72 @@ See the provider-specific documentation for configuration options:
 
 ### Getting Quotes
 
-All providers support fetching quotes for cross-chain operations using the OIF format:
+All providers support fetching quotes using the SDK `QuoteRequest` format:
 
 ```typescript
-const quotes = await provider.getQuotes({
-    user: USER_INTEROP_ADDRESS, // user's interop address (binary format)
-    intent: {
-        intentType: "oif-swap",
-        inputs: [
-            {
-                user: USER_INTEROP_ADDRESS, // sender's interop address (binary format)
-                asset: INPUT_TOKEN_INTEROP_ADDRESS, // input token interop address (binary format)
-                amount: "1000000000000000000", // 1 token (in wei)
-            },
-        ],
-        outputs: [
-            {
-                receiver: RECEIVER_INTEROP_ADDRESS, // recipient's interop address (binary format)
-                asset: OUTPUT_TOKEN_INTEROP_ADDRESS, // output token interop address (binary format)
-            },
-        ],
-        swapType: "exact-input",
-    },
-    supportedTypes: ["oif-escrow-v0"], // or provider-specific types
-});
+import type { QuoteRequest } from "@wonderland/interop-cross-chain";
 
+const request: QuoteRequest = {
+    user: "0xYourAddress",
+    input: {
+        chainId: 1,
+        assetAddress: "0xInputToken",
+        amount: "1000000000000000000", // 1 token (in wei)
+    },
+    output: {
+        chainId: 42161,
+        assetAddress: "0xOutputToken",
+        recipient: "0xRecipient",
+    },
+    swapType: "exact-input",
+};
+
+const quotes = await provider.getQuotes(request);
 const quote = quotes[0]; // Select the first quote
 ```
 
 ### Executing Transactions
 
-After getting a quote, execute the transaction using the prepared transaction:
+After getting a quote, execute based on the order's step type:
 
 ```typescript
-if (quote.preparedTransaction) {
-    const hash = await walletClient.sendTransaction(quote.preparedTransaction);
+import {
+    getSignatureSteps,
+    getTransactionSteps,
+    isSignatureOnlyOrder,
+} from "@wonderland/interop-cross-chain";
+
+if (isSignatureOnlyOrder(quote.order)) {
+    // Protocol mode: sign EIP-712 typed data (gasless for user)
+    const step = getSignatureSteps(quote.order)[0];
+    const { signatureType, ...typedData } = step.signaturePayload;
+    const signature = await walletClient.signTypedData(typedData);
+    await provider.submitOrder(quote, signature);
+} else {
+    // User mode: send transaction directly
+    const step = getTransactionSteps(quote.order)[0];
+    const hash = await walletClient.sendTransaction({
+        to: step.transaction.to,
+        data: step.transaction.data,
+        value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
+    });
     console.log("Transaction sent:", hash);
 }
 ```
 
 ### Using Multiple Providers
 
-For comparing quotes across providers, use the `ProviderExecutor`:
+For comparing quotes across providers, use the `Aggregator`:
 
 ```typescript
-import { createProviderExecutor } from "@wonderland/interop-cross-chain";
+import { createAggregator } from "@wonderland/interop-cross-chain";
 
-const executor = createProviderExecutor({
+const aggregator = createAggregator({
     providers: [acrossProvider, oifProvider],
 });
 
-const response = await executor.getQuotes({
-    /* ... */
+const response = await aggregator.getQuotes({
+    /* QuoteRequest ... */
 });
 // response.quotes - sorted quotes from all providers
 // response.errors - any provider errors

--- a/apps/docs/docs/cross-chain/intent-tracking.md
+++ b/apps/docs/docs/cross-chain/intent-tracking.md
@@ -7,7 +7,7 @@ The SDK includes **order tracking** to monitor cross-chain transfers from initia
 Tracking supports **two ways of observing the same lifecycle**, depending on the provider and how the order is created:
 
 -   **Onchain tracking**: derive tracking data from the origin transaction (e.g. ERC-7683 open event), then watch the fill on the destination chain.
--   **Offchain tracking**: query a provider API for order state transitions (e.g. polling an “order status / deposit status” endpoint).
+-   **Offchain tracking**: query a provider API for order state transitions (e.g. polling an "order status / deposit status" endpoint).
 
 ## Overview
 
@@ -23,7 +23,7 @@ The `OrderTracker` streams updates using the full OIF `OrderStatus` set (see the
 -   **Failed**
 -   **Refunded**
 
-In other words, you can subscribe to **any** `OrderStatus` via `tracker.on(OrderStatus.<status>, ...)` — the examples below just show the most common ones.
+In other words, you can subscribe to **any** `OrderStatus` via `tracker.on(OrderStatus.<status>, ...)` --- the examples below just show the most common ones.
 
 In addition, the tracker can emit:
 
@@ -32,18 +32,18 @@ In addition, the tracker can emit:
 
 ## Basic Usage
 
-The recommended way to track orders is through the `ProviderExecutor`, which handles tracker creation and caching automatically:
+The recommended way to track orders is through the `Aggregator`, which handles tracker creation and caching automatically:
 
 ```typescript
 import {
+    createAggregator,
     createCrossChainProvider,
-    createProviderExecutor,
     OrderTrackerFactory,
 } from "@wonderland/interop-cross-chain";
 
 const acrossProvider = createCrossChainProvider("across", { isTestnet: true });
 
-const executor = createProviderExecutor({
+const aggregator = createAggregator({
     providers: [acrossProvider],
     trackerFactory: new OrderTrackerFactory({
         rpcUrls: {
@@ -56,15 +56,24 @@ const executor = createProviderExecutor({
 
 ### Tracking an Order
 
-After sending the transaction, use `executor.track()` for real-time updates:
+After sending the transaction, use `aggregator.track()` for real-time updates:
 
 ```typescript
-import { OrderStatus, OrderTrackerEvent } from "@wonderland/interop-cross-chain";
+import {
+    getTransactionSteps,
+    OrderStatus,
+    OrderTrackerEvent,
+} from "@wonderland/interop-cross-chain";
 
 const quote = response.quotes[0];
-const hash = await walletClient.sendTransaction(quote.preparedTransaction);
+const step = getTransactionSteps(quote.order)[0];
+const hash = await walletClient.sendTransaction({
+    to: step.transaction.to,
+    data: step.transaction.data,
+    value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
+});
 
-const tracker = executor.track({
+const tracker = aggregator.track({
     txHash: hash,
     providerId: quote.provider,
     originChainId: 11155111,
@@ -85,7 +94,7 @@ tracker.on(OrderTrackerEvent.Error, (error) => console.error("Error:", error));
 Check the current status of an order without watching:
 
 ```typescript
-const status = await executor.getOrderStatus({
+const status = await aggregator.getOrderStatus({
     txHash: "0xabc...",
     providerId: "across",
     originChainId: 11155111,
@@ -107,7 +116,7 @@ if (status.fillEvent) {
 
 ## Advanced: Standalone Tracker
 
-For advanced use cases, you can create a tracker directly without using the executor:
+For advanced use cases, you can create a tracker directly without using the aggregator:
 
 ```typescript
 import { createCrossChainProvider, createOrderTracker } from "@wonderland/interop-cross-chain";

--- a/apps/docs/docs/cross-chain/oif-provider.md
+++ b/apps/docs/docs/cross-chain/oif-provider.md
@@ -6,22 +6,51 @@ The [OIF (Open Intents Framework)](https://github.com/BootNodeDev/intents-framew
 
 ## Configuration
 
-| Field             | Type   | Required | Description                        |
-| ----------------- | ------ | -------- | ---------------------------------- |
-| `solverId`        | string | Yes      | Solver identifier                  |
-| `url`             | string | Yes      | Solver API endpoint URL            |
-| `headers`         | object | No       | Custom HTTP headers                |
-| `adapterMetadata` | object | No       | Additional metadata for the solver |
-| `providerId`      | string | No       | Custom provider identifier         |
+| Field             | Type     | Required | Description                                                                                                |
+| ----------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------- |
+| `solverId`        | string   | Yes      | Solver identifier                                                                                          |
+| `url`             | string   | Yes      | Solver API endpoint URL                                                                                    |
+| `headers`         | object   | No       | Custom HTTP headers                                                                                        |
+| `adapterMetadata` | object   | No       | Additional metadata for the solver                                                                         |
+| `providerId`      | string   | No       | Custom provider identifier                                                                                 |
+| `supportedLocks`  | string[] | No       | Lock mechanisms to request (e.g. `["oif-escrow"]`, `["compact-resource-lock"]`). Default: `["oif-escrow"]` |
+| `submissionModes` | string[] | No       | Execution modes: `["user-transaction"]`, `["gasless"]`, or both (default). Controls order types            |
+
+### Lock Mechanism Mapping
+
+The `supportedLocks` option controls which OIF order types the solver returns:
+
+| Lock Mechanism          | OIF Order Types                |
+| ----------------------- | ------------------------------ |
+| `oif-escrow`            | `oif-escrow-v0`, `oif-3009-v0` |
+| `compact-resource-lock` | `oif-resource-lock-v0`         |
+
+`oif-user-open-v0` (user-pays-gas) is controlled by `submissionModes` independently.
 
 ## Creating the Provider
 
 ```typescript
 import { createCrossChainProvider } from "@wonderland/interop-cross-chain";
 
+// Default: oif-escrow lock type, all submission modes
 const oifProvider = createCrossChainProvider("oif", {
     solverId: "my-solver",
     url: "https://oif-api.example.com",
+});
+
+// Gasless only (escrow-based)
+const gaslessProvider = createCrossChainProvider("oif", {
+    solverId: "my-solver",
+    url: "https://oif-api.example.com",
+    supportedLocks: ["oif-escrow"],
+    submissionModes: ["gasless"],
+});
+
+// User-pays-gas only
+const userTxProvider = createCrossChainProvider("oif", {
+    solverId: "my-solver",
+    url: "https://oif-api.example.com",
+    submissionModes: ["user-transaction"],
 });
 ```
 
@@ -34,87 +63,79 @@ The provider offers intent-based cross-chain operations with two execution modes
 User signs EIP-712 message, solver executes on their behalf:
 
 ```typescript
+import { createCrossChainProvider, getSignatureSteps } from "@wonderland/interop-cross-chain";
 import { createWalletClient, http } from "viem";
 import { base } from "viem/chains";
 
 const quotes = await oifProvider.getQuotes({
-    user: USER_INTEROP_ADDRESS, // user's interop address (binary format)
-    intent: {
-        intentType: "oif-swap",
-        inputs: [
-            {
-                user: USER_INTEROP_ADDRESS, // sender's interop address (binary format)
-                asset: INPUT_TOKEN_INTEROP_ADDRESS, // input token interop address (binary format)
-                amount: "1000000",
-            },
-        ],
-        outputs: [
-            {
-                receiver: RECEIVER_INTEROP_ADDRESS, // recipient's interop address (binary format)
-                asset: OUTPUT_TOKEN_INTEROP_ADDRESS, // output token interop address (binary format)
-            },
-        ],
-        swapType: "exact-input",
+    user: "0xYourAddress",
+    input: {
+        chainId: 1,
+        assetAddress: "0xInputTokenAddress",
+        amount: "1000000",
     },
-    supportedTypes: ["oif-escrow-v0"],
+    output: {
+        chainId: 42161,
+        assetAddress: "0xOutputTokenAddress",
+    },
+    swapType: "exact-input",
 });
 
 const quote = quotes[0];
 const walletClient = createWalletClient({ account, chain: base, transport: http() });
-const { domain, primaryType, message, types } = quote.order.payload;
-const signature = await walletClient.signTypedData({ domain, primaryType, message, types });
-await oifProvider.submitSignedOrder(quote, signature);
+const step = getSignatureSteps(quote.order)[0];
+const { signatureType, ...typedData } = step.signaturePayload;
+const signature = await walletClient.signTypedData(typedData);
+await oifProvider.submitOrder(quote, signature);
 ```
 
 ### User Mode (User Pays Gas)
 
-User executes transaction directly. The `preparedTransaction` is included automatically in the quote:
+User executes transaction directly:
 
 ```typescript
+import { getTransactionSteps } from "@wonderland/interop-cross-chain";
+
 const quotes = await oifProvider.getQuotes({
-    user: USER_INTEROP_ADDRESS, // user's interop address (binary format)
-    intent: {
-        intentType: "oif-swap",
-        inputs: [
-            {
-                user: USER_INTEROP_ADDRESS, // sender's interop address (binary format)
-                asset: INPUT_TOKEN_INTEROP_ADDRESS, // input token interop address (binary format)
-                amount: "1000000",
-            },
-        ],
-        outputs: [
-            {
-                receiver: RECEIVER_INTEROP_ADDRESS, // recipient's interop address (binary format)
-                asset: OUTPUT_TOKEN_INTEROP_ADDRESS, // output token interop address (binary format)
-            },
-        ],
-        originSubmission: { mode: "user" },
-        swapType: "exact-input",
+    user: "0xYourAddress",
+    input: {
+        chainId: 1,
+        assetAddress: "0xInputTokenAddress",
+        amount: "1000000",
     },
-    supportedTypes: ["oif-user-open-v0"],
+    output: {
+        chainId: 42161,
+        assetAddress: "0xOutputTokenAddress",
+    },
+    swapType: "exact-input",
 });
 
 const quote = quotes[0];
-if (quote.preparedTransaction) {
-    await walletClient.sendTransaction(quote.preparedTransaction);
-}
+const step = getTransactionSteps(quote.order)[0];
+await walletClient.sendTransaction({
+    to: step.transaction.to,
+    data: step.transaction.data,
+    value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
+});
 ```
 
 ## Approvals
 
-Access approval information from quotes:
+Access approval information from the order checks:
 
 ```typescript
-// Protocol mode (oif-escrow-v0) - typically Permit2
-const spender = quote.order.payload.message.spender;
-
-// User mode (oif-user-open-v0)
-const { token, user, spender, required } = quote.order.checks.allowances[0];
+// Allowance requirements from order checks
+const allowances = quote.order.checks?.allowances ?? [];
+for (const { spender, tokenAddress, required } of allowances) {
+    // Approve token spend if needed
+}
 ```
 
 ## Supported Order Types
 
--   `oif-escrow-v0` - Gasless execution via solver
+-   `oif-escrow-v0` - Permit2-based escrow (gasless)
+-   `oif-3009-v0` - EIP-3009 transfer with authorization (gasless)
+-   `oif-resource-lock-v0` - Compact resource locking (gasless)
 -   `oif-user-open-v0` - User executes transaction directly
 
 ## Payload Validation

--- a/packages/cross-chain/README.md
+++ b/packages/cross-chain/README.md
@@ -1,7 +1,5 @@
 # @wonderland/interop-cross-chain
 
-🚧 The cross-chain package is under construction 🚧
-
 The cross-chain package provides a standardized interface for interacting with cross-chain bridges and protocols. It enables seamless token transfers and swaps between different blockchain networks through a unified API.
 
 Key features:
@@ -11,6 +9,7 @@ Key features:
 -   Quote fetching for cross-chain operations
 -   Standardized provider interface for integrating different bridge protocols
 -   Type-safe interactions with comprehensive TypeScript support
+-   Step-based order model (signature and transaction steps)
 
 ## Setup
 
@@ -35,71 +34,70 @@ Available scripts that can be run using `pnpm`:
 ## Usage
 
 ```typescript
-import { createCrossChainProvider, createProviderExecutor } from "@wonderland/interop-cross-chain";
-import { createPublicClient, createWalletClient, http } from "viem";
+import type { QuoteRequest } from "@wonderland/interop-cross-chain";
+import {
+    createAggregator,
+    createCrossChainProvider,
+    getSignatureSteps,
+    getTransactionSteps,
+    isSignatureOnlyOrder,
+} from "@wonderland/interop-cross-chain";
+import { createWalletClient, http } from "viem";
 import { sepolia } from "viem/chains";
-
-// Setup viem clients (needed for transaction execution)
-const publicClient = createPublicClient({
-    chain: sepolia,
-    transport: http("https://..."),
-});
 
 const walletClient = createWalletClient({
     chain: sepolia,
     transport: http("https://..."),
-    account: "0x...", // Your account
+    account: "0x...",
 });
 
 // Create providers for different protocols
-// Across - config optional (defaults to mainnet: https://app.across.to/api)
-// Testnet: https://testnet.across.to/api
 const acrossProvider = createCrossChainProvider("across");
-
-// Across with testnet config
-const testnetProvider = createCrossChainProvider("across", { isTestnet: true });
-
-// OIF - config required
 const oifProvider = createCrossChainProvider("oif", {
     solverId: "my-solver",
     url: "https://...",
 });
 
-// Create executor with providers (can mix Across, OIF, etc.)
-const executor = createProviderExecutor({
+// Create aggregator with providers (can mix Across, OIF, etc.)
+const aggregator = createAggregator({
     providers: [acrossProvider, oifProvider],
 });
 
-// Get quotes using OIF GetQuoteRequest format
-// Addresses must be EIP-7930 binary format (0x0001...)
-// Use nameToBinary() from @wonderland/interop-addresses to convert
-const response = await executor.getQuotes({
-    user: "0x0001000aa36a7114...",
-    intent: {
-        intentType: "oif-swap",
-        inputs: [
-            {
-                user: "0x0001000aa36a7114...",
-                asset: "0x0001000aa36a7114...",
-                amount: "1000000000000000000",
-            },
-        ],
-        outputs: [
-            {
-                receiver: "0x0001000149d4114...",
-                asset: "0x0001000149d4114...",
-            },
-        ],
-        swapType: "exact-input",
+// Get quotes using SDK QuoteRequest format
+const quoteRequest: QuoteRequest = {
+    user: "0xYourAddress",
+    input: {
+        chainId: 11155111,
+        assetAddress: "0xTokenAddress",
+        amount: "1000000000000000000",
     },
-    supportedTypes: ["oif-escrow-v0"],
-});
+    output: {
+        chainId: 84532,
+        assetAddress: "0xOutputTokenAddress",
+        recipient: "0xRecipientAddress",
+    },
+    swapType: "exact-input",
+};
 
-// Execute the selected quote
+const response = await aggregator.getQuotes(quoteRequest);
 const selectedQuote = response.quotes[0];
-if (selectedQuote?.preparedTransaction) {
-    const hash = await walletClient.sendTransaction(selectedQuote.preparedTransaction);
-    const receipt = await publicClient.waitForTransactionReceipt({ hash });
+
+if (selectedQuote) {
+    if (isSignatureOnlyOrder(selectedQuote.order)) {
+        // Protocol mode: sign EIP-712 typed data (gasless for user)
+        const step = getSignatureSteps(selectedQuote.order)[0];
+        const { signatureType, ...typedData } = step.signaturePayload;
+        const signature = await walletClient.signTypedData(typedData);
+        await aggregator.submitOrder(selectedQuote, signature);
+    } else {
+        // User mode: execute transaction directly (user pays gas)
+        const step = getTransactionSteps(selectedQuote.order)[0];
+        await walletClient.sendTransaction({
+            to: step.transaction.to,
+            data: step.transaction.data,
+            value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
+        });
+    }
 }
 ```
 
@@ -107,13 +105,13 @@ if (selectedQuote?.preparedTransaction) {
 
 ### Providers
 
--   `createCrossChainProvider(protocolName, config?)` – Create a provider for a supported protocol. Config is optional for Across (defaults to mainnet), required for OIF.
+-   `createCrossChainProvider(protocolName, config?)` -- Create a provider for a supported protocol. Config is optional for Across (defaults to mainnet), required for OIF.
 -   `CrossChainProvider` (abstract class)
-    -   `.getProtocolName()` – Returns the protocol name.
-    -   `.getProviderId()` – Returns the provider identifier.
-    -   `.getQuotes(params)` – Fetch quotes for a cross-chain request (OIF GetQuoteRequest format).
-    -   `.submitSignedOrder(quote, signature)` – Submit a signed order to the provider (throws MethodNotImplemented for providers that don't support it, like Across).
-    -   `.getTrackingConfig()` – Get configuration for order tracking.
+    -   `.protocolName` -- Returns the protocol name.
+    -   `.providerId` -- Returns the provider identifier.
+    -   `.getQuotes(params: QuoteRequest)` -- Fetch quotes for a cross-chain request.
+    -   `.submitOrder(quote, signature)` -- Submit a signed order to the provider.
+    -   `.getTrackingConfig()` -- Get configuration for order tracking.
 
 ### Tracking Notes (Across)
 
@@ -121,30 +119,31 @@ if (selectedQuote?.preparedTransaction) {
 -   **Testnet**: fill tracking defaults to **event-based watching** (Across testnet API is not reliable).
 -   The SDK still parses the **origin-chain open event**, so provide an origin-chain RPC URL for robust tracking.
 
-### Provider Executor
+### Aggregator
 
--   `createProviderExecutor(config)` – Create an executor for batch quoting and execution.
+-   `createAggregator(config)` -- Create an aggregator for batch quoting and execution.
     -   Config: `{ providers: CrossChainProvider[], sortingStrategy?, timeoutMs?, trackerFactory? }`
--   `ProviderExecutor`
-    -   `.getQuotes(params)` – Get quotes from all providers (params: GetQuoteRequest, returns: GetQuotesResponse).
-    -   `.prepareTracking(providerId)` – Prepare order tracking for a provider.
-    -   `.track(params)` – Track an existing transaction.
-    -   `.getOrderStatus(params)` – Get current status without watching.
+-   `Aggregator`
+    -   `.getQuotes(params: QuoteRequest)` -- Get quotes from all providers. Returns `{ quotes: ExecutableQuote[], errors: GetQuotesError[] }`.
+    -   `.submitOrder(quote, signature)` -- Submit a signed order.
+    -   `.prepareTracking(providerId)` -- Prepare order tracking for a provider.
+    -   `.track(params)` -- Track an existing transaction.
+    -   `.getOrderStatus(params)` -- Get current status without watching.
 
 ### Asset Discovery
 
 The SDK provides utilities to discover supported assets from providers. All discovery methods return a pre-processed `DiscoveredAssets` structure ready for consumption.
 
-**Via ProviderExecutor (recommended):**
+**Via Aggregator (recommended):**
 
 ```typescript
 import { toChainIdentifier } from "@wonderland/interop-addresses";
-import { createProviderExecutor } from "@wonderland/interop-cross-chain";
+import { createAggregator } from "@wonderland/interop-cross-chain";
 
-const executor = createProviderExecutor({ providers: [acrossProvider] });
+const aggregator = createAggregator({ providers: [acrossProvider] });
 
 // Discover assets from all configured providers
-const discovered = await executor.discoverAssets({ chainIds: [1, 42161] });
+const discovered = await aggregator.discoverAssets({ chainIds: [1, 42161] });
 
 // Get tokens for Ethereum using CAIP-350 chain identifier
 const ethTokens = discovered.tokensByChain[toChainIdentifier(1)]; // "eip155:1"
@@ -175,15 +174,23 @@ const ethTokens = discovered.tokensByChain[toChainIdentifier(1)];
 
 **Types:**
 
--   `DiscoveredAssets` – Aggregated discovery result with `tokensByChain`, `tokenMetadata`, and `chainIds`.
--   `AssetInfo` – Token metadata: `{ address, symbol, decimals }`.
+-   `DiscoveredAssets` -- Aggregated discovery result with `tokensByChain`, `tokenMetadata`, and `chainIds`.
+-   `AssetInfo` -- Token metadata: `{ address, symbol, decimals }`.
 
 ### Types
 
--   `GetQuoteRequest` – OIF-compliant quote request (see `@openintentsframework/oif-specs`).
--   `GetQuotesResponse` – Response containing `{ quotes: ExecutableQuote[], errors: GetQuotesError[] }`.
--   `ExecutableQuote` – Quote with optional `preparedTransaction` for execution.
--   `ProviderExecutorConfig`, `OrderTrackerConfig`, and more (see exported types).
+-   `QuoteRequest` -- SDK-friendly quote request with `user`, `input`, `output`, and `swapType`.
+-   `Quote` -- Quote with step-based `order`, `preview`, `provider`, and `metadata`.
+-   `ExecutableQuote` -- Quote with provider context for submission.
+-   `Order` -- Step-based order model with `steps: (SignatureStep | TransactionStep)[]`.
+-   `InteropAccountId` -- Chain-aware account identifier: `{ chainId: number, address: string }`.
+
+### Step Helpers
+
+-   `getSignatureSteps(order)` -- Extract signature steps from an order.
+-   `getTransactionSteps(order)` -- Extract transaction steps from an order.
+-   `isSignatureOnlyOrder(order)` -- Check if an order only requires signatures.
+-   `isTransactionOnlyOrder(order)` -- Check if an order only requires transactions.
 
 ## OIF Provider
 
@@ -192,11 +199,15 @@ The OIF Provider enables integration with any [Open Intents Framework](https://d
 ### Usage
 
 ```typescript
-import { createCrossChainProvider } from "@wonderland/interop-cross-chain";
+import type { QuoteRequest } from "@wonderland/interop-cross-chain";
+import {
+    createCrossChainProvider,
+    getSignatureSteps,
+    getTransactionSteps,
+} from "@wonderland/interop-cross-chain";
 import { createWalletClient, http } from "viem";
 import { mainnet } from "viem/chains";
 
-// Setup wallet client
 const walletClient = createWalletClient({
     chain: mainnet,
     transport: http("https://..."),
@@ -209,51 +220,52 @@ const provider = createCrossChainProvider("oif", {
     url: "https://...",
 });
 
-// Get quotes using OIF GetQuoteRequest format
-// Addresses must be EIP-7930 binary format (0x0001...)
-const response = await provider.getQuotes({
-    user: "0x00010000000114...",
-    intent: {
-        intentType: "oif-swap",
-        inputs: [
-            {
-                user: "0x00010000000114...",
-                asset: "0x00010000000114...",
-                amount: "1000000",
-            },
-        ],
-        outputs: [
-            {
-                receiver: "0x00010000000114...",
-                asset: "0x00010000000114...",
-            },
-        ],
-        swapType: "exact-input",
+// Get quotes using SDK QuoteRequest
+const quotes = await provider.getQuotes({
+    user: "0xYourAddress",
+    input: {
+        chainId: 1,
+        assetAddress: "0xTokenAddress",
+        amount: "1000000",
     },
-    supportedTypes: ["oif-escrow-v0"],
+    output: {
+        chainId: 42161,
+        assetAddress: "0xOutputTokenAddress",
+    },
+    swapType: "exact-input",
 });
 
+const quote = quotes[0];
+
 // Protocol Mode: Sign and submit order (gasless for user)
-const { domain, primaryType, message, types } = response[0].order.payload;
-const signature = await walletClient.signTypedData({ domain, primaryType, message, types });
-await provider.submitSignedOrder(response[0], signature);
+const signatureSteps = getSignatureSteps(quote.order);
+if (signatureSteps.length > 0) {
+    const { signatureType, ...typedData } = signatureSteps[0].signaturePayload;
+    const signature = await walletClient.signTypedData(typedData);
+    await provider.submitOrder(quote, signature);
+}
 
 // User Mode: Execute transaction directly (user pays gas)
-if (response[0]?.preparedTransaction) {
-    await walletClient.sendTransaction(response[0].preparedTransaction);
+const txSteps = getTransactionSteps(quote.order);
+if (txSteps.length > 0) {
+    await walletClient.sendTransaction({
+        to: txSteps[0].transaction.to,
+        data: txSteps[0].transaction.data,
+        value: txSteps[0].transaction.value ? BigInt(txSteps[0].transaction.value) : undefined,
+    });
 }
 ```
 
 ### Approval Requirements
 
-Access approval info directly from the quote:
+Access approval info from the order checks:
 
 ```typescript
-// Protocol mode (oif-escrow-v0)
-const spender = quote.order.payload.message.spender;
-
-// User mode (oif-user-open-v0)
-const { spender, token, required } = quote.order.checks.allowances[0];
+// Get allowance requirements from order checks
+const allowances = quote.order.checks?.allowances ?? [];
+for (const { spender, tokenAddress, required } of allowances) {
+    // Approve token spend if needed
+}
 ```
 
 ## Payload Validation

--- a/packages/cross-chain/README.md
+++ b/packages/cross-chain/README.md
@@ -204,6 +204,7 @@ import {
     createCrossChainProvider,
     getSignatureSteps,
     getTransactionSteps,
+    isSignatureOnlyOrder,
 } from "@wonderland/interop-cross-chain";
 import { createWalletClient, http } from "viem";
 import { mainnet } from "viem/chains";

--- a/packages/cross-chain/README.md
+++ b/packages/cross-chain/README.md
@@ -236,6 +236,7 @@ const quotes = await provider.getQuotes({
 });
 
 const quote = quotes[0];
+if (!quote) throw new Error("No quotes returned");
 
 // Protocol Mode: Sign and submit order (gasless for user)
 const signatureSteps = getSignatureSteps(quote.order);

--- a/packages/cross-chain/README.md
+++ b/packages/cross-chain/README.md
@@ -238,21 +238,19 @@ const quotes = await provider.getQuotes({
 const quote = quotes[0];
 if (!quote) throw new Error("No quotes returned");
 
-// Protocol Mode: Sign and submit order (gasless for user)
-const signatureSteps = getSignatureSteps(quote.order);
-if (signatureSteps.length > 0) {
-    const { signatureType, ...typedData } = signatureSteps[0].signaturePayload;
+if (isSignatureOnlyOrder(quote.order)) {
+    // Protocol Mode: Sign and submit order (gasless for user)
+    const step = getSignatureSteps(quote.order)[0];
+    const { signatureType, ...typedData } = step.signaturePayload;
     const signature = await walletClient.signTypedData(typedData);
     await provider.submitOrder(quote, signature);
-}
-
-// User Mode: Execute transaction directly (user pays gas)
-const txSteps = getTransactionSteps(quote.order);
-if (txSteps.length > 0) {
+} else {
+    // User Mode: Execute transaction directly (user pays gas)
+    const step = getTransactionSteps(quote.order)[0];
     await walletClient.sendTransaction({
-        to: txSteps[0].transaction.to,
-        data: txSteps[0].transaction.data,
-        value: txSteps[0].transaction.value ? BigInt(txSteps[0].transaction.value) : undefined,
+        to: step.transaction.to,
+        data: step.transaction.data,
+        value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
     });
 }
 ```


### PR DESCRIPTION
## Summary

Updates all cross-chain documentation to reflect the new SDK types and API.

- `cross-chain.md` — overview with new type names
- `api.md` — full API reference for new types and methods
- `getting-started.md` — updated quickstart with `QuoteRequest` / `Aggregator`
- `advanced-usage.md` — step-based order execution examples
- `providers.md` / `across-provider.md` / `oif-provider.md` — provider-specific docs
- Package `README.md`

**9 files changed**

## Why

Docs should reflect the final API. This is the last PR in the stack.

## Stack

1. #185 — SDK types, schemas, utilities
2. #186 — OIF adapter layer
3. #187 — Wire providers, rename to Aggregator, update example app
4. #188 — Update Across provider
5. #189 — Package reorganization
6. **This PR** — Documentation updates

## Test plan

- [x] Documentation accurately reflects the new API
- [x] Code examples in docs are correct
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)