### PR TITLE
feat(cross-chain): add Relay protocol schemas

### DIFF
--- a/.changeset/relay-types-schemas.md
+++ b/.changeset/relay-types-schemas.md
@@ -1,0 +1,11 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+feat: add Relay protocol types and schemas
+
+Add Zod schemas and TypeScript types for the Relay protocol:
+
+-   Quote request and response schemas aligned with Relay OpenAPI spec
+-   Intent status request schema
+-   Relay-specific types (fees, details, currency)

--- a/packages/cross-chain/src/protocols/relay/index.ts
+++ b/packages/cross-chain/src/protocols/relay/index.ts
@@ -1,3 +1,2 @@
-export * from "./provider.js";
 export * from "./schemas.js";
 export * from "./types.js";

--- a/packages/cross-chain/src/protocols/relay/index.ts
+++ b/packages/cross-chain/src/protocols/relay/index.ts
@@ -1,0 +1,3 @@
+export * from "./provider.js";
+export * from "./schemas.js";
+export * from "./types.js";

--- a/packages/cross-chain/src/protocols/relay/schemas.ts
+++ b/packages/cross-chain/src/protocols/relay/schemas.ts
@@ -45,6 +45,9 @@ const RelayStepItemDataSchema = z.object({
     data: z.string(),
     value: z.string().optional(),
     chainId: z.number().int().positive(),
+    gas: z.string().optional(),
+    maxFeePerGas: z.string().optional(),
+    maxPriorityFeePerGas: z.string().optional(),
 });
 
 /** Schema for a check object that tells the client how to poll status. */
@@ -133,7 +136,7 @@ const RelayDetailsSchema = z.object({
     userBalance: z.string().optional(),
     fallbackType: z.string().optional(),
     isFixedRate: z.boolean().optional(),
-    fixedRateFee: z.string().optional(),
+    fixedRateFee: z.object({ usd: z.string() }).optional(),
     route: z
         .object({
             origin: RelayRouteLegSchema.optional(),
@@ -169,7 +172,7 @@ export const RelayQuoteResponseSchema = z.object({
 /** Schema for the Relay 400 Bad Request response. */
 export const RelayBadRequestResponseSchema = z.object({
     message: z.string(),
-    errorCode: z.string(),
+    errorCode: z.string().optional(),
     errorData: z.string().optional(),
     requestId: z.string().optional(),
     approxSimulatedBlock: z.number().optional(),
@@ -197,7 +200,7 @@ export const RelayRateLimitedResponseSchema = z.object({
 /** Schema for the Relay 500 Server Error response. */
 export const RelayServerErrorResponseSchema = z.object({
     message: z.string(),
-    errorCode: z.string(),
+    errorCode: z.string().optional(),
     requestId: z.string().optional(),
 });
 
@@ -213,6 +216,7 @@ export const RelayIntentStatusEnum = z.enum([
     "refunded",
     "failure",
     "refund",
+    "unknown",
 ]);
 
 /** Schema for the Relay GET `/intents/status/v3` response body. */

--- a/packages/cross-chain/src/protocols/relay/schemas.ts
+++ b/packages/cross-chain/src/protocols/relay/schemas.ts
@@ -182,8 +182,8 @@ const RelayProtocolV2Schema = z.object({
 /** Schema for the Relay POST `/quote/v2` response body. */
 export const RelayQuoteResponseSchema = z.object({
     steps: z.array(RelayQuoteStepSchema).min(1),
-    fees: RelayFeesSchema,
-    details: RelayDetailsSchema,
+    fees: RelayFeesSchema.optional(),
+    details: RelayDetailsSchema.optional(),
     protocol: z.object({ v2: RelayProtocolV2Schema.optional() }).optional(),
 });
 

--- a/packages/cross-chain/src/protocols/relay/schemas.ts
+++ b/packages/cross-chain/src/protocols/relay/schemas.ts
@@ -12,7 +12,7 @@ const RelayAppFeeSchema = z.object({
 
 /** Schema for a destination call transaction in a quote request. */
 const RelayTxSchema = z.object({
-    to: z.string(),
+    to: addressString,
     value: z.string().optional(),
     data: z.string().optional(),
     originalTxValue: z.string().optional(),
@@ -21,7 +21,7 @@ const RelayTxSchema = z.object({
 /** Schema for an EIP-7702 authorization entry. */
 const RelayAuthorizationSchema = z.object({
     chainId: z.number(),
-    address: z.string(),
+    address: addressString,
     nonce: z.number(),
     yParity: z.number(),
     r: z.string(),
@@ -47,7 +47,7 @@ export const RelayQuoteRequestSchema = z.object({
         })
         .optional(),
     referrer: z.string().optional(),
-    referrerAddress: z.string().optional(),
+    referrerAddress: addressString.optional(),
     refundTo: z.string().optional(),
     topupGas: z.boolean().optional(),
     topupGasAmount: z.string().optional(),

--- a/packages/cross-chain/src/protocols/relay/schemas.ts
+++ b/packages/cross-chain/src/protocols/relay/schemas.ts
@@ -30,13 +30,7 @@ const RelayCurrencyAmountSchema = z.object({
 });
 
 /** Schema for a single fee entry. */
-const RelayFeeSchema = z.object({
-    currency: RelayCurrencySchema.optional(),
-    amount: z.string().optional(),
-    amountFormatted: z.string().optional(),
-    amountUsd: z.string().optional(),
-    minimumAmount: z.string().optional(),
-});
+const RelayFeeSchema = RelayCurrencyAmountSchema;
 
 /** Schema for transaction data inside a step item. */
 const RelayStepItemDataSchema = z.object({
@@ -56,23 +50,49 @@ const RelayStepCheckSchema = z.object({
     method: z.string(),
 });
 
-/** Schema for a single item within a step. */
-const RelayStepItemSchema = z.object({
+/** Schema for a check object inside a step item. */
+const RelayStepItemBaseSchema = z.object({
     status: z.enum(["complete", "incomplete"]),
-    data: RelayStepItemDataSchema,
     check: RelayStepCheckSchema.optional(),
 });
 
-/** Schema for a single step in a Relay quote response. */
-export const RelayQuoteStepSchema = z.object({
-    id: z.string(),
+/** Schema for a transaction step in a Relay quote response. */
+const RelayTransactionStepItemSchema = RelayStepItemBaseSchema.extend({
+    data: RelayStepItemDataSchema,
+});
+
+/** Schema for a signature step item in a Relay quote response. */
+const RelaySignatureStepItemSchema = RelayStepItemBaseSchema.extend({
+    data: z.record(z.unknown()),
+});
+
+/** Schema for a transaction step in a Relay quote response. */
+export const RelayTransactionStepSchema = z.object({
+    id: z.enum(["deposit", "approve", "authorize", "authorize1", "authorize2", "swap", "send"]),
     action: z.string(),
     description: z.string(),
-    kind: z.enum(["transaction", "signature"]),
+    kind: z.literal("transaction"),
     requestId: z.string().min(1),
     depositAddress: z.string().optional(),
-    items: z.array(RelayStepItemSchema).min(1),
+    items: z.array(RelayTransactionStepItemSchema).min(1),
 });
+
+/** Schema for a signature step in a Relay quote response. */
+export const RelaySignatureStepSchema = z.object({
+    id: z.enum(["deposit", "approve", "authorize", "authorize1", "authorize2", "swap", "send"]),
+    action: z.string(),
+    description: z.string(),
+    kind: z.literal("signature"),
+    requestId: z.string().min(1),
+    depositAddress: z.string().optional(),
+    items: z.array(RelaySignatureStepItemSchema).min(1),
+});
+
+/** Schema for a single step in a Relay quote response. */
+export const RelayQuoteStepSchema = z.discriminatedUnion("kind", [
+    RelayTransactionStepSchema,
+    RelaySignatureStepSchema,
+]);
 
 /** Schema for the fees breakdown in a quote response. */
 const RelayFeesSchema = z.object({
@@ -107,7 +127,7 @@ const RelayRouteLegSchema = z.object({
 
 /** Schema for the details object in a quote response. */
 const RelayDetailsSchema = z.object({
-    operation: z.string().optional(),
+    operation: z.enum(["send", "swap", "wrap", "unwrap", "bridge"]).optional(),
     sender: z.string().optional(),
     recipient: z.string().optional(),
     currencyIn: RelayCurrencyAmountSchema.optional(),
@@ -151,7 +171,7 @@ const RelayProtocolV2Schema = z.object({
     orderData: z.unknown().optional(),
     paymentDetails: z
         .object({
-            chainId: z.union([z.number().int().positive(), z.string()]).optional(),
+            chainId: z.string().optional(),
             depository: z.string().optional(),
             currency: z.string().optional(),
             amount: z.string().optional(),
@@ -162,9 +182,9 @@ const RelayProtocolV2Schema = z.object({
 /** Schema for the Relay POST `/quote/v2` response body. */
 export const RelayQuoteResponseSchema = z.object({
     steps: z.array(RelayQuoteStepSchema).min(1),
-    fees: RelayFeesSchema.optional(),
-    details: RelayDetailsSchema.optional(),
-    protocol: z.object({ v2: RelayProtocolV2Schema.optional() }).optional(),
+    fees: RelayFeesSchema,
+    details: RelayDetailsSchema,
+    protocol: z.object({ v2: RelayProtocolV2Schema.optional() }),
 });
 
 // ── Relay Error Responses ──────────────────────────────
@@ -172,7 +192,7 @@ export const RelayQuoteResponseSchema = z.object({
 /** Schema for the Relay 400 Bad Request response. */
 export const RelayBadRequestResponseSchema = z.object({
     message: z.string(),
-    errorCode: z.string().optional(),
+    errorCode: z.string(),
     errorData: z.string().optional(),
     requestId: z.string().optional(),
     approxSimulatedBlock: z.number().optional(),
@@ -200,7 +220,7 @@ export const RelayRateLimitedResponseSchema = z.object({
 /** Schema for the Relay 500 Server Error response. */
 export const RelayServerErrorResponseSchema = z.object({
     message: z.string(),
-    errorCode: z.string().optional(),
+    errorCode: z.string(),
     requestId: z.string().optional(),
 });
 

--- a/packages/cross-chain/src/protocols/relay/schemas.ts
+++ b/packages/cross-chain/src/protocols/relay/schemas.ts
@@ -72,7 +72,7 @@ export const RelayTransactionStepSchema = z.object({
     action: z.string(),
     description: z.string(),
     kind: z.literal("transaction"),
-    requestId: z.string().min(1),
+    requestId: z.string().optional(),
     depositAddress: z.string().optional(),
     items: z.array(RelayTransactionStepItemSchema).min(1),
 });
@@ -83,7 +83,7 @@ export const RelaySignatureStepSchema = z.object({
     action: z.string(),
     description: z.string(),
     kind: z.literal("signature"),
-    requestId: z.string().min(1),
+    requestId: z.string().optional(),
     depositAddress: z.string().optional(),
     items: z.array(RelaySignatureStepItemSchema).min(1),
 });
@@ -127,7 +127,7 @@ const RelayRouteLegSchema = z.object({
 
 /** Schema for the details object in a quote response. */
 const RelayDetailsSchema = z.object({
-    operation: z.enum(["send", "swap", "wrap", "unwrap", "bridge"]).optional(),
+    operation: z.string().optional(),
     sender: z.string().optional(),
     recipient: z.string().optional(),
     currencyIn: RelayCurrencyAmountSchema.optional(),
@@ -228,15 +228,12 @@ export const RelayServerErrorResponseSchema = z.object({
 
 /** Valid Relay intent statuses as documented in the API. */
 export const RelayIntentStatusEnum = z.enum([
+    "refund",
     "waiting",
+    "failure",
     "pending",
     "submitted",
     "success",
-    "delayed",
-    "refunded",
-    "failure",
-    "refund",
-    "unknown",
 ]);
 
 /** Schema for the Relay GET `/intents/status/v3` response body. */
@@ -246,8 +243,8 @@ export const RelayIntentStatusResponseSchema = z.object({
     inTxHashes: z.array(z.string()).optional(),
     txHashes: z.array(z.string()).optional(),
     updatedAt: z.number().optional(),
-    originChainId: z.number().int().positive().optional(),
-    destinationChainId: z.number().int().positive().optional(),
+    originChainId: z.number().optional(),
+    destinationChainId: z.number().optional(),
 });
 
 // ── Types ───────────────────────────────────────────────

--- a/packages/cross-chain/src/protocols/relay/schemas.ts
+++ b/packages/cross-chain/src/protocols/relay/schemas.ts
@@ -2,7 +2,87 @@ import { z } from "zod";
 
 import { addressString } from "../../core/schemas/common.js";
 
-// ── Relay Quote v2 ──────────────────────────────────────
+// ── Relay Quote v2 Request ─────────────────────────────
+
+/** Schema for an app fee entry in a quote request. */
+const RelayAppFeeSchema = z.object({
+    recipient: z.string(),
+    fee: z.string(),
+});
+
+/** Schema for a destination call transaction in a quote request. */
+const RelayTxSchema = z.object({
+    to: z.string(),
+    value: z.string().optional(),
+    data: z.string().optional(),
+    originalTxValue: z.string().optional(),
+});
+
+/** Schema for an EIP-7702 authorization entry. */
+const RelayAuthorizationSchema = z.object({
+    chainId: z.number(),
+    address: z.string(),
+    nonce: z.number(),
+    yParity: z.number(),
+    r: z.string(),
+    s: z.string(),
+});
+
+/** Schema for the Relay POST `/quote/v2` request body. */
+export const RelayQuoteRequestSchema = z.object({
+    user: z.string(),
+    recipient: z.string().optional(),
+    originChainId: z.number(),
+    destinationChainId: z.number(),
+    originCurrency: z.string(),
+    destinationCurrency: z.string(),
+    amount: z.string().regex(/^[0-9]+$/),
+    tradeType: z.enum(["EXACT_INPUT", "EXACT_OUTPUT", "EXPECTED_OUTPUT"]),
+    txs: z.array(RelayTxSchema).optional(),
+    txsGasLimit: z.number().optional(),
+    authorizationList: z.array(RelayAuthorizationSchema).optional(),
+    additionalData: z
+        .object({
+            userPublicKey: z.string().optional(),
+        })
+        .optional(),
+    referrer: z.string().optional(),
+    referrerAddress: z.string().optional(),
+    refundTo: z.string().optional(),
+    topupGas: z.boolean().optional(),
+    topupGasAmount: z.string().optional(),
+    useReceiver: z.boolean().optional(),
+    enableTrueExactOutput: z.boolean().optional(),
+    explicitDeposit: z.boolean().optional(),
+    useExternalLiquidity: z.boolean().optional(),
+    useFallbacks: z.boolean().optional(),
+    usePermit: z.boolean().optional(),
+    permitExpiry: z.number().optional(),
+    useDepositAddress: z.boolean().optional(),
+    strict: z.boolean().optional(),
+    slippageTolerance: z.string().optional(),
+    latePaymentSlippageTolerance: z.string().optional(),
+    appFees: z.array(RelayAppFeeSchema).optional(),
+    gasLimitForDepositSpecifiedTxs: z.number().optional(),
+    forceSolverExecution: z.boolean().optional(),
+    subsidizeFees: z.boolean().optional(),
+    maxSubsidizationAmount: z.string().optional(),
+    subsidizeRent: z.boolean().optional(),
+    includedSwapSources: z.array(z.string()).optional(),
+    excludedSwapSources: z.array(z.string()).optional(),
+    includedOriginSwapSources: z.array(z.string()).optional(),
+    includedDestinationSwapSources: z.array(z.string()).optional(),
+    originGasOverhead: z.number().optional(),
+    depositFeePayer: z.string().optional(),
+    maxRouteLength: z.number().optional(),
+    useSharedAccounts: z.boolean().optional(),
+    includeComputeUnitLimit: z.boolean().optional(),
+    overridePriceImpact: z.boolean().optional(),
+    disableOriginSwaps: z.boolean().optional(),
+    fixedRate: z.string().optional(),
+});
+
+// ── Relay Quote v2 Response ────────────────────────────
 
 /** Schema for currency metadata inside a Relay response. */
 const RelayCurrencySchema = z.object({
@@ -226,6 +306,11 @@ export const RelayServerErrorResponseSchema = z.object({
 
 // ── Relay Intent Status v3 ──────────────────────────────
 
+/** Schema for the Relay GET `/intents/status/v3` query parameters. */
+export const RelayIntentStatusRequestSchema = z.object({
+    requestId: z.string().optional(),
+});
+
 /** Valid Relay intent statuses as documented in the API. */
 export const RelayIntentStatusEnum = z.enum([
     "refund",
@@ -249,11 +334,17 @@ export const RelayIntentStatusResponseSchema = z.object({
 
 // ── Types ───────────────────────────────────────────────
 
+/** Request body for the Relay POST `/quote/v2` endpoint. */
+export type RelayQuoteRequest = z.infer<typeof RelayQuoteRequestSchema>;
+
 /** A single step in a Relay quote response. */
 export type RelayQuoteStep = z.infer<typeof RelayQuoteStepSchema>;
 
 /** Response from the Relay POST `/quote/v2` endpoint. */
 export type RelayQuoteResponse = z.infer<typeof RelayQuoteResponseSchema>;
+
+/** Query parameters for the Relay GET `/intents/status/v3` endpoint. */
+export type RelayIntentStatusRequest = z.infer<typeof RelayIntentStatusRequestSchema>;
 
 /** Status of a Relay intent. */
 export type RelayIntentStatus = z.infer<typeof RelayIntentStatusEnum>;

--- a/packages/cross-chain/src/protocols/relay/schemas.ts
+++ b/packages/cross-chain/src/protocols/relay/schemas.ts
@@ -1,0 +1,253 @@
+import { z } from "zod";
+
+import { addressString } from "../../core/schemas/common.js";
+
+// ── Relay Quote v2 ──────────────────────────────────────
+
+/** Schema for currency metadata inside a Relay response. */
+const RelayCurrencySchema = z.object({
+    chainId: z.number().int().positive(),
+    address: z.string(),
+    symbol: z.string(),
+    name: z.string(),
+    decimals: z.number().int().nonnegative(),
+    metadata: z
+        .object({
+            logoURI: z.string().optional(),
+            verified: z.boolean().optional(),
+            isNative: z.boolean().optional(),
+        })
+        .optional(),
+});
+
+/** Schema for a currency amount object (used in fees and details). */
+const RelayCurrencyAmountSchema = z.object({
+    currency: RelayCurrencySchema,
+    amount: z.string(),
+    amountFormatted: z.string().optional(),
+    amountUsd: z.string().optional(),
+    minimumAmount: z.string().optional(),
+});
+
+/** Schema for a single fee entry. */
+const RelayFeeSchema = z.object({
+    currency: RelayCurrencySchema.optional(),
+    amount: z.string().optional(),
+    amountFormatted: z.string().optional(),
+    amountUsd: z.string().optional(),
+    minimumAmount: z.string().optional(),
+});
+
+/** Schema for transaction data inside a step item. */
+const RelayStepItemDataSchema = z.object({
+    from: addressString.optional(),
+    to: addressString,
+    data: z.string(),
+    value: z.string().optional(),
+    chainId: z.number().int().positive(),
+});
+
+/** Schema for a check object that tells the client how to poll status. */
+const RelayStepCheckSchema = z.object({
+    endpoint: z.string(),
+    method: z.string(),
+});
+
+/** Schema for a single item within a step. */
+const RelayStepItemSchema = z.object({
+    status: z.enum(["complete", "incomplete"]),
+    data: RelayStepItemDataSchema,
+    check: RelayStepCheckSchema.optional(),
+});
+
+/** Schema for a single step in a Relay quote response. */
+export const RelayQuoteStepSchema = z.object({
+    id: z.string(),
+    action: z.string(),
+    description: z.string(),
+    kind: z.enum(["transaction", "signature"]),
+    requestId: z.string().min(1),
+    depositAddress: z.string().optional(),
+    items: z.array(RelayStepItemSchema).min(1),
+});
+
+/** Schema for the fees breakdown in a quote response. */
+const RelayFeesSchema = z.object({
+    gas: RelayFeeSchema.optional(),
+    relayer: RelayFeeSchema.optional(),
+    relayerGas: RelayFeeSchema.optional(),
+    relayerService: RelayFeeSchema.optional(),
+    app: RelayFeeSchema.optional(),
+    subsidized: RelayFeeSchema.optional(),
+});
+
+/** Schema for a price impact entry (usd amount). */
+const RelayPriceImpactSchema = z.object({
+    usd: z.string(),
+    percent: z.string().optional(),
+});
+
+/** Schema for a slippage tolerance entry. */
+const RelaySlippageToleranceEntrySchema = z.object({
+    usd: z.string().optional(),
+    value: z.string().optional(),
+    percent: z.string().optional(),
+});
+
+/** Schema for route leg (origin or destination). */
+const RelayRouteLegSchema = z.object({
+    inputCurrency: RelayCurrencyAmountSchema.optional(),
+    outputCurrency: RelayCurrencyAmountSchema.optional(),
+    router: z.string().optional(),
+    includedSwapSources: z.array(z.string()).optional(),
+});
+
+/** Schema for the details object in a quote response. */
+const RelayDetailsSchema = z.object({
+    operation: z.string().optional(),
+    sender: z.string().optional(),
+    recipient: z.string().optional(),
+    currencyIn: RelayCurrencyAmountSchema.optional(),
+    currencyOut: RelayCurrencyAmountSchema.optional(),
+    refundCurrency: RelayCurrencyAmountSchema.optional(),
+    currencyGasTopup: RelayCurrencyAmountSchema.optional(),
+    timeEstimate: z.number().nonnegative().optional(),
+    rate: z.string().optional(),
+    totalImpact: RelayPriceImpactSchema.optional(),
+    swapImpact: RelayPriceImpactSchema.optional(),
+    expandedPriceImpact: z
+        .object({
+            swap: z.object({ usd: z.string() }).optional(),
+            execution: z.object({ usd: z.string() }).optional(),
+            relay: z.object({ usd: z.string() }).optional(),
+            app: z.object({ usd: z.string() }).optional(),
+            sponsored: z.object({ usd: z.string() }).optional(),
+        })
+        .optional(),
+    slippageTolerance: z
+        .object({
+            origin: RelaySlippageToleranceEntrySchema.optional(),
+            destination: RelaySlippageToleranceEntrySchema.optional(),
+        })
+        .optional(),
+    userBalance: z.string().optional(),
+    fallbackType: z.string().optional(),
+    isFixedRate: z.boolean().optional(),
+    fixedRateFee: z.string().optional(),
+    route: z
+        .object({
+            origin: RelayRouteLegSchema.optional(),
+            destination: RelayRouteLegSchema.optional(),
+        })
+        .optional(),
+});
+
+/** Schema for the protocol-specific v2 order data. */
+const RelayProtocolV2Schema = z.object({
+    orderId: z.string().optional(),
+    orderData: z.unknown().optional(),
+    paymentDetails: z
+        .object({
+            chainId: z.union([z.number().int().positive(), z.string()]).optional(),
+            depository: z.string().optional(),
+            currency: z.string().optional(),
+            amount: z.string().optional(),
+        })
+        .optional(),
+});
+
+/** Schema for the Relay POST `/quote/v2` response body. */
+export const RelayQuoteResponseSchema = z.object({
+    steps: z.array(RelayQuoteStepSchema).min(1),
+    fees: RelayFeesSchema.optional(),
+    details: RelayDetailsSchema.optional(),
+    protocol: z.object({ v2: RelayProtocolV2Schema.optional() }).optional(),
+});
+
+// ── Relay Error Responses ──────────────────────────────
+
+/** Schema for the Relay 400 Bad Request response. */
+export const RelayBadRequestResponseSchema = z.object({
+    message: z.string(),
+    errorCode: z.string(),
+    errorData: z.string().optional(),
+    requestId: z.string().optional(),
+    approxSimulatedBlock: z.number().optional(),
+    failedCallData: z
+        .object({
+            from: z.string().optional(),
+            to: z.string().optional(),
+            data: z.string().optional(),
+            value: z.string().optional(),
+        })
+        .optional(),
+});
+
+/** Schema for the Relay 401 Unauthorized response. */
+export const RelayUnauthorizedResponseSchema = z.object({
+    message: z.string(),
+    errorCode: z.string(),
+});
+
+/** Schema for the Relay 429 Rate Limited response. */
+export const RelayRateLimitedResponseSchema = z.object({
+    message: z.string(),
+});
+
+/** Schema for the Relay 500 Server Error response. */
+export const RelayServerErrorResponseSchema = z.object({
+    message: z.string(),
+    errorCode: z.string(),
+    requestId: z.string().optional(),
+});
+
+// ── Relay Intent Status v3 ──────────────────────────────
+
+/** Valid Relay intent statuses as documented in the API. */
+export const RelayIntentStatusEnum = z.enum([
+    "waiting",
+    "pending",
+    "submitted",
+    "success",
+    "delayed",
+    "refunded",
+    "failure",
+    "refund",
+]);
+
+/** Schema for the Relay GET `/intents/status/v3` response body. */
+export const RelayIntentStatusResponseSchema = z.object({
+    status: RelayIntentStatusEnum,
+    details: z.string().optional(),
+    inTxHashes: z.array(z.string()).optional(),
+    txHashes: z.array(z.string()).optional(),
+    updatedAt: z.number().optional(),
+    originChainId: z.number().int().positive().optional(),
+    destinationChainId: z.number().int().positive().optional(),
+});
+
+// ── Types ───────────────────────────────────────────────
+
+/** A single step in a Relay quote response. */
+export type RelayQuoteStep = z.infer<typeof RelayQuoteStepSchema>;
+
+/** Response from the Relay POST `/quote/v2` endpoint. */
+export type RelayQuoteResponse = z.infer<typeof RelayQuoteResponseSchema>;
+
+/** Status of a Relay intent. */
+export type RelayIntentStatus = z.infer<typeof RelayIntentStatusEnum>;
+
+/** Response from the Relay GET `/intents/status/v3` endpoint. */
+export type RelayIntentStatusResponse = z.infer<typeof RelayIntentStatusResponseSchema>;
+
+/** Relay 400 Bad Request response. */
+export type RelayBadRequestResponse = z.infer<typeof RelayBadRequestResponseSchema>;
+
+/** Relay 401 Unauthorized response. */
+export type RelayUnauthorizedResponse = z.infer<typeof RelayUnauthorizedResponseSchema>;
+
+/** Relay 429 Rate Limited response. */
+export type RelayRateLimitedResponse = z.infer<typeof RelayRateLimitedResponseSchema>;
+
+/** Relay 500 Server Error response. */
+export type RelayServerErrorResponse = z.infer<typeof RelayServerErrorResponseSchema>;

--- a/packages/cross-chain/src/protocols/relay/schemas.ts
+++ b/packages/cross-chain/src/protocols/relay/schemas.ts
@@ -184,7 +184,7 @@ export const RelayQuoteResponseSchema = z.object({
     steps: z.array(RelayQuoteStepSchema).min(1),
     fees: RelayFeesSchema,
     details: RelayDetailsSchema,
-    protocol: z.object({ v2: RelayProtocolV2Schema.optional() }),
+    protocol: z.object({ v2: RelayProtocolV2Schema.optional() }).optional(),
 });
 
 // ── Relay Error Responses ──────────────────────────────

--- a/packages/cross-chain/src/protocols/relay/types.ts
+++ b/packages/cross-chain/src/protocols/relay/types.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+/** Default Relay API base URL. */
+export const RELAY_BASE_URL = "https://api.relay.link";
+
+/** Schema for validating Relay provider configuration. */
+export const RelayConfigSchema = z.object({
+    /** Custom API base URL. Defaults to `https://api.relay.link`. */
+    baseUrl: z.string().url().optional(),
+    /** Unique provider identifier. Defaults to `"relay"`. */
+    providerId: z.string().optional(),
+    /** Relay API key for authentication. Required in production. */
+    apiKey: z.string().optional(),
+    /**
+     * Default slippage tolerance in basis points (e.g. 50 = 0.5%).
+     * Applied to all quote requests unless overridden.
+     */
+    slippageTolerance: z.number().int().nonnegative().optional(),
+});
+
+/** Configuration options for {@link RelayProvider}. */
+export type RelayConfigs = z.infer<typeof RelayConfigSchema>;

--- a/packages/cross-chain/src/protocols/relay/types.ts
+++ b/packages/cross-chain/src/protocols/relay/types.ts
@@ -11,11 +11,6 @@ export const RelayConfigSchema = z.object({
     providerId: z.string().optional(),
     /** Relay API key for authentication. Required in production. */
     apiKey: z.string().optional(),
-    /**
-     * Default slippage tolerance in basis points (e.g. 50 = 0.5%).
-     * Applied to all quote requests unless overridden.
-     */
-    slippageTolerance: z.number().int().nonnegative().optional(),
 });
 
 /** Configuration options for {@link RelayProvider}. */

--- a/packages/cross-chain/test/protocols/relay/schemas.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/schemas.spec.ts
@@ -3,7 +3,9 @@ import { ZodError } from "zod";
 
 import {
     RelayBadRequestResponseSchema,
+    RelayIntentStatusRequestSchema,
     RelayIntentStatusResponseSchema,
+    RelayQuoteRequestSchema,
     RelayQuoteResponseSchema,
     RelayRateLimitedResponseSchema,
     RelayServerErrorResponseSchema,
@@ -197,6 +199,75 @@ function buildQuoteResponse(overrides?: Record<string, unknown>): Record<string,
         ...overrides,
     };
 }
+
+// ── Quote Request Tests ──────────────────────────────────
+
+describe("RelayQuoteRequestSchema", () => {
+    const VALID_REQUEST = {
+        user: VALID_ADDRESS,
+        originChainId: ORIGIN_CHAIN_ID,
+        destinationChainId: DESTINATION_CHAIN_ID,
+        originCurrency: VALID_ADDRESS,
+        destinationCurrency: VALID_ADDRESS,
+        amount: INPUT_AMOUNT,
+        tradeType: "EXACT_INPUT" as const,
+    };
+
+    it("accepts a minimal valid request", () => {
+        const result = RelayQuoteRequestSchema.parse(VALID_REQUEST);
+        expect(result.user).toBe(VALID_ADDRESS);
+        expect(result.tradeType).toBe("EXACT_INPUT");
+    });
+
+    it("accepts a request with all optional fields", () => {
+        const result = RelayQuoteRequestSchema.parse({
+            ...VALID_REQUEST,
+            recipient: VALID_ADDRESS,
+            slippageTolerance: "50",
+            appFees: [{ recipient: VALID_ADDRESS, fee: "100" }],
+            txs: [{ to: VALID_ADDRESS, value: "0", data: "0x" }],
+            usePermit: false,
+            topupGas: true,
+            topupGasAmount: "2000000",
+            referrer: "my-app",
+            subsidizeFees: false,
+        });
+        expect(result.recipient).toBe(VALID_ADDRESS);
+        expect(result.slippageTolerance).toBe("50");
+        expect(result.appFees).toHaveLength(1);
+    });
+
+    it("rejects an invalid tradeType", () => {
+        expect(() =>
+            RelayQuoteRequestSchema.parse({ ...VALID_REQUEST, tradeType: "INVALID" }),
+        ).toThrow(ZodError);
+    });
+
+    it("rejects a non-numeric amount", () => {
+        expect(() => RelayQuoteRequestSchema.parse({ ...VALID_REQUEST, amount: "abc" })).toThrow(
+            ZodError,
+        );
+    });
+
+    it("rejects a request missing required fields", () => {
+        const { user: _, ...noUser } = VALID_REQUEST;
+        expect(() => RelayQuoteRequestSchema.parse(noUser)).toThrow(ZodError);
+    });
+});
+
+// ── Intent Status Request Tests ─────────────────────────
+
+describe("RelayIntentStatusRequestSchema", () => {
+    it("accepts a request with requestId", () => {
+        const result = RelayIntentStatusRequestSchema.parse({ requestId: REQUEST_ID });
+        expect(result.requestId).toBe(REQUEST_ID);
+    });
+
+    it("accepts an empty request", () => {
+        const result = RelayIntentStatusRequestSchema.parse({});
+        expect(result.requestId).toBeUndefined();
+    });
+});
 
 // ── Quote Response Tests ─────────────────────────────────
 

--- a/packages/cross-chain/test/protocols/relay/schemas.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/schemas.spec.ts
@@ -284,12 +284,13 @@ describe("RelayQuoteResponseSchema", () => {
         expect(() => RelayQuoteResponseSchema.parse(response)).toThrow(ZodError);
     });
 
-    it("rejects a step with missing requestId", () => {
+    it("accepts a step without requestId", () => {
         const step = buildStep();
         const { requestId: _, ...stepWithoutId } = step;
-        expect(() =>
-            RelayQuoteResponseSchema.parse(buildQuoteResponse({ steps: [stepWithoutId] })),
-        ).toThrow(ZodError);
+        const result = RelayQuoteResponseSchema.parse(
+            buildQuoteResponse({ steps: [stepWithoutId] }),
+        );
+        expect(result.steps[0]!.requestId).toBeUndefined();
     });
 
     it("accepts a step with kind 'signature'", () => {

--- a/packages/cross-chain/test/protocols/relay/schemas.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/schemas.spec.ts
@@ -1,0 +1,486 @@
+import { describe, expect, it } from "vitest";
+import { ZodError } from "zod";
+
+import {
+    RelayBadRequestResponseSchema,
+    RelayIntentStatusResponseSchema,
+    RelayQuoteResponseSchema,
+    RelayRateLimitedResponseSchema,
+    RelayServerErrorResponseSchema,
+    RelayUnauthorizedResponseSchema,
+} from "../../../src/protocols/relay/schemas.js";
+
+const VALID_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+const ORIGIN_CHAIN_ID = 1;
+const DESTINATION_CHAIN_ID = 10;
+const REQUEST_ID = "0xabc123";
+const ORDER_ID = "0xorder456";
+const TX_DATA = "0xdeadbeef";
+const INPUT_AMOUNT = "1000000";
+const OUTPUT_AMOUNT = "999000";
+const GAS_FEE_AMOUNT = "100000";
+const GAS_FEE_USD = "0.10";
+const RELAYER_FEE_AMOUNT = "50000";
+const RELAYER_FEE_USD = "0.05";
+const TIME_ESTIMATE_SECONDS = 30;
+const USDC_DECIMALS = 6;
+const SAMPLE_IN_TX_HASH = "0xabc";
+const SAMPLE_OUT_TX_HASH = "0xdef";
+const SAMPLE_UPDATED_AT = 1700000000000;
+const SAMPLE_RATE = "0.999";
+const SAMPLE_SLIPPAGE_USD = "0.50";
+const SAMPLE_SLIPPAGE_VALUE = "500";
+const SAMPLE_SLIPPAGE_PERCENT = "0.5";
+const SAMPLE_PRICE_IMPACT_USD = "-0.01";
+const SAMPLE_PRICE_IMPACT_PERCENT = "-0.001";
+const SAMPLE_SIMULATED_BLOCK = 19000000;
+const SAMPLE_ERROR_CODE = "INSUFFICIENT_BALANCE";
+const SAMPLE_ERROR_MESSAGE = "Insufficient balance for this transaction";
+
+const USDC_CURRENCY = {
+    chainId: DESTINATION_CHAIN_ID,
+    address: VALID_ADDRESS,
+    symbol: "USDC",
+    name: "USD Coin",
+    decimals: USDC_DECIMALS,
+};
+
+const validQuoteResponse = {
+    steps: [
+        {
+            id: "deposit",
+            action: "Confirm transaction in your wallet",
+            description: "Deposit funds for executing the bridge",
+            kind: "transaction",
+            requestId: REQUEST_ID,
+            items: [
+                {
+                    status: "incomplete",
+                    data: {
+                        from: VALID_ADDRESS,
+                        to: VALID_ADDRESS,
+                        data: TX_DATA,
+                        value: INPUT_AMOUNT,
+                        chainId: ORIGIN_CHAIN_ID,
+                    },
+                    check: {
+                        endpoint: `/intents/status?requestId=${REQUEST_ID}`,
+                        method: "GET",
+                    },
+                },
+            ],
+        },
+    ],
+    fees: {
+        gas: { amount: GAS_FEE_AMOUNT, amountUsd: GAS_FEE_USD },
+        relayer: { amount: RELAYER_FEE_AMOUNT, amountUsd: RELAYER_FEE_USD },
+    },
+    details: {
+        operation: "bridge",
+        timeEstimate: TIME_ESTIMATE_SECONDS,
+        currencyOut: {
+            currency: USDC_CURRENCY,
+            amount: OUTPUT_AMOUNT,
+        },
+    },
+};
+
+describe("RelayQuoteResponseSchema", () => {
+    it("should accept a valid quote response", () => {
+        const result = RelayQuoteResponseSchema.parse(validQuoteResponse);
+        expect(result.steps).toHaveLength(1);
+        expect(result.steps[0]!.requestId).toBe(REQUEST_ID);
+    });
+
+    it("should accept a minimal response with only steps", () => {
+        const minimalRequestId = "0x123";
+        const minimal = {
+            steps: [
+                {
+                    id: "deposit",
+                    action: "Confirm",
+                    description: "Bridge",
+                    kind: "transaction",
+                    requestId: minimalRequestId,
+                    items: [
+                        {
+                            status: "incomplete",
+                            data: {
+                                to: VALID_ADDRESS,
+                                data: "0x00",
+                                chainId: ORIGIN_CHAIN_ID,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+        const result = RelayQuoteResponseSchema.parse(minimal);
+        expect(result.steps).toHaveLength(1);
+    });
+
+    it("should accept a full response with protocol, expanded details, and all fees", () => {
+        const fullResponse = {
+            ...validQuoteResponse,
+            fees: {
+                gas: { amount: GAS_FEE_AMOUNT, amountUsd: GAS_FEE_USD },
+                relayer: { amount: RELAYER_FEE_AMOUNT, amountUsd: RELAYER_FEE_USD },
+                relayerGas: { amount: GAS_FEE_AMOUNT },
+                relayerService: { amount: RELAYER_FEE_AMOUNT },
+                app: { amount: "0" },
+                subsidized: { amount: "0" },
+            },
+            details: {
+                ...validQuoteResponse.details,
+                sender: VALID_ADDRESS,
+                recipient: VALID_ADDRESS,
+                currencyIn: { currency: USDC_CURRENCY, amount: INPUT_AMOUNT },
+                currencyOut: { currency: USDC_CURRENCY, amount: OUTPUT_AMOUNT },
+                refundCurrency: { currency: USDC_CURRENCY, amount: INPUT_AMOUNT },
+                currencyGasTopup: { currency: USDC_CURRENCY, amount: GAS_FEE_AMOUNT },
+                rate: SAMPLE_RATE,
+                totalImpact: { usd: SAMPLE_PRICE_IMPACT_USD, percent: SAMPLE_PRICE_IMPACT_PERCENT },
+                swapImpact: { usd: SAMPLE_PRICE_IMPACT_USD, percent: SAMPLE_PRICE_IMPACT_PERCENT },
+                expandedPriceImpact: {
+                    swap: { usd: SAMPLE_PRICE_IMPACT_USD },
+                    execution: { usd: SAMPLE_PRICE_IMPACT_USD },
+                    relay: { usd: SAMPLE_PRICE_IMPACT_USD },
+                    app: { usd: "0" },
+                    sponsored: { usd: "0" },
+                },
+                slippageTolerance: {
+                    origin: {
+                        usd: SAMPLE_SLIPPAGE_USD,
+                        value: SAMPLE_SLIPPAGE_VALUE,
+                        percent: SAMPLE_SLIPPAGE_PERCENT,
+                    },
+                    destination: {
+                        usd: SAMPLE_SLIPPAGE_USD,
+                        value: SAMPLE_SLIPPAGE_VALUE,
+                        percent: SAMPLE_SLIPPAGE_PERCENT,
+                    },
+                },
+                userBalance: INPUT_AMOUNT,
+                fallbackType: "canonical",
+                isFixedRate: true,
+                route: {
+                    origin: {
+                        inputCurrency: { currency: USDC_CURRENCY, amount: INPUT_AMOUNT },
+                        outputCurrency: { currency: USDC_CURRENCY, amount: INPUT_AMOUNT },
+                        router: "uniswap",
+                        includedSwapSources: ["uniswap-v3"],
+                    },
+                    destination: {
+                        inputCurrency: { currency: USDC_CURRENCY, amount: OUTPUT_AMOUNT },
+                        outputCurrency: { currency: USDC_CURRENCY, amount: OUTPUT_AMOUNT },
+                    },
+                },
+            },
+            protocol: {
+                v2: {
+                    orderId: ORDER_ID,
+                    orderData: { some: "data" },
+                    paymentDetails: {
+                        chainId: ORIGIN_CHAIN_ID,
+                        depository: VALID_ADDRESS,
+                        currency: VALID_ADDRESS,
+                        amount: INPUT_AMOUNT,
+                    },
+                },
+            },
+        };
+
+        const result = RelayQuoteResponseSchema.parse(fullResponse);
+
+        expect(result.details?.expandedPriceImpact?.swap?.usd).toBe(SAMPLE_PRICE_IMPACT_USD);
+        expect(result.details?.slippageTolerance?.origin?.percent).toBe(SAMPLE_SLIPPAGE_PERCENT);
+        expect(result.details?.route?.origin?.router).toBe("uniswap");
+        expect(result.details?.refundCurrency?.amount).toBe(INPUT_AMOUNT);
+        expect(result.details?.fallbackType).toBe("canonical");
+        expect(result.protocol?.v2?.orderId).toBe(ORDER_ID);
+    });
+
+    it("should accept a step with depositAddress", () => {
+        const depositAddress = "0xdeposit1234567890abcdef1234567890abcdef";
+        const response = {
+            steps: [
+                {
+                    ...validQuoteResponse.steps[0],
+                    depositAddress,
+                },
+            ],
+        };
+        const result = RelayQuoteResponseSchema.parse(response);
+        expect(result.steps[0]!.depositAddress).toBe(depositAddress);
+    });
+
+    it("should reject a response with empty steps", () => {
+        const invalid = { ...validQuoteResponse, steps: [] };
+        expect(() => RelayQuoteResponseSchema.parse(invalid)).toThrow(ZodError);
+    });
+
+    it("should reject an invalid address format in step item data", () => {
+        const invalidAddress = "not-an-address";
+        const invalid = {
+            ...validQuoteResponse,
+            steps: [
+                {
+                    ...validQuoteResponse.steps[0],
+                    items: [
+                        {
+                            status: "incomplete",
+                            data: {
+                                to: invalidAddress,
+                                data: "0x00",
+                                chainId: ORIGIN_CHAIN_ID,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+        expect(() => RelayQuoteResponseSchema.parse(invalid)).toThrow(ZodError);
+    });
+
+    it("should reject a step with missing requestId", () => {
+        const { requestId: _, ...stepWithoutId } = validQuoteResponse.steps[0]!;
+        const invalid = { ...validQuoteResponse, steps: [stepWithoutId] };
+        expect(() => RelayQuoteResponseSchema.parse(invalid)).toThrow(ZodError);
+    });
+
+    it("should accept a step with kind 'signature'", () => {
+        const signatureStep = {
+            ...validQuoteResponse.steps[0],
+            kind: "signature",
+        };
+        const response = { steps: [signatureStep] };
+        const result = RelayQuoteResponseSchema.parse(response);
+        expect(result.steps[0]!.kind).toBe("signature");
+    });
+
+    it("should accept a step item with status 'complete'", () => {
+        const response = {
+            steps: [
+                {
+                    ...validQuoteResponse.steps[0],
+                    items: [
+                        {
+                            status: "complete",
+                            data: {
+                                to: VALID_ADDRESS,
+                                data: TX_DATA,
+                                chainId: ORIGIN_CHAIN_ID,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+        const result = RelayQuoteResponseSchema.parse(response);
+        expect(result.steps[0]!.items[0]!.status).toBe("complete");
+    });
+
+    it("should accept a currency with metadata", () => {
+        const logoURI = "https://example.com/usdc.png";
+        const response = {
+            ...validQuoteResponse,
+            details: {
+                ...validQuoteResponse.details,
+                currencyOut: {
+                    currency: {
+                        ...USDC_CURRENCY,
+                        metadata: {
+                            logoURI,
+                            verified: true,
+                            isNative: false,
+                        },
+                    },
+                    amount: OUTPUT_AMOUNT,
+                },
+            },
+        };
+        const result = RelayQuoteResponseSchema.parse(response);
+        expect(result.details?.currencyOut?.currency.metadata?.logoURI).toBe(logoURI);
+        expect(result.details?.currencyOut?.currency.metadata?.verified).toBe(true);
+    });
+
+    it("should strip unknown fields from response", () => {
+        const response = {
+            ...validQuoteResponse,
+            unknownTopLevel: "stripped",
+        };
+        const result = RelayQuoteResponseSchema.parse(response);
+        expect(result).not.toHaveProperty("unknownTopLevel");
+    });
+
+    it("should reject a step with empty items array", () => {
+        const response = {
+            steps: [
+                {
+                    ...validQuoteResponse.steps[0],
+                    items: [],
+                },
+            ],
+        };
+        expect(() => RelayQuoteResponseSchema.parse(response)).toThrow(ZodError);
+    });
+
+    it("should reject an invalid step kind", () => {
+        const response = {
+            steps: [
+                {
+                    ...validQuoteResponse.steps[0],
+                    kind: "unknown-kind",
+                },
+            ],
+        };
+        expect(() => RelayQuoteResponseSchema.parse(response)).toThrow(ZodError);
+    });
+
+    it("should reject an invalid step item status", () => {
+        const response = {
+            steps: [
+                {
+                    ...validQuoteResponse.steps[0],
+                    items: [
+                        {
+                            status: "unknown-status",
+                            data: {
+                                to: VALID_ADDRESS,
+                                data: TX_DATA,
+                                chainId: ORIGIN_CHAIN_ID,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+        expect(() => RelayQuoteResponseSchema.parse(response)).toThrow(ZodError);
+    });
+});
+
+describe("RelayIntentStatusResponseSchema", () => {
+    it.each([
+        "waiting",
+        "pending",
+        "submitted",
+        "success",
+        "delayed",
+        "refunded",
+        "failure",
+        "refund",
+    ] as const)("should accept status '%s'", (status) => {
+        const result = RelayIntentStatusResponseSchema.parse({ status });
+        expect(result.status).toBe(status);
+    });
+
+    it("should accept a full status response with all fields", () => {
+        const result = RelayIntentStatusResponseSchema.parse({
+            status: "success",
+            details: "Transfer complete",
+            inTxHashes: [SAMPLE_IN_TX_HASH],
+            txHashes: [SAMPLE_OUT_TX_HASH],
+            updatedAt: SAMPLE_UPDATED_AT,
+            originChainId: ORIGIN_CHAIN_ID,
+            destinationChainId: DESTINATION_CHAIN_ID,
+        });
+        expect(result.status).toBe("success");
+        expect(result.inTxHashes).toEqual([SAMPLE_IN_TX_HASH]);
+        expect(result.txHashes).toEqual([SAMPLE_OUT_TX_HASH]);
+    });
+
+    it("should reject an invalid status value", () => {
+        expect(() => RelayIntentStatusResponseSchema.parse({ status: "invalid" })).toThrow(
+            ZodError,
+        );
+    });
+});
+
+describe("RelayBadRequestResponseSchema", () => {
+    it("should accept a minimal bad request response", () => {
+        const result = RelayBadRequestResponseSchema.parse({
+            message: SAMPLE_ERROR_MESSAGE,
+            errorCode: SAMPLE_ERROR_CODE,
+        });
+        expect(result.message).toBe(SAMPLE_ERROR_MESSAGE);
+        expect(result.errorCode).toBe(SAMPLE_ERROR_CODE);
+    });
+
+    it("should accept a full bad request response with failedCallData", () => {
+        const result = RelayBadRequestResponseSchema.parse({
+            message: SAMPLE_ERROR_MESSAGE,
+            errorCode: SAMPLE_ERROR_CODE,
+            errorData: "additional error context",
+            requestId: REQUEST_ID,
+            approxSimulatedBlock: SAMPLE_SIMULATED_BLOCK,
+            failedCallData: {
+                from: VALID_ADDRESS,
+                to: VALID_ADDRESS,
+                data: TX_DATA,
+                value: INPUT_AMOUNT,
+            },
+        });
+        expect(result.failedCallData?.to).toBe(VALID_ADDRESS);
+        expect(result.approxSimulatedBlock).toBe(SAMPLE_SIMULATED_BLOCK);
+    });
+
+    it("should reject a response without required fields", () => {
+        expect(() =>
+            RelayBadRequestResponseSchema.parse({ message: SAMPLE_ERROR_MESSAGE }),
+        ).toThrow(ZodError);
+    });
+});
+
+describe("RelayUnauthorizedResponseSchema", () => {
+    it("should accept a valid unauthorized response", () => {
+        const result = RelayUnauthorizedResponseSchema.parse({
+            message: "Unauthorized",
+            errorCode: "UNAUTHORIZED",
+        });
+        expect(result.message).toBe("Unauthorized");
+    });
+
+    it("should reject a response without errorCode", () => {
+        expect(() => RelayUnauthorizedResponseSchema.parse({ message: "Unauthorized" })).toThrow(
+            ZodError,
+        );
+    });
+});
+
+describe("RelayRateLimitedResponseSchema", () => {
+    it("should accept a valid rate limited response", () => {
+        const result = RelayRateLimitedResponseSchema.parse({
+            message: "Rate limit exceeded",
+        });
+        expect(result.message).toBe("Rate limit exceeded");
+    });
+
+    it("should reject a response without message", () => {
+        expect(() => RelayRateLimitedResponseSchema.parse({})).toThrow(ZodError);
+    });
+});
+
+describe("RelayServerErrorResponseSchema", () => {
+    it("should accept a minimal server error response", () => {
+        const result = RelayServerErrorResponseSchema.parse({
+            message: "Internal server error",
+            errorCode: "INTERNAL_ERROR",
+        });
+        expect(result.message).toBe("Internal server error");
+    });
+
+    it("should accept a server error response with requestId", () => {
+        const result = RelayServerErrorResponseSchema.parse({
+            message: "Internal server error",
+            errorCode: "INTERNAL_ERROR",
+            requestId: REQUEST_ID,
+        });
+        expect(result.requestId).toBe(REQUEST_ID);
+    });
+
+    it("should reject a response without errorCode", () => {
+        expect(() =>
+            RelayServerErrorResponseSchema.parse({ message: "Internal server error" }),
+        ).toThrow(ZodError);
+    });
+});

--- a/packages/cross-chain/test/protocols/relay/schemas.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/schemas.spec.ts
@@ -272,33 +272,45 @@ describe("RelayQuoteResponseSchema", () => {
         expect(result.steps[0]!.requestId).toBe(REQUEST_ID);
     });
 
-    it("accepts a full response with all optional fields", () => {
+    it("accepts expanded price impact in details", () => {
+        const response = buildQuoteResponse({ details: buildDetails() });
+        const result = RelayQuoteResponseSchema.parse(response);
+        expect(result.details?.expandedPriceImpact?.swap?.usd).toBe(SAMPLE_PRICE_IMPACT_USD);
+    });
+
+    it("accepts slippage tolerance in details", () => {
+        const response = buildQuoteResponse({ details: buildDetails() });
+        const result = RelayQuoteResponseSchema.parse(response);
+        expect(result.details?.slippageTolerance?.origin?.percent).toBe(SAMPLE_SLIPPAGE_PERCENT);
+    });
+
+    it("accepts route in details", () => {
+        const response = buildQuoteResponse({ details: buildDetails() });
+        const result = RelayQuoteResponseSchema.parse(response);
+        expect(result.details?.route?.origin?.router).toBe(SAMPLE_ROUTER);
+    });
+
+    it("accepts refund currency in details", () => {
         const response = buildQuoteResponse({
-            fees: {
-                gas: buildFee(GAS_FEE_AMOUNT, GAS_FEE_USD),
-                relayer: buildFee(RELAYER_FEE_AMOUNT, RELAYER_FEE_USD),
-                relayerGas: buildFee(GAS_FEE_AMOUNT, GAS_FEE_USD),
-                relayerService: buildFee(RELAYER_FEE_AMOUNT, RELAYER_FEE_USD),
-                app: buildFee(ZERO_AMOUNT, ZERO_AMOUNT),
-                subsidized: buildFee(ZERO_AMOUNT, ZERO_AMOUNT),
-            },
-            details: buildDetails({
-                refundCurrency: buildCurrencyAmount(INPUT_AMOUNT),
-                currencyGasTopup: buildCurrencyAmount(GAS_FEE_AMOUNT),
-                fallbackType: SAMPLE_FALLBACK_TYPE,
-                isFixedRate: true,
-                fixedRateFee: { usd: SAMPLE_PRICE_IMPACT_USD },
-            }),
+            details: buildDetails({ refundCurrency: buildCurrencyAmount(INPUT_AMOUNT) }),
+        });
+        const result = RelayQuoteResponseSchema.parse(response);
+        expect(result.details?.refundCurrency?.amount).toBe(INPUT_AMOUNT);
+    });
+
+    it("accepts fallback type in details", () => {
+        const response = buildQuoteResponse({
+            details: buildDetails({ fallbackType: SAMPLE_FALLBACK_TYPE }),
+        });
+        const result = RelayQuoteResponseSchema.parse(response);
+        expect(result.details?.fallbackType).toBe(SAMPLE_FALLBACK_TYPE);
+    });
+
+    it("accepts protocol with order data", () => {
+        const response = buildQuoteResponse({
             protocol: buildProtocol({ orderData: { some: "data" } }),
         });
-
         const result = RelayQuoteResponseSchema.parse(response);
-
-        expect(result.details?.expandedPriceImpact?.swap?.usd).toBe(SAMPLE_PRICE_IMPACT_USD);
-        expect(result.details?.slippageTolerance?.origin?.percent).toBe(SAMPLE_SLIPPAGE_PERCENT);
-        expect(result.details?.route?.origin?.router).toBe(SAMPLE_ROUTER);
-        expect(result.details?.refundCurrency?.amount).toBe(INPUT_AMOUNT);
-        expect(result.details?.fallbackType).toBe(SAMPLE_FALLBACK_TYPE);
         expect(result.protocol?.v2?.orderId).toBe(ORDER_ID);
     });
 

--- a/packages/cross-chain/test/protocols/relay/schemas.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/schemas.spec.ts
@@ -229,12 +229,12 @@ describe("RelayQuoteResponseSchema", () => {
 
         const result = RelayQuoteResponseSchema.parse(response);
 
-        expect(result.details.expandedPriceImpact.swap.usd).toBe(SAMPLE_PRICE_IMPACT_USD);
-        expect(result.details.slippageTolerance.origin.percent).toBe(SAMPLE_SLIPPAGE_PERCENT);
-        expect(result.details.route.origin.router).toBe(SAMPLE_ROUTER);
-        expect(result.details.refundCurrency?.amount).toBe(INPUT_AMOUNT);
-        expect(result.details.fallbackType).toBe(SAMPLE_FALLBACK_TYPE);
-        expect(result.protocol.v2.orderId).toBe(ORDER_ID);
+        expect(result.details?.expandedPriceImpact?.swap?.usd).toBe(SAMPLE_PRICE_IMPACT_USD);
+        expect(result.details?.slippageTolerance?.origin?.percent).toBe(SAMPLE_SLIPPAGE_PERCENT);
+        expect(result.details?.route?.origin?.router).toBe(SAMPLE_ROUTER);
+        expect(result.details?.refundCurrency?.amount).toBe(INPUT_AMOUNT);
+        expect(result.details?.fallbackType).toBe(SAMPLE_FALLBACK_TYPE);
+        expect(result.protocol?.v2?.orderId).toBe(ORDER_ID);
     });
 
     it("accepts a step with depositAddress", () => {
@@ -251,14 +251,16 @@ describe("RelayQuoteResponseSchema", () => {
         );
     });
 
-    it("rejects a response without required fees", () => {
+    it("accepts a response without fees", () => {
         const { fees: _, ...noFees } = buildQuoteResponse();
-        expect(() => RelayQuoteResponseSchema.parse(noFees)).toThrow(ZodError);
+        const result = RelayQuoteResponseSchema.parse(noFees);
+        expect(result.fees).toBeUndefined();
     });
 
-    it("rejects a response without required details", () => {
+    it("accepts a response without details", () => {
         const { details: _, ...noDetails } = buildQuoteResponse();
-        expect(() => RelayQuoteResponseSchema.parse(noDetails)).toThrow(ZodError);
+        const result = RelayQuoteResponseSchema.parse(noDetails);
+        expect(result.details).toBeUndefined();
     });
 
     it("accepts a response without protocol (same-chain swaps)", () => {

--- a/packages/cross-chain/test/protocols/relay/schemas.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/schemas.spec.ts
@@ -261,9 +261,10 @@ describe("RelayQuoteResponseSchema", () => {
         expect(() => RelayQuoteResponseSchema.parse(noDetails)).toThrow(ZodError);
     });
 
-    it("should reject a response without required protocol", () => {
+    it("should accept a response without protocol (same-chain swaps)", () => {
         const { protocol: _, ...noProtocol } = buildQuoteResponse();
-        expect(() => RelayQuoteResponseSchema.parse(noProtocol)).toThrow(ZodError);
+        const result = RelayQuoteResponseSchema.parse(noProtocol);
+        expect(result.protocol).toBeUndefined();
     });
 
     it("should reject an invalid address format in step item data", () => {

--- a/packages/cross-chain/test/protocols/relay/schemas.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/schemas.spec.ts
@@ -10,6 +10,8 @@ import {
     RelayUnauthorizedResponseSchema,
 } from "../../../src/protocols/relay/schemas.js";
 
+// ── Constants ────────────────────────────────────────────
+
 const VALID_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
 const ORIGIN_CHAIN_ID = 1;
 const DESTINATION_CHAIN_ID = 10;
@@ -36,348 +38,322 @@ const SAMPLE_PRICE_IMPACT_PERCENT = "-0.001";
 const SAMPLE_SIMULATED_BLOCK = 19000000;
 const SAMPLE_ERROR_CODE = "INSUFFICIENT_BALANCE";
 const SAMPLE_ERROR_MESSAGE = "Insufficient balance for this transaction";
+const SAMPLE_LOGO_URI = "https://example.com/usdc.png";
+const SAMPLE_ROUTER = "uniswap";
+const SAMPLE_SWAP_SOURCE = "uniswap-v3";
+const SAMPLE_FALLBACK_TYPE = "canonical";
+const SAMPLE_ERROR_DATA = "additional error context";
+const SAMPLE_STATUS_DETAILS = "Transfer complete";
+const ZERO_AMOUNT = "0";
+const DEPOSIT_ADDRESS = "0xdeposit1234567890abcdef1234567890abcdef";
+const PAYMENT_CHAIN_ID = "1";
 
-const USDC_CURRENCY = {
-    chainId: DESTINATION_CHAIN_ID,
-    address: VALID_ADDRESS,
-    symbol: "USDC",
-    name: "USD Coin",
-    decimals: USDC_DECIMALS,
-};
+// ── Helpers ──────────────────────────────────────────────
 
-const validQuoteResponse = {
-    steps: [
-        {
-            id: "deposit",
-            action: "Confirm transaction in your wallet",
-            description: "Deposit funds for executing the bridge",
-            kind: "transaction",
-            requestId: REQUEST_ID,
-            items: [
-                {
-                    status: "incomplete",
-                    data: {
-                        from: VALID_ADDRESS,
-                        to: VALID_ADDRESS,
-                        data: TX_DATA,
-                        value: INPUT_AMOUNT,
-                        chainId: ORIGIN_CHAIN_ID,
-                    },
-                    check: {
-                        endpoint: `/intents/status?requestId=${REQUEST_ID}`,
-                        method: "GET",
-                    },
-                },
-            ],
+function buildCurrency(overrides?: Record<string, unknown>): Record<string, unknown> {
+    return {
+        chainId: DESTINATION_CHAIN_ID,
+        address: VALID_ADDRESS,
+        symbol: "USDC",
+        name: "USD Coin",
+        decimals: USDC_DECIMALS,
+        metadata: {
+            logoURI: SAMPLE_LOGO_URI,
+            verified: true,
+            isNative: false,
         },
-    ],
-    fees: {
-        gas: { amount: GAS_FEE_AMOUNT, amountUsd: GAS_FEE_USD },
-        relayer: { amount: RELAYER_FEE_AMOUNT, amountUsd: RELAYER_FEE_USD },
-    },
-    details: {
+        ...overrides,
+    };
+}
+
+function buildCurrencyAmount(
+    amount: string,
+    overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+    return {
+        currency: buildCurrency(),
+        amount,
+        amountFormatted: amount,
+        amountUsd: amount,
+        minimumAmount: amount,
+        ...overrides,
+    };
+}
+
+function buildStepItem(overrides?: Record<string, unknown>): Record<string, unknown> {
+    return {
+        status: "incomplete",
+        data: {
+            from: VALID_ADDRESS,
+            to: VALID_ADDRESS,
+            data: TX_DATA,
+            value: INPUT_AMOUNT,
+            chainId: ORIGIN_CHAIN_ID,
+        },
+        check: {
+            endpoint: `/intents/status?requestId=${REQUEST_ID}`,
+            method: "GET",
+        },
+        ...overrides,
+    };
+}
+
+function buildStep(overrides?: Record<string, unknown>): Record<string, unknown> {
+    return {
+        id: "deposit",
+        action: "Confirm transaction in your wallet",
+        description: "Deposit funds for executing the bridge",
+        kind: "transaction",
+        requestId: REQUEST_ID,
+        items: [buildStepItem()],
+        ...overrides,
+    };
+}
+
+function buildFee(amount: string, amountUsd: string): Record<string, unknown> {
+    return {
+        currency: buildCurrency(),
+        amount,
+        amountFormatted: amount,
+        amountUsd,
+        minimumAmount: amount,
+    };
+}
+
+function buildDetails(overrides?: Record<string, unknown>): Record<string, unknown> {
+    return {
         operation: "bridge",
+        sender: VALID_ADDRESS,
+        recipient: VALID_ADDRESS,
+        currencyIn: buildCurrencyAmount(INPUT_AMOUNT),
+        currencyOut: buildCurrencyAmount(OUTPUT_AMOUNT),
         timeEstimate: TIME_ESTIMATE_SECONDS,
-        currencyOut: {
-            currency: USDC_CURRENCY,
-            amount: OUTPUT_AMOUNT,
+        rate: SAMPLE_RATE,
+        totalImpact: { usd: SAMPLE_PRICE_IMPACT_USD, percent: SAMPLE_PRICE_IMPACT_PERCENT },
+        swapImpact: { usd: SAMPLE_PRICE_IMPACT_USD, percent: SAMPLE_PRICE_IMPACT_PERCENT },
+        expandedPriceImpact: {
+            swap: { usd: SAMPLE_PRICE_IMPACT_USD },
+            execution: { usd: SAMPLE_PRICE_IMPACT_USD },
+            relay: { usd: SAMPLE_PRICE_IMPACT_USD },
+            app: { usd: ZERO_AMOUNT },
+            sponsored: { usd: ZERO_AMOUNT },
         },
-    },
-};
+        slippageTolerance: {
+            origin: {
+                usd: SAMPLE_SLIPPAGE_USD,
+                value: SAMPLE_SLIPPAGE_VALUE,
+                percent: SAMPLE_SLIPPAGE_PERCENT,
+            },
+            destination: {
+                usd: SAMPLE_SLIPPAGE_USD,
+                value: SAMPLE_SLIPPAGE_VALUE,
+                percent: SAMPLE_SLIPPAGE_PERCENT,
+            },
+        },
+        userBalance: INPUT_AMOUNT,
+        isFixedRate: false,
+        route: {
+            origin: {
+                inputCurrency: buildCurrencyAmount(INPUT_AMOUNT),
+                outputCurrency: buildCurrencyAmount(INPUT_AMOUNT),
+                router: SAMPLE_ROUTER,
+                includedSwapSources: [SAMPLE_SWAP_SOURCE],
+            },
+            destination: {
+                inputCurrency: buildCurrencyAmount(OUTPUT_AMOUNT),
+                outputCurrency: buildCurrencyAmount(OUTPUT_AMOUNT),
+                router: SAMPLE_ROUTER,
+                includedSwapSources: [SAMPLE_SWAP_SOURCE],
+            },
+        },
+        ...overrides,
+    };
+}
+
+function buildProtocol(overrides?: Record<string, unknown>): Record<string, unknown> {
+    return {
+        v2: {
+            orderId: ORDER_ID,
+            paymentDetails: {
+                chainId: PAYMENT_CHAIN_ID,
+                depository: VALID_ADDRESS,
+                currency: VALID_ADDRESS,
+                amount: INPUT_AMOUNT,
+            },
+            ...overrides,
+        },
+    };
+}
+
+function buildQuoteResponse(overrides?: Record<string, unknown>): Record<string, unknown> {
+    return {
+        steps: [buildStep()],
+        fees: {
+            gas: buildFee(GAS_FEE_AMOUNT, GAS_FEE_USD),
+            relayer: buildFee(RELAYER_FEE_AMOUNT, RELAYER_FEE_USD),
+        },
+        details: buildDetails(),
+        protocol: buildProtocol(),
+        ...overrides,
+    };
+}
+
+// ── Quote Response Tests ─────────────────────────────────
 
 describe("RelayQuoteResponseSchema", () => {
     it("should accept a valid quote response", () => {
-        const result = RelayQuoteResponseSchema.parse(validQuoteResponse);
+        const result = RelayQuoteResponseSchema.parse(buildQuoteResponse());
         expect(result.steps).toHaveLength(1);
         expect(result.steps[0]!.requestId).toBe(REQUEST_ID);
     });
 
-    it("should accept a minimal response with only steps", () => {
-        const minimalRequestId = "0x123";
-        const minimal = {
-            steps: [
-                {
-                    id: "deposit",
-                    action: "Confirm",
-                    description: "Bridge",
-                    kind: "transaction",
-                    requestId: minimalRequestId,
-                    items: [
-                        {
-                            status: "incomplete",
-                            data: {
-                                to: VALID_ADDRESS,
-                                data: "0x00",
-                                chainId: ORIGIN_CHAIN_ID,
-                            },
-                        },
-                    ],
-                },
-            ],
-        };
-        const result = RelayQuoteResponseSchema.parse(minimal);
-        expect(result.steps).toHaveLength(1);
-    });
-
-    it("should accept a full response with protocol, expanded details, and all fees", () => {
-        const fullResponse = {
-            ...validQuoteResponse,
+    it("should accept a full response with all optional fields", () => {
+        const response = buildQuoteResponse({
             fees: {
-                gas: { amount: GAS_FEE_AMOUNT, amountUsd: GAS_FEE_USD },
-                relayer: { amount: RELAYER_FEE_AMOUNT, amountUsd: RELAYER_FEE_USD },
-                relayerGas: { amount: GAS_FEE_AMOUNT },
-                relayerService: { amount: RELAYER_FEE_AMOUNT },
-                app: { amount: "0" },
-                subsidized: { amount: "0" },
+                gas: buildFee(GAS_FEE_AMOUNT, GAS_FEE_USD),
+                relayer: buildFee(RELAYER_FEE_AMOUNT, RELAYER_FEE_USD),
+                relayerGas: buildFee(GAS_FEE_AMOUNT, GAS_FEE_USD),
+                relayerService: buildFee(RELAYER_FEE_AMOUNT, RELAYER_FEE_USD),
+                app: buildFee(ZERO_AMOUNT, ZERO_AMOUNT),
+                subsidized: buildFee(ZERO_AMOUNT, ZERO_AMOUNT),
             },
-            details: {
-                ...validQuoteResponse.details,
-                sender: VALID_ADDRESS,
-                recipient: VALID_ADDRESS,
-                currencyIn: { currency: USDC_CURRENCY, amount: INPUT_AMOUNT },
-                currencyOut: { currency: USDC_CURRENCY, amount: OUTPUT_AMOUNT },
-                refundCurrency: { currency: USDC_CURRENCY, amount: INPUT_AMOUNT },
-                currencyGasTopup: { currency: USDC_CURRENCY, amount: GAS_FEE_AMOUNT },
-                rate: SAMPLE_RATE,
-                totalImpact: { usd: SAMPLE_PRICE_IMPACT_USD, percent: SAMPLE_PRICE_IMPACT_PERCENT },
-                swapImpact: { usd: SAMPLE_PRICE_IMPACT_USD, percent: SAMPLE_PRICE_IMPACT_PERCENT },
-                expandedPriceImpact: {
-                    swap: { usd: SAMPLE_PRICE_IMPACT_USD },
-                    execution: { usd: SAMPLE_PRICE_IMPACT_USD },
-                    relay: { usd: SAMPLE_PRICE_IMPACT_USD },
-                    app: { usd: "0" },
-                    sponsored: { usd: "0" },
-                },
-                slippageTolerance: {
-                    origin: {
-                        usd: SAMPLE_SLIPPAGE_USD,
-                        value: SAMPLE_SLIPPAGE_VALUE,
-                        percent: SAMPLE_SLIPPAGE_PERCENT,
-                    },
-                    destination: {
-                        usd: SAMPLE_SLIPPAGE_USD,
-                        value: SAMPLE_SLIPPAGE_VALUE,
-                        percent: SAMPLE_SLIPPAGE_PERCENT,
-                    },
-                },
-                userBalance: INPUT_AMOUNT,
-                fallbackType: "canonical",
+            details: buildDetails({
+                refundCurrency: buildCurrencyAmount(INPUT_AMOUNT),
+                currencyGasTopup: buildCurrencyAmount(GAS_FEE_AMOUNT),
+                fallbackType: SAMPLE_FALLBACK_TYPE,
                 isFixedRate: true,
-                route: {
-                    origin: {
-                        inputCurrency: { currency: USDC_CURRENCY, amount: INPUT_AMOUNT },
-                        outputCurrency: { currency: USDC_CURRENCY, amount: INPUT_AMOUNT },
-                        router: "uniswap",
-                        includedSwapSources: ["uniswap-v3"],
-                    },
-                    destination: {
-                        inputCurrency: { currency: USDC_CURRENCY, amount: OUTPUT_AMOUNT },
-                        outputCurrency: { currency: USDC_CURRENCY, amount: OUTPUT_AMOUNT },
-                    },
-                },
-            },
-            protocol: {
-                v2: {
-                    orderId: ORDER_ID,
-                    orderData: { some: "data" },
-                    paymentDetails: {
-                        chainId: ORIGIN_CHAIN_ID,
-                        depository: VALID_ADDRESS,
-                        currency: VALID_ADDRESS,
-                        amount: INPUT_AMOUNT,
-                    },
-                },
-            },
-        };
+                fixedRateFee: { usd: SAMPLE_PRICE_IMPACT_USD },
+            }),
+            protocol: buildProtocol({ orderData: { some: "data" } }),
+        });
 
-        const result = RelayQuoteResponseSchema.parse(fullResponse);
+        const result = RelayQuoteResponseSchema.parse(response);
 
-        expect(result.details?.expandedPriceImpact?.swap?.usd).toBe(SAMPLE_PRICE_IMPACT_USD);
-        expect(result.details?.slippageTolerance?.origin?.percent).toBe(SAMPLE_SLIPPAGE_PERCENT);
-        expect(result.details?.route?.origin?.router).toBe("uniswap");
-        expect(result.details?.refundCurrency?.amount).toBe(INPUT_AMOUNT);
-        expect(result.details?.fallbackType).toBe("canonical");
-        expect(result.protocol?.v2?.orderId).toBe(ORDER_ID);
+        expect(result.details.expandedPriceImpact.swap.usd).toBe(SAMPLE_PRICE_IMPACT_USD);
+        expect(result.details.slippageTolerance.origin.percent).toBe(SAMPLE_SLIPPAGE_PERCENT);
+        expect(result.details.route.origin.router).toBe(SAMPLE_ROUTER);
+        expect(result.details.refundCurrency?.amount).toBe(INPUT_AMOUNT);
+        expect(result.details.fallbackType).toBe(SAMPLE_FALLBACK_TYPE);
+        expect(result.protocol.v2.orderId).toBe(ORDER_ID);
     });
 
     it("should accept a step with depositAddress", () => {
-        const depositAddress = "0xdeposit1234567890abcdef1234567890abcdef";
-        const response = {
-            steps: [
-                {
-                    ...validQuoteResponse.steps[0],
-                    depositAddress,
-                },
-            ],
-        };
+        const response = buildQuoteResponse({
+            steps: [buildStep({ depositAddress: DEPOSIT_ADDRESS })],
+        });
         const result = RelayQuoteResponseSchema.parse(response);
-        expect(result.steps[0]!.depositAddress).toBe(depositAddress);
+        expect(result.steps[0]!.depositAddress).toBe(DEPOSIT_ADDRESS);
     });
 
     it("should reject a response with empty steps", () => {
-        const invalid = { ...validQuoteResponse, steps: [] };
-        expect(() => RelayQuoteResponseSchema.parse(invalid)).toThrow(ZodError);
+        expect(() => RelayQuoteResponseSchema.parse(buildQuoteResponse({ steps: [] }))).toThrow(
+            ZodError,
+        );
+    });
+
+    it("should reject a response without required fees", () => {
+        const { fees: _, ...noFees } = buildQuoteResponse();
+        expect(() => RelayQuoteResponseSchema.parse(noFees)).toThrow(ZodError);
+    });
+
+    it("should reject a response without required details", () => {
+        const { details: _, ...noDetails } = buildQuoteResponse();
+        expect(() => RelayQuoteResponseSchema.parse(noDetails)).toThrow(ZodError);
+    });
+
+    it("should reject a response without required protocol", () => {
+        const { protocol: _, ...noProtocol } = buildQuoteResponse();
+        expect(() => RelayQuoteResponseSchema.parse(noProtocol)).toThrow(ZodError);
     });
 
     it("should reject an invalid address format in step item data", () => {
-        const invalidAddress = "not-an-address";
-        const invalid = {
-            ...validQuoteResponse,
+        const response = buildQuoteResponse({
             steps: [
-                {
-                    ...validQuoteResponse.steps[0],
+                buildStep({
                     items: [
-                        {
-                            status: "incomplete",
-                            data: {
-                                to: invalidAddress,
-                                data: "0x00",
-                                chainId: ORIGIN_CHAIN_ID,
-                            },
-                        },
+                        buildStepItem({
+                            data: { to: "not-an-address", data: TX_DATA, chainId: ORIGIN_CHAIN_ID },
+                        }),
                     ],
-                },
+                }),
             ],
-        };
-        expect(() => RelayQuoteResponseSchema.parse(invalid)).toThrow(ZodError);
+        });
+        expect(() => RelayQuoteResponseSchema.parse(response)).toThrow(ZodError);
     });
 
     it("should reject a step with missing requestId", () => {
-        const { requestId: _, ...stepWithoutId } = validQuoteResponse.steps[0]!;
-        const invalid = { ...validQuoteResponse, steps: [stepWithoutId] };
-        expect(() => RelayQuoteResponseSchema.parse(invalid)).toThrow(ZodError);
+        const step = buildStep();
+        const { requestId: _, ...stepWithoutId } = step;
+        expect(() =>
+            RelayQuoteResponseSchema.parse(buildQuoteResponse({ steps: [stepWithoutId] })),
+        ).toThrow(ZodError);
     });
 
     it("should accept a step with kind 'signature'", () => {
-        const signatureStep = {
-            ...validQuoteResponse.steps[0],
-            kind: "signature",
-        };
-        const response = { steps: [signatureStep] };
+        const response = buildQuoteResponse({
+            steps: [buildStep({ kind: "signature" })],
+        });
         const result = RelayQuoteResponseSchema.parse(response);
         expect(result.steps[0]!.kind).toBe("signature");
     });
 
     it("should accept a step item with status 'complete'", () => {
-        const response = {
-            steps: [
-                {
-                    ...validQuoteResponse.steps[0],
-                    items: [
-                        {
-                            status: "complete",
-                            data: {
-                                to: VALID_ADDRESS,
-                                data: TX_DATA,
-                                chainId: ORIGIN_CHAIN_ID,
-                            },
-                        },
-                    ],
-                },
-            ],
-        };
+        const response = buildQuoteResponse({
+            steps: [buildStep({ items: [buildStepItem({ status: "complete" })] })],
+        });
         const result = RelayQuoteResponseSchema.parse(response);
         expect(result.steps[0]!.items[0]!.status).toBe("complete");
     });
 
-    it("should accept a currency with metadata", () => {
-        const logoURI = "https://example.com/usdc.png";
-        const response = {
-            ...validQuoteResponse,
-            details: {
-                ...validQuoteResponse.details,
-                currencyOut: {
-                    currency: {
-                        ...USDC_CURRENCY,
-                        metadata: {
-                            logoURI,
-                            verified: true,
-                            isNative: false,
-                        },
-                    },
-                    amount: OUTPUT_AMOUNT,
-                },
-            },
-        };
-        const result = RelayQuoteResponseSchema.parse(response);
-        expect(result.details?.currencyOut?.currency.metadata?.logoURI).toBe(logoURI);
-        expect(result.details?.currencyOut?.currency.metadata?.verified).toBe(true);
-    });
-
     it("should strip unknown fields from response", () => {
-        const response = {
-            ...validQuoteResponse,
-            unknownTopLevel: "stripped",
-        };
-        const result = RelayQuoteResponseSchema.parse(response);
+        const result = RelayQuoteResponseSchema.parse(
+            buildQuoteResponse({ unknownTopLevel: "stripped" }),
+        );
         expect(result).not.toHaveProperty("unknownTopLevel");
     });
 
     it("should reject a step with empty items array", () => {
-        const response = {
-            steps: [
-                {
-                    ...validQuoteResponse.steps[0],
-                    items: [],
-                },
-            ],
-        };
-        expect(() => RelayQuoteResponseSchema.parse(response)).toThrow(ZodError);
+        expect(() =>
+            RelayQuoteResponseSchema.parse(
+                buildQuoteResponse({ steps: [buildStep({ items: [] })] }),
+            ),
+        ).toThrow(ZodError);
     });
 
     it("should reject an invalid step kind", () => {
-        const response = {
-            steps: [
-                {
-                    ...validQuoteResponse.steps[0],
-                    kind: "unknown-kind",
-                },
-            ],
-        };
-        expect(() => RelayQuoteResponseSchema.parse(response)).toThrow(ZodError);
+        expect(() =>
+            RelayQuoteResponseSchema.parse(
+                buildQuoteResponse({ steps: [buildStep({ kind: "unknown-kind" })] }),
+            ),
+        ).toThrow(ZodError);
     });
 
     it("should reject an invalid step item status", () => {
-        const response = {
-            steps: [
-                {
-                    ...validQuoteResponse.steps[0],
-                    items: [
-                        {
-                            status: "unknown-status",
-                            data: {
-                                to: VALID_ADDRESS,
-                                data: TX_DATA,
-                                chainId: ORIGIN_CHAIN_ID,
-                            },
-                        },
-                    ],
-                },
-            ],
-        };
-        expect(() => RelayQuoteResponseSchema.parse(response)).toThrow(ZodError);
+        expect(() =>
+            RelayQuoteResponseSchema.parse(
+                buildQuoteResponse({
+                    steps: [buildStep({ items: [buildStepItem({ status: "unknown-status" })] })],
+                }),
+            ),
+        ).toThrow(ZodError);
     });
 });
 
+// ── Intent Status Tests ──────────────────────────────────
+
 describe("RelayIntentStatusResponseSchema", () => {
-    it.each([
-        "waiting",
-        "pending",
-        "submitted",
-        "success",
-        "delayed",
-        "refunded",
-        "failure",
-        "refund",
-    ] as const)("should accept status '%s'", (status) => {
-        const result = RelayIntentStatusResponseSchema.parse({ status });
-        expect(result.status).toBe(status);
-    });
+    it.each(["waiting", "pending", "submitted", "success", "failure", "refund"] as const)(
+        "should accept status '%s'",
+        (status) => {
+            const result = RelayIntentStatusResponseSchema.parse({ status });
+            expect(result.status).toBe(status);
+        },
+    );
 
     it("should accept a full status response with all fields", () => {
         const result = RelayIntentStatusResponseSchema.parse({
             status: "success",
-            details: "Transfer complete",
+            details: SAMPLE_STATUS_DETAILS,
             inTxHashes: [SAMPLE_IN_TX_HASH],
             txHashes: [SAMPLE_OUT_TX_HASH],
             updatedAt: SAMPLE_UPDATED_AT,
@@ -396,6 +372,8 @@ describe("RelayIntentStatusResponseSchema", () => {
     });
 });
 
+// ── Error Response Tests ─────────────────────────────────
+
 describe("RelayBadRequestResponseSchema", () => {
     it("should accept a minimal bad request response", () => {
         const result = RelayBadRequestResponseSchema.parse({
@@ -410,7 +388,7 @@ describe("RelayBadRequestResponseSchema", () => {
         const result = RelayBadRequestResponseSchema.parse({
             message: SAMPLE_ERROR_MESSAGE,
             errorCode: SAMPLE_ERROR_CODE,
-            errorData: "additional error context",
+            errorData: SAMPLE_ERROR_DATA,
             requestId: REQUEST_ID,
             approxSimulatedBlock: SAMPLE_SIMULATED_BLOCK,
             failedCallData: {
@@ -424,7 +402,7 @@ describe("RelayBadRequestResponseSchema", () => {
         expect(result.approxSimulatedBlock).toBe(SAMPLE_SIMULATED_BLOCK);
     });
 
-    it("should reject a response without required fields", () => {
+    it("should reject a response without errorCode", () => {
         expect(() =>
             RelayBadRequestResponseSchema.parse({ message: SAMPLE_ERROR_MESSAGE }),
         ).toThrow(ZodError);
@@ -434,25 +412,25 @@ describe("RelayBadRequestResponseSchema", () => {
 describe("RelayUnauthorizedResponseSchema", () => {
     it("should accept a valid unauthorized response", () => {
         const result = RelayUnauthorizedResponseSchema.parse({
-            message: "Unauthorized",
-            errorCode: "UNAUTHORIZED",
+            message: SAMPLE_ERROR_MESSAGE,
+            errorCode: SAMPLE_ERROR_CODE,
         });
-        expect(result.message).toBe("Unauthorized");
+        expect(result.message).toBe(SAMPLE_ERROR_MESSAGE);
     });
 
     it("should reject a response without errorCode", () => {
-        expect(() => RelayUnauthorizedResponseSchema.parse({ message: "Unauthorized" })).toThrow(
-            ZodError,
-        );
+        expect(() =>
+            RelayUnauthorizedResponseSchema.parse({ message: SAMPLE_ERROR_MESSAGE }),
+        ).toThrow(ZodError);
     });
 });
 
 describe("RelayRateLimitedResponseSchema", () => {
     it("should accept a valid rate limited response", () => {
         const result = RelayRateLimitedResponseSchema.parse({
-            message: "Rate limit exceeded",
+            message: SAMPLE_ERROR_MESSAGE,
         });
-        expect(result.message).toBe("Rate limit exceeded");
+        expect(result.message).toBe(SAMPLE_ERROR_MESSAGE);
     });
 
     it("should reject a response without message", () => {
@@ -463,16 +441,16 @@ describe("RelayRateLimitedResponseSchema", () => {
 describe("RelayServerErrorResponseSchema", () => {
     it("should accept a minimal server error response", () => {
         const result = RelayServerErrorResponseSchema.parse({
-            message: "Internal server error",
-            errorCode: "INTERNAL_ERROR",
+            message: SAMPLE_ERROR_MESSAGE,
+            errorCode: SAMPLE_ERROR_CODE,
         });
-        expect(result.message).toBe("Internal server error");
+        expect(result.message).toBe(SAMPLE_ERROR_MESSAGE);
     });
 
     it("should accept a server error response with requestId", () => {
         const result = RelayServerErrorResponseSchema.parse({
-            message: "Internal server error",
-            errorCode: "INTERNAL_ERROR",
+            message: SAMPLE_ERROR_MESSAGE,
+            errorCode: SAMPLE_ERROR_CODE,
             requestId: REQUEST_ID,
         });
         expect(result.requestId).toBe(REQUEST_ID);
@@ -480,7 +458,7 @@ describe("RelayServerErrorResponseSchema", () => {
 
     it("should reject a response without errorCode", () => {
         expect(() =>
-            RelayServerErrorResponseSchema.parse({ message: "Internal server error" }),
+            RelayServerErrorResponseSchema.parse({ message: SAMPLE_ERROR_MESSAGE }),
         ).toThrow(ZodError);
     });
 });

--- a/packages/cross-chain/test/protocols/relay/schemas.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/schemas.spec.ts
@@ -201,13 +201,13 @@ function buildQuoteResponse(overrides?: Record<string, unknown>): Record<string,
 // ── Quote Response Tests ─────────────────────────────────
 
 describe("RelayQuoteResponseSchema", () => {
-    it("should accept a valid quote response", () => {
+    it("accepts a valid quote response", () => {
         const result = RelayQuoteResponseSchema.parse(buildQuoteResponse());
         expect(result.steps).toHaveLength(1);
         expect(result.steps[0]!.requestId).toBe(REQUEST_ID);
     });
 
-    it("should accept a full response with all optional fields", () => {
+    it("accepts a full response with all optional fields", () => {
         const response = buildQuoteResponse({
             fees: {
                 gas: buildFee(GAS_FEE_AMOUNT, GAS_FEE_USD),
@@ -237,7 +237,7 @@ describe("RelayQuoteResponseSchema", () => {
         expect(result.protocol.v2.orderId).toBe(ORDER_ID);
     });
 
-    it("should accept a step with depositAddress", () => {
+    it("accepts a step with depositAddress", () => {
         const response = buildQuoteResponse({
             steps: [buildStep({ depositAddress: DEPOSIT_ADDRESS })],
         });
@@ -245,29 +245,29 @@ describe("RelayQuoteResponseSchema", () => {
         expect(result.steps[0]!.depositAddress).toBe(DEPOSIT_ADDRESS);
     });
 
-    it("should reject a response with empty steps", () => {
+    it("rejects a response with empty steps", () => {
         expect(() => RelayQuoteResponseSchema.parse(buildQuoteResponse({ steps: [] }))).toThrow(
             ZodError,
         );
     });
 
-    it("should reject a response without required fees", () => {
+    it("rejects a response without required fees", () => {
         const { fees: _, ...noFees } = buildQuoteResponse();
         expect(() => RelayQuoteResponseSchema.parse(noFees)).toThrow(ZodError);
     });
 
-    it("should reject a response without required details", () => {
+    it("rejects a response without required details", () => {
         const { details: _, ...noDetails } = buildQuoteResponse();
         expect(() => RelayQuoteResponseSchema.parse(noDetails)).toThrow(ZodError);
     });
 
-    it("should accept a response without protocol (same-chain swaps)", () => {
+    it("accepts a response without protocol (same-chain swaps)", () => {
         const { protocol: _, ...noProtocol } = buildQuoteResponse();
         const result = RelayQuoteResponseSchema.parse(noProtocol);
         expect(result.protocol).toBeUndefined();
     });
 
-    it("should reject an invalid address format in step item data", () => {
+    it("rejects an invalid address format in step item data", () => {
         const response = buildQuoteResponse({
             steps: [
                 buildStep({
@@ -282,7 +282,7 @@ describe("RelayQuoteResponseSchema", () => {
         expect(() => RelayQuoteResponseSchema.parse(response)).toThrow(ZodError);
     });
 
-    it("should reject a step with missing requestId", () => {
+    it("rejects a step with missing requestId", () => {
         const step = buildStep();
         const { requestId: _, ...stepWithoutId } = step;
         expect(() =>
@@ -290,7 +290,7 @@ describe("RelayQuoteResponseSchema", () => {
         ).toThrow(ZodError);
     });
 
-    it("should accept a step with kind 'signature'", () => {
+    it("accepts a step with kind 'signature'", () => {
         const response = buildQuoteResponse({
             steps: [buildStep({ kind: "signature" })],
         });
@@ -298,7 +298,7 @@ describe("RelayQuoteResponseSchema", () => {
         expect(result.steps[0]!.kind).toBe("signature");
     });
 
-    it("should accept a step item with status 'complete'", () => {
+    it("accepts a step item with status 'complete'", () => {
         const response = buildQuoteResponse({
             steps: [buildStep({ items: [buildStepItem({ status: "complete" })] })],
         });
@@ -306,14 +306,14 @@ describe("RelayQuoteResponseSchema", () => {
         expect(result.steps[0]!.items[0]!.status).toBe("complete");
     });
 
-    it("should strip unknown fields from response", () => {
+    it("strips unknown fields from response", () => {
         const result = RelayQuoteResponseSchema.parse(
             buildQuoteResponse({ unknownTopLevel: "stripped" }),
         );
         expect(result).not.toHaveProperty("unknownTopLevel");
     });
 
-    it("should reject a step with empty items array", () => {
+    it("rejects a step with empty items array", () => {
         expect(() =>
             RelayQuoteResponseSchema.parse(
                 buildQuoteResponse({ steps: [buildStep({ items: [] })] }),
@@ -321,7 +321,7 @@ describe("RelayQuoteResponseSchema", () => {
         ).toThrow(ZodError);
     });
 
-    it("should reject an invalid step kind", () => {
+    it("rejects an invalid step kind", () => {
         expect(() =>
             RelayQuoteResponseSchema.parse(
                 buildQuoteResponse({ steps: [buildStep({ kind: "unknown-kind" })] }),
@@ -329,7 +329,7 @@ describe("RelayQuoteResponseSchema", () => {
         ).toThrow(ZodError);
     });
 
-    it("should reject an invalid step item status", () => {
+    it("rejects an invalid step item status", () => {
         expect(() =>
             RelayQuoteResponseSchema.parse(
                 buildQuoteResponse({
@@ -344,14 +344,14 @@ describe("RelayQuoteResponseSchema", () => {
 
 describe("RelayIntentStatusResponseSchema", () => {
     it.each(["waiting", "pending", "submitted", "success", "failure", "refund"] as const)(
-        "should accept status '%s'",
+        "accepts status '%s'",
         (status) => {
             const result = RelayIntentStatusResponseSchema.parse({ status });
             expect(result.status).toBe(status);
         },
     );
 
-    it("should accept a full status response with all fields", () => {
+    it("accepts a full status response with all fields", () => {
         const result = RelayIntentStatusResponseSchema.parse({
             status: "success",
             details: SAMPLE_STATUS_DETAILS,
@@ -366,7 +366,7 @@ describe("RelayIntentStatusResponseSchema", () => {
         expect(result.txHashes).toEqual([SAMPLE_OUT_TX_HASH]);
     });
 
-    it("should reject an invalid status value", () => {
+    it("rejects an invalid status value", () => {
         expect(() => RelayIntentStatusResponseSchema.parse({ status: "invalid" })).toThrow(
             ZodError,
         );
@@ -376,7 +376,7 @@ describe("RelayIntentStatusResponseSchema", () => {
 // ── Error Response Tests ─────────────────────────────────
 
 describe("RelayBadRequestResponseSchema", () => {
-    it("should accept a minimal bad request response", () => {
+    it("accepts a minimal bad request response", () => {
         const result = RelayBadRequestResponseSchema.parse({
             message: SAMPLE_ERROR_MESSAGE,
             errorCode: SAMPLE_ERROR_CODE,
@@ -385,7 +385,7 @@ describe("RelayBadRequestResponseSchema", () => {
         expect(result.errorCode).toBe(SAMPLE_ERROR_CODE);
     });
 
-    it("should accept a full bad request response with failedCallData", () => {
+    it("accepts a full bad request response with failedCallData", () => {
         const result = RelayBadRequestResponseSchema.parse({
             message: SAMPLE_ERROR_MESSAGE,
             errorCode: SAMPLE_ERROR_CODE,
@@ -403,7 +403,7 @@ describe("RelayBadRequestResponseSchema", () => {
         expect(result.approxSimulatedBlock).toBe(SAMPLE_SIMULATED_BLOCK);
     });
 
-    it("should reject a response without errorCode", () => {
+    it("rejects a response without errorCode", () => {
         expect(() =>
             RelayBadRequestResponseSchema.parse({ message: SAMPLE_ERROR_MESSAGE }),
         ).toThrow(ZodError);
@@ -411,7 +411,7 @@ describe("RelayBadRequestResponseSchema", () => {
 });
 
 describe("RelayUnauthorizedResponseSchema", () => {
-    it("should accept a valid unauthorized response", () => {
+    it("accepts a valid unauthorized response", () => {
         const result = RelayUnauthorizedResponseSchema.parse({
             message: SAMPLE_ERROR_MESSAGE,
             errorCode: SAMPLE_ERROR_CODE,
@@ -419,7 +419,7 @@ describe("RelayUnauthorizedResponseSchema", () => {
         expect(result.message).toBe(SAMPLE_ERROR_MESSAGE);
     });
 
-    it("should reject a response without errorCode", () => {
+    it("rejects a response without errorCode", () => {
         expect(() =>
             RelayUnauthorizedResponseSchema.parse({ message: SAMPLE_ERROR_MESSAGE }),
         ).toThrow(ZodError);
@@ -427,20 +427,20 @@ describe("RelayUnauthorizedResponseSchema", () => {
 });
 
 describe("RelayRateLimitedResponseSchema", () => {
-    it("should accept a valid rate limited response", () => {
+    it("accepts a valid rate limited response", () => {
         const result = RelayRateLimitedResponseSchema.parse({
             message: SAMPLE_ERROR_MESSAGE,
         });
         expect(result.message).toBe(SAMPLE_ERROR_MESSAGE);
     });
 
-    it("should reject a response without message", () => {
+    it("rejects a response without message", () => {
         expect(() => RelayRateLimitedResponseSchema.parse({})).toThrow(ZodError);
     });
 });
 
 describe("RelayServerErrorResponseSchema", () => {
-    it("should accept a minimal server error response", () => {
+    it("accepts a minimal server error response", () => {
         const result = RelayServerErrorResponseSchema.parse({
             message: SAMPLE_ERROR_MESSAGE,
             errorCode: SAMPLE_ERROR_CODE,
@@ -448,7 +448,7 @@ describe("RelayServerErrorResponseSchema", () => {
         expect(result.message).toBe(SAMPLE_ERROR_MESSAGE);
     });
 
-    it("should accept a server error response with requestId", () => {
+    it("accepts a server error response with requestId", () => {
         const result = RelayServerErrorResponseSchema.parse({
             message: SAMPLE_ERROR_MESSAGE,
             errorCode: SAMPLE_ERROR_CODE,
@@ -457,7 +457,7 @@ describe("RelayServerErrorResponseSchema", () => {
         expect(result.requestId).toBe(REQUEST_ID);
     });
 
-    it("should reject a response without errorCode", () => {
+    it("rejects a response without errorCode", () => {
         expect(() =>
             RelayServerErrorResponseSchema.parse({ message: SAMPLE_ERROR_MESSAGE }),
         ).toThrow(ZodError);

--- a/packages/cross-chain/test/protocols/relay/schemas.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/schemas.spec.ts
@@ -272,45 +272,33 @@ describe("RelayQuoteResponseSchema", () => {
         expect(result.steps[0]!.requestId).toBe(REQUEST_ID);
     });
 
-    it("accepts expanded price impact in details", () => {
-        const response = buildQuoteResponse({ details: buildDetails() });
-        const result = RelayQuoteResponseSchema.parse(response);
-        expect(result.details?.expandedPriceImpact?.swap?.usd).toBe(SAMPLE_PRICE_IMPACT_USD);
-    });
-
-    it("accepts slippage tolerance in details", () => {
-        const response = buildQuoteResponse({ details: buildDetails() });
-        const result = RelayQuoteResponseSchema.parse(response);
-        expect(result.details?.slippageTolerance?.origin?.percent).toBe(SAMPLE_SLIPPAGE_PERCENT);
-    });
-
-    it("accepts route in details", () => {
-        const response = buildQuoteResponse({ details: buildDetails() });
-        const result = RelayQuoteResponseSchema.parse(response);
-        expect(result.details?.route?.origin?.router).toBe(SAMPLE_ROUTER);
-    });
-
-    it("accepts refund currency in details", () => {
+    it("accepts a full response with all optional fields", () => {
         const response = buildQuoteResponse({
-            details: buildDetails({ refundCurrency: buildCurrencyAmount(INPUT_AMOUNT) }),
-        });
-        const result = RelayQuoteResponseSchema.parse(response);
-        expect(result.details?.refundCurrency?.amount).toBe(INPUT_AMOUNT);
-    });
-
-    it("accepts fallback type in details", () => {
-        const response = buildQuoteResponse({
-            details: buildDetails({ fallbackType: SAMPLE_FALLBACK_TYPE }),
-        });
-        const result = RelayQuoteResponseSchema.parse(response);
-        expect(result.details?.fallbackType).toBe(SAMPLE_FALLBACK_TYPE);
-    });
-
-    it("accepts protocol with order data", () => {
-        const response = buildQuoteResponse({
+            fees: {
+                gas: buildFee(GAS_FEE_AMOUNT, GAS_FEE_USD),
+                relayer: buildFee(RELAYER_FEE_AMOUNT, RELAYER_FEE_USD),
+                relayerGas: buildFee(GAS_FEE_AMOUNT, GAS_FEE_USD),
+                relayerService: buildFee(RELAYER_FEE_AMOUNT, RELAYER_FEE_USD),
+                app: buildFee(ZERO_AMOUNT, ZERO_AMOUNT),
+                subsidized: buildFee(ZERO_AMOUNT, ZERO_AMOUNT),
+            },
+            details: buildDetails({
+                refundCurrency: buildCurrencyAmount(INPUT_AMOUNT),
+                currencyGasTopup: buildCurrencyAmount(GAS_FEE_AMOUNT),
+                fallbackType: SAMPLE_FALLBACK_TYPE,
+                isFixedRate: true,
+                fixedRateFee: { usd: SAMPLE_PRICE_IMPACT_USD },
+            }),
             protocol: buildProtocol({ orderData: { some: "data" } }),
         });
+
         const result = RelayQuoteResponseSchema.parse(response);
+
+        expect(result.details?.expandedPriceImpact?.swap?.usd).toBe(SAMPLE_PRICE_IMPACT_USD);
+        expect(result.details?.slippageTolerance?.origin?.percent).toBe(SAMPLE_SLIPPAGE_PERCENT);
+        expect(result.details?.route?.origin?.router).toBe(SAMPLE_ROUTER);
+        expect(result.details?.refundCurrency?.amount).toBe(INPUT_AMOUNT);
+        expect(result.details?.fallbackType).toBe(SAMPLE_FALLBACK_TYPE);
         expect(result.protocol?.v2?.orderId).toBe(ORDER_ID);
     });
 

--- a/packages/cross-chain/test/protocols/relay/schemas.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/schemas.spec.ts
@@ -47,7 +47,6 @@ const SAMPLE_FALLBACK_TYPE = "canonical";
 const SAMPLE_ERROR_DATA = "additional error context";
 const SAMPLE_STATUS_DETAILS = "Transfer complete";
 const ZERO_AMOUNT = "0";
-const DEPOSIT_ADDRESS = "0xdeposit1234567890abcdef1234567890abcdef";
 const PAYMENT_CHAIN_ID = "1";
 
 // ── Helpers ──────────────────────────────────────────────
@@ -262,11 +261,6 @@ describe("RelayIntentStatusRequestSchema", () => {
         const result = RelayIntentStatusRequestSchema.parse({ requestId: REQUEST_ID });
         expect(result.requestId).toBe(REQUEST_ID);
     });
-
-    it("accepts an empty request", () => {
-        const result = RelayIntentStatusRequestSchema.parse({});
-        expect(result.requestId).toBeUndefined();
-    });
 });
 
 // ── Quote Response Tests ─────────────────────────────────
@@ -306,14 +300,6 @@ describe("RelayQuoteResponseSchema", () => {
         expect(result.details?.refundCurrency?.amount).toBe(INPUT_AMOUNT);
         expect(result.details?.fallbackType).toBe(SAMPLE_FALLBACK_TYPE);
         expect(result.protocol?.v2?.orderId).toBe(ORDER_ID);
-    });
-
-    it("accepts a step with depositAddress", () => {
-        const response = buildQuoteResponse({
-            steps: [buildStep({ depositAddress: DEPOSIT_ADDRESS })],
-        });
-        const result = RelayQuoteResponseSchema.parse(response);
-        expect(result.steps[0]!.depositAddress).toBe(DEPOSIT_ADDRESS);
     });
 
     it("rejects a response with empty steps", () => {
@@ -372,43 +358,10 @@ describe("RelayQuoteResponseSchema", () => {
         expect(result.steps[0]!.kind).toBe("signature");
     });
 
-    it("accepts a step item with status 'complete'", () => {
-        const response = buildQuoteResponse({
-            steps: [buildStep({ items: [buildStepItem({ status: "complete" })] })],
-        });
-        const result = RelayQuoteResponseSchema.parse(response);
-        expect(result.steps[0]!.items[0]!.status).toBe("complete");
-    });
-
-    it("strips unknown fields from response", () => {
-        const result = RelayQuoteResponseSchema.parse(
-            buildQuoteResponse({ unknownTopLevel: "stripped" }),
-        );
-        expect(result).not.toHaveProperty("unknownTopLevel");
-    });
-
     it("rejects a step with empty items array", () => {
         expect(() =>
             RelayQuoteResponseSchema.parse(
                 buildQuoteResponse({ steps: [buildStep({ items: [] })] }),
-            ),
-        ).toThrow(ZodError);
-    });
-
-    it("rejects an invalid step kind", () => {
-        expect(() =>
-            RelayQuoteResponseSchema.parse(
-                buildQuoteResponse({ steps: [buildStep({ kind: "unknown-kind" })] }),
-            ),
-        ).toThrow(ZodError);
-    });
-
-    it("rejects an invalid step item status", () => {
-        expect(() =>
-            RelayQuoteResponseSchema.parse(
-                buildQuoteResponse({
-                    steps: [buildStep({ items: [buildStepItem({ status: "unknown-status" })] })],
-                }),
             ),
         ).toThrow(ZodError);
     });
@@ -492,12 +445,6 @@ describe("RelayUnauthorizedResponseSchema", () => {
         });
         expect(result.message).toBe(SAMPLE_ERROR_MESSAGE);
     });
-
-    it("rejects a response without errorCode", () => {
-        expect(() =>
-            RelayUnauthorizedResponseSchema.parse({ message: SAMPLE_ERROR_MESSAGE }),
-        ).toThrow(ZodError);
-    });
 });
 
 describe("RelayRateLimitedResponseSchema", () => {
@@ -507,21 +454,9 @@ describe("RelayRateLimitedResponseSchema", () => {
         });
         expect(result.message).toBe(SAMPLE_ERROR_MESSAGE);
     });
-
-    it("rejects a response without message", () => {
-        expect(() => RelayRateLimitedResponseSchema.parse({})).toThrow(ZodError);
-    });
 });
 
 describe("RelayServerErrorResponseSchema", () => {
-    it("accepts a minimal server error response", () => {
-        const result = RelayServerErrorResponseSchema.parse({
-            message: SAMPLE_ERROR_MESSAGE,
-            errorCode: SAMPLE_ERROR_CODE,
-        });
-        expect(result.message).toBe(SAMPLE_ERROR_MESSAGE);
-    });
-
     it("accepts a server error response with requestId", () => {
         const result = RelayServerErrorResponseSchema.parse({
             message: SAMPLE_ERROR_MESSAGE,
@@ -529,11 +464,5 @@ describe("RelayServerErrorResponseSchema", () => {
             requestId: REQUEST_ID,
         });
         expect(result.requestId).toBe(REQUEST_ID);
-    });
-
-    it("rejects a response without errorCode", () => {
-        expect(() =>
-            RelayServerErrorResponseSchema.parse({ message: SAMPLE_ERROR_MESSAGE }),
-        ).toThrow(ZodError);
     });
 });


### PR DESCRIPTION
## Summary

Adds Zod validation schemas and TypeScript types for the Relay cross-chain protocol API. This lays the type foundation for the upcoming Relay provider implementation.

Covers the two endpoints needed to integrate Relay as a bridge provider:
- [`POST /quote/v2`](https://docs.relay.link/references/api/get-quote-v2) — request body and response
- [`GET /intents/status/v3`](https://docs.relay.link/references/api/get-intents-status-v3) — query parameters and response
- Error responses (400, 401, 429, 500)
- Provider configuration (`RelayConfigSchema`)

All schemas are aligned with the [official Relay OpenAPI spec](https://docs.relay.link/references/api/overview).

## Test plan

- [x] 30 unit tests passing
- [x] Type-checks pass
- [x] Lint and format pass