### PR TITLE
fix(ui): use regex for cross-chain URL assertion to avoid flaky E2E test

### DIFF
--- a/examples/ui/tests/app.spec.ts
+++ b/examples/ui/tests/app.spec.ts
@@ -33,6 +33,6 @@ test('Navigate to Interoperable Addresses', async ({ page }) => {
 test('Navigate to Cross-Chain Intent Swap', async ({ page }) => {
   await page.getByRole('link', { name: 'Cross-Chain Intent Swap' }).click();
 
-  await expect(page).toHaveURL('/cross-chain');
+  await expect(page).toHaveURL(/\/cross-chain/);
   await expect(page.getByRole('heading', { name: 'Cross-Chain Intent Swap' })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- PR #179 added URL search param syncing which appends query params to `/cross-chain` asynchronously
- The exact `toHaveURL('/cross-chain')` match was flaky — Playwright sometimes checks before params arrive, sometimes after
- Changed to regex `toHaveURL(/\/cross-chain/)` to avoid the race condition