### PR TITLE
feat(cross-chain): add RelayProvider implementation

### DIFF
--- a/examples/ui/app/cross-chain/constants/providers.ts
+++ b/examples/ui/app/cross-chain/constants/providers.ts
@@ -15,6 +15,11 @@ export const PROVIDERS: ProviderConfig[] = [
       providerId: 'across',
     },
   },
+  {
+    id: PROTOCOLS.RELAY,
+    displayName: 'Relay',
+    config: { providerId: 'relay' },
+  },
 ];
 
 /**

--- a/examples/ui/app/cross-chain/services/orderExecution/flows.ts
+++ b/examples/ui/app/cross-chain/services/orderExecution/flows.ts
@@ -68,38 +68,44 @@ export const executeDirectTransaction = async ({
   onStateChange,
 }: FlowParams): Promise<TrackingIdentifier> => {
   const txSteps = getTransactionSteps(quote.order);
-  const txStep = txSteps[0];
 
-  if (!txStep?.transaction?.to || !txStep?.transaction?.data) {
-    throw new Error('Invalid quote: missing transaction data');
+  if (txSteps.length === 0) {
+    throw new Error('Invalid quote: no transaction steps');
   }
 
   const isNativeInput = isNativeAddress(inputTokenAddress, 'eip155');
+  let lastTxHash: Hex | undefined;
 
-  if (!isNativeInput) {
-    await handleTokenApproval(
+  for (const txStep of txSteps) {
+    if (!txStep.transaction?.to || !txStep.transaction?.data) {
+      throw new Error('Invalid quote: missing transaction data');
+    }
+
+    if (!isNativeInput) {
+      await handleTokenApproval(
+        publicClient,
+        walletClient,
+        ownerAddress,
+        inputTokenAddress,
+        txStep.transaction.to as Address,
+        inputAmount,
+        chainContext,
+        onStateChange,
+      );
+    }
+
+    const value = isNativeInput ? inputAmount : undefined;
+
+    lastTxHash = await submitBridgeTransaction(
       publicClient,
       walletClient,
-      ownerAddress,
-      inputTokenAddress,
       txStep.transaction.to as Address,
-      inputAmount,
+      txStep.transaction.data as Hex,
       chainContext,
       onStateChange,
+      value,
     );
   }
 
-  const value = isNativeInput ? inputAmount : undefined;
-
-  const txHash = await submitBridgeTransaction(
-    publicClient,
-    walletClient,
-    txStep.transaction.to as Address,
-    txStep.transaction.data as Hex,
-    chainContext,
-    onStateChange,
-    value,
-  );
-
-  return { txHash };
+  return { txHash: lastTxHash! };
 };

--- a/examples/ui/app/cross-chain/services/sdk.ts
+++ b/examples/ui/app/cross-chain/services/sdk.ts
@@ -14,6 +14,8 @@ const RPC_URLS = IS_TESTNET ? TESTNET_RPC_URLS : MAINNET_RPC_URLS;
 const OIF_API_URL = 'https://oif-api.openzeppelin.com/api';
 const OIF_SOLVER_ID = IS_TESTNET ? 'testnet-solver' : 'mainnet-solver';
 
+const RELAY_API_URL = IS_TESTNET ? 'https://api.testnets.relay.link' : 'https://api.relay.link';
+
 /**
  * Provider configuration with display names
  */
@@ -46,6 +48,7 @@ const providers: CrossChainProvider[] = [
     providerId: 'oif',
   }),
   createCrossChainProvider(PROTOCOLS.RELAY, {
+    baseUrl: RELAY_API_URL,
     providerId: 'relay',
   }),
 ];

--- a/examples/ui/app/cross-chain/services/sdk.ts
+++ b/examples/ui/app/cross-chain/services/sdk.ts
@@ -26,6 +26,10 @@ const PROVIDER_CONFIGS = [
     providerId: 'oif',
     displayName: 'OIF Sample Solver',
   },
+  {
+    providerId: 'relay',
+    displayName: 'Relay',
+  },
 ];
 
 /**
@@ -40,6 +44,9 @@ const providers: CrossChainProvider[] = [
     solverId: OIF_SOLVER_ID,
     url: OIF_API_URL,
     providerId: 'oif',
+  }),
+  createCrossChainProvider(PROTOCOLS.RELAY, {
+    providerId: 'relay',
   }),
 ];
 

--- a/packages/cross-chain/src/core/errors/ProviderGetStatusFailure.exception.ts
+++ b/packages/cross-chain/src/core/errors/ProviderGetStatusFailure.exception.ts
@@ -1,0 +1,7 @@
+import { BaseError } from "./BaseError.exception.js";
+
+export class ProviderGetStatusFailure extends BaseError {
+    constructor(message: string, cause?: string, stack?: string) {
+        super(message, cause, stack);
+    }
+}

--- a/packages/cross-chain/src/core/errors/index.ts
+++ b/packages/cross-chain/src/core/errors/index.ts
@@ -6,6 +6,7 @@ export * from "./UnsupportedProtocol.exception.js";
 export * from "./ProviderNotFound.exception.js";
 export * from "./UnsupportedAddress.exception.js";
 export * from "./ProviderGetQuoteFailure.exception.js";
+export * from "./ProviderGetStatusFailure.exception.js";
 export * from "./ProviderExecuteNotImplemented.exception.js";
 export * from "./ProviderExecuteFailure.exception.js";
 export * from "./ProviderTimeout.exception.js";

--- a/packages/cross-chain/src/core/interfaces/openedIntentParser.interface.ts
+++ b/packages/cross-chain/src/core/interfaces/openedIntentParser.interface.ts
@@ -58,15 +58,28 @@ export interface CustomEventOpenedIntentParserConfig {
 }
 
 /**
- * Configuration for API-based opened intent parsing (future)
+ * Configuration for API-based opened intent parsing.
+ * Allows protocols to define how to fetch and extract OpenedIntent data from their own APIs.
+ *
+ * @typeParam TResponse - Expected shape of the API response for type-safe extraction
  */
-export interface APIOpenedIntentParserConfig {
+export interface APIOpenedIntentParserConfig<TResponse = unknown> {
     /** Protocol name for error messages */
     protocolName: string;
-    /** API endpoint URL */
-    endpoint: string;
-    /** Function to extract OpenedIntent from API response */
-    extractOpenedIntent: (response: unknown, txHash: Hex) => OpenedIntent;
+    /** Optional custom headers (e.g. for authentication) */
+    headers?: Record<string, string>;
+    /**
+     * Build the full URL to fetch intent data.
+     * @param txHash - Transaction hash to look up
+     * @param chainId - Chain ID where the transaction occurred
+     * @example (txHash) => `https://api.relay.link/intents/status/v3?requestId=${txHash}`
+     */
+    buildUrl: (txHash: Hex, chainId: number) => string;
+    /**
+     * Extract and validate OpenedIntent from API response.
+     * Should throw {@link OpenedIntentNotFoundError} if the response does not contain valid data.
+     */
+    extractOpenedIntent: (response: TResponse, txHash: Hex) => OpenedIntent;
 }
 
 /**

--- a/packages/cross-chain/src/core/services/APIOpenedIntentParser.ts
+++ b/packages/cross-chain/src/core/services/APIOpenedIntentParser.ts
@@ -1,0 +1,46 @@
+import type { Hex } from "viem";
+
+import type {
+    APIOpenedIntentParserConfig,
+    OpenedIntentParser,
+} from "../interfaces/openedIntentParser.interface.js";
+import type { OpenedIntent } from "../types/orderTracking.js";
+import { OpenedIntentNotFoundError } from "../errors/OpenedIntentNotFound.exception.js";
+
+/**
+ * API-based opened intent parser.
+ * Fetches intent data from a protocol's HTTP API instead of parsing on-chain events.
+ *
+ * Used by protocols like Relay that don't emit standard on-chain open events
+ * and instead track intents via their own API.
+ */
+export class APIOpenedIntentParser<TResponse = unknown> implements OpenedIntentParser {
+    constructor(private readonly config: APIOpenedIntentParserConfig<TResponse>) {}
+
+    /**
+     * Fetch opened intent information from the configured API endpoint.
+     *
+     * @param txHash - Transaction hash to look up
+     * @param chainId - Chain ID where the transaction occurred
+     * @returns Opened intent data needed for tracking
+     * @throws {OpenedIntentNotFoundError} If the API returns a non-OK status or extractOpenedIntent rejects the response
+     */
+    async getOpenedIntent(txHash: Hex, chainId: number): Promise<OpenedIntent> {
+        const url = this.config.buildUrl(txHash, chainId);
+
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+            ...this.config.headers,
+        };
+
+        const response = await fetch(url, { headers });
+
+        if (!response.ok) {
+            throw new OpenedIntentNotFoundError(txHash, this.config.protocolName);
+        }
+
+        const data = (await response.json()) as TResponse;
+
+        return this.config.extractOpenedIntent(data, txHash);
+    }
+}

--- a/packages/cross-chain/src/core/services/index.ts
+++ b/packages/cross-chain/src/core/services/index.ts
@@ -1,4 +1,5 @@
 export * from "./aggregator.js";
+export * from "./APIOpenedIntentParser.js";
 export * from "./CustomEventOpenedIntentParser.js";
 export * from "./EventBasedFillWatcher.js";
 export * from "./APIBasedFillWatcher.js";

--- a/packages/cross-chain/src/external.ts
+++ b/packages/cross-chain/src/external.ts
@@ -25,6 +25,7 @@ export {
     OrderTracker,
     OrderTrackerFactory,
     OIFOpenedIntentParser,
+    APIOpenedIntentParser,
     CustomEventOpenedIntentParser,
     // Sorting
     SortingStrategyFactory,

--- a/packages/cross-chain/src/external.ts
+++ b/packages/cross-chain/src/external.ts
@@ -14,6 +14,8 @@ export {
     // Providers
     AcrossProvider,
     OifProvider,
+    RelayProvider,
+    type RelayConfigs,
     createCrossChainProvider,
     // Aggregator
     Aggregator,

--- a/packages/cross-chain/src/factories/crossChainProviderFactory.ts
+++ b/packages/cross-chain/src/factories/crossChainProviderFactory.ts
@@ -1,5 +1,16 @@
-import type { AcrossConfigs, CrossChainProvider, OifProviderConfig } from "../internal.js";
-import { AcrossProvider, OifProvider, PROTOCOLS, UnsupportedProtocol } from "../internal.js";
+import type {
+    AcrossConfigs,
+    CrossChainProvider,
+    OifProviderConfig,
+    RelayConfigs,
+} from "../internal.js";
+import {
+    AcrossProvider,
+    OifProvider,
+    PROTOCOLS,
+    RelayProvider,
+    UnsupportedProtocol,
+} from "../internal.js";
 
 /**
  * Creates a CrossChainProvider for Across protocol
@@ -20,6 +31,15 @@ export function createCrossChainProvider(
     config: OifProviderConfig,
 ): CrossChainProvider;
 /**
+ * Creates a CrossChainProvider for Relay protocol
+ * @param protocolName - "relay"
+ * @param config - Optional configuration (defaults to mainnet)
+ */
+export function createCrossChainProvider(
+    protocolName: typeof PROTOCOLS.RELAY,
+    config?: RelayConfigs,
+): CrossChainProvider;
+/**
  * Creates a CrossChainProvider for the specified protocol
  * @param protocolName - The name of the protocol
  * @param config - The configuration for the provider
@@ -33,5 +53,6 @@ export function createCrossChainProvider(
     if (protocolName === PROTOCOLS.ACROSS)
         return new AcrossProvider((config as AcrossConfigs) ?? {});
     if (protocolName === PROTOCOLS.OIF) return new OifProvider(config as OifProviderConfig);
+    if (protocolName === PROTOCOLS.RELAY) return new RelayProvider((config as RelayConfigs) ?? {});
     throw new UnsupportedProtocol(protocolName);
 }

--- a/packages/cross-chain/src/factories/orderTrackerFactory.ts
+++ b/packages/cross-chain/src/factories/orderTrackerFactory.ts
@@ -1,5 +1,6 @@
 import {
     APIBasedFillWatcher,
+    APIOpenedIntentParser,
     CrossChainProvider,
     CustomEventOpenedIntentParser,
     EventBasedFillWatcher,
@@ -85,8 +86,7 @@ export class OrderTrackerFactory {
                 });
 
             case "api":
-                // TODO: Implement APIOpenedIntentParser when needed
-                throw new Error("API-based OpenedIntentParser not yet implemented");
+                return new APIOpenedIntentParser(config.config);
 
             default:
                 const _exhaustive: never = config;

--- a/packages/cross-chain/src/factories/providers.ts
+++ b/packages/cross-chain/src/factories/providers.ts
@@ -1,8 +1,16 @@
-import type { AcrossConfigs, AcrossProvider, OifProvider, OifProviderConfig } from "../internal.js";
+import type {
+    AcrossConfigs,
+    AcrossProvider,
+    OifProvider,
+    OifProviderConfig,
+    RelayConfigs,
+    RelayProvider,
+} from "../internal.js";
 
 export const PROTOCOLS = {
     ACROSS: "across",
     OIF: "oif",
+    RELAY: "relay",
 } as const;
 
 export type SupportedProtocols = (typeof PROTOCOLS)[keyof typeof PROTOCOLS];
@@ -10,9 +18,11 @@ export type SupportedProtocols = (typeof PROTOCOLS)[keyof typeof PROTOCOLS];
 export type SupportedProtocolProviders = {
     [PROTOCOLS.ACROSS]: AcrossProvider;
     [PROTOCOLS.OIF]: OifProvider;
+    [PROTOCOLS.RELAY]: RelayProvider;
 };
 
 export type SupportedProtocolsConfigs<Protocol extends SupportedProtocols> = {
     [PROTOCOLS.ACROSS]: AcrossConfigs;
     [PROTOCOLS.OIF]: OifProviderConfig;
+    [PROTOCOLS.RELAY]: RelayConfigs;
 }[Protocol];

--- a/packages/cross-chain/src/protocols/index.ts
+++ b/packages/cross-chain/src/protocols/index.ts
@@ -1,3 +1,4 @@
 export * from "./oif/index.js";
 export * from "./across/index.js";
+export * from "./relay/index.js";
 export * from "./sample/index.js";

--- a/packages/cross-chain/src/protocols/relay/index.ts
+++ b/packages/cross-chain/src/protocols/relay/index.ts
@@ -1,2 +1,3 @@
+export * from "./provider.js";
 export * from "./schemas.js";
 export * from "./types.js";

--- a/packages/cross-chain/src/protocols/relay/provider.ts
+++ b/packages/cross-chain/src/protocols/relay/provider.ts
@@ -73,7 +73,7 @@ export class RelayProvider extends CrossChainProvider {
 
             const headers: Record<string, string> = {};
             if (parsed.apiKey) {
-                headers["Authorization"] = `Bearer ${parsed.apiKey}`;
+                headers["x-api-key"] = parsed.apiKey;
             }
             this.http = axios.create({ baseURL: this.baseUrl, headers });
         } catch (error) {

--- a/packages/cross-chain/src/protocols/relay/provider.ts
+++ b/packages/cross-chain/src/protocols/relay/provider.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from "axios";
-import type { Hex } from "viem";
+import type { Address, Hex } from "viem";
 import axios, { AxiosError } from "axios";
 import { zeroAddress } from "viem";
 import { ZodError } from "zod";
@@ -8,6 +8,7 @@ import type {
     APIBasedFillWatcherConfig,
     FillEvent,
     FillWatcherConfig,
+    OpenedIntent,
     OpenedIntentParserConfig,
     Quote,
     QuoteRequest,
@@ -23,6 +24,7 @@ import type {
 import type { RelayConfigs } from "./types.js";
 import {
     CrossChainProvider,
+    OpenedIntentNotFoundError,
     OrderFailureReason,
     OrderStatus,
     ProviderConfigFailure,
@@ -207,12 +209,42 @@ export class RelayProvider extends CrossChainProvider {
                 type: "api",
                 config: {
                     protocolName: RelayProvider.PROTOCOL_NAME,
-                    endpoint: `${this.baseUrl}/intents/status/v3`,
-                    extractOpenedIntent: (): never => {
-                        throw new Error(
-                            "Relay does not support parsing opened intents from transactions. " +
-                                "Use API-based tracking instead.",
-                        );
+                    buildUrl: (txHash: Hex): string =>
+                        `${this.baseUrl}/intents/status/v3?requestId=${txHash}`,
+                    extractOpenedIntent: (response, txHash): OpenedIntent => {
+                        const parsed = RelayIntentStatusResponseSchema.safeParse(response);
+
+                        if (!parsed.success) {
+                            throw new OpenedIntentNotFoundError(
+                                txHash,
+                                RelayProvider.PROTOCOL_NAME,
+                            );
+                        }
+
+                        const data = parsed.data;
+                        const originTxHash = (data.inTxHashes?.[0] as Hex) ?? txHash;
+
+                        return {
+                            user: zeroAddress as Address,
+                            originChainId: data.originChainId ?? 0,
+                            openDeadline: 0,
+                            fillDeadline: 0,
+                            orderId: txHash,
+                            maxSpent: [],
+                            minReceived: [],
+                            fillInstructions: data.destinationChainId
+                                ? [
+                                      {
+                                          destinationChainId: data.destinationChainId,
+                                          destinationSettler: zeroAddress as Hex,
+                                          originData: "0x" as Hex,
+                                      },
+                                  ]
+                                : [],
+                            txHash: originTxHash,
+                            blockNumber: 0n,
+                            originContract: zeroAddress as Address,
+                        };
                     },
                 },
             },

--- a/packages/cross-chain/src/protocols/relay/provider.ts
+++ b/packages/cross-chain/src/protocols/relay/provider.ts
@@ -45,6 +45,9 @@ const RELAY_STATUS_MAP: Record<
     string,
     { status: OrderStatus; failureReason?: OrderFailureReason }
 > = {
+    waiting: { status: OrderStatus.Pending },
+    pending: { status: OrderStatus.Executing },
+    submitted: { status: OrderStatus.Settling },
     success: { status: OrderStatus.Finalized },
     failure: { status: OrderStatus.Failed, failureReason: OrderFailureReason.Unknown },
     refund: { status: OrderStatus.Refunded },
@@ -165,33 +168,27 @@ export class RelayProvider extends CrossChainProvider {
                 event: FillEvent | null;
                 status: OrderStatus;
                 failureReason?: OrderFailureReason;
+                fillTxHash?: string;
             } => {
                 const { status, failureReason } = RELAY_STATUS_MAP[response.status] ?? {
                     status: OrderStatus.Pending,
                 };
-
-                if (status !== OrderStatus.Finalized) {
-                    return { event: null, status, failureReason };
-                }
-
                 const fillTxHash = response.txHashes?.[0];
-                if (!fillTxHash) {
-                    return { event: null, status, failureReason };
-                }
 
-                return {
-                    event: {
-                        fillTxHash: fillTxHash as Hex,
-                        blockNumber: 0n,
-                        timestamp: response.updatedAt ?? 0,
-                        originChainId: params.originChainId,
-                        orderId: params.orderId,
-                        relayer: zeroAddress,
-                        recipient: zeroAddress,
-                    },
-                    status,
-                    failureReason,
-                };
+                const isFilled = status === OrderStatus.Finalized && fillTxHash;
+                const event: FillEvent | null = isFilled
+                    ? {
+                          fillTxHash: fillTxHash as Hex,
+                          blockNumber: 0n,
+                          timestamp: response.updatedAt ?? 0,
+                          originChainId: params.originChainId,
+                          orderId: params.orderId,
+                          relayer: zeroAddress,
+                          recipient: zeroAddress,
+                      }
+                    : null;
+
+                return { event, status, failureReason, fillTxHash };
             },
         };
     }

--- a/packages/cross-chain/src/protocols/relay/provider.ts
+++ b/packages/cross-chain/src/protocols/relay/provider.ts
@@ -1,0 +1,351 @@
+import type { AxiosInstance } from "axios";
+import type { Hex } from "viem";
+import axios, { AxiosError } from "axios";
+import { zeroAddress } from "viem";
+import { ZodError } from "zod";
+
+import type {
+    APIBasedFillWatcherConfig,
+    FillEvent,
+    FillWatcherConfig,
+    OpenedIntentParserConfig,
+    Quote,
+    QuoteRequest,
+    RelayIntentStatusResponse,
+    Step,
+} from "../../internal.js";
+import type {
+    RelayIntentStatusRequest,
+    RelayQuoteRequest,
+    RelayQuoteResponse,
+    RelayQuoteStep,
+} from "./schemas.js";
+import type { RelayConfigs } from "./types.js";
+import {
+    CrossChainProvider,
+    OrderFailureReason,
+    OrderStatus,
+    ProviderConfigFailure,
+    ProviderGetQuoteFailure,
+    ProviderGetStatusFailure,
+} from "../../internal.js";
+import {
+    RelayBadRequestResponseSchema,
+    RelayIntentStatusRequestSchema,
+    RelayIntentStatusResponseSchema,
+    RelayQuoteRequestSchema,
+    RelayQuoteResponseSchema,
+} from "./schemas.js";
+import { RELAY_BASE_URL, RelayConfigSchema } from "./types.js";
+
+/** Maps Relay intent status strings to SDK OrderStatus values. */
+const RELAY_STATUS_MAP: Record<
+    string,
+    { status: OrderStatus; failureReason?: OrderFailureReason }
+> = {
+    success: { status: OrderStatus.Finalized },
+    failure: { status: OrderStatus.Failed, failureReason: OrderFailureReason.Unknown },
+    refund: { status: OrderStatus.Refunded },
+};
+
+/**
+ * A {@link CrossChainProvider} implementation for the Relay protocol.
+ *
+ * @see https://docs.relay.link/
+ */
+export class RelayProvider extends CrossChainProvider {
+    static readonly PROTOCOL_NAME = "relay" as const;
+
+    readonly protocolName = RelayProvider.PROTOCOL_NAME;
+    readonly providerId: string;
+    private readonly http: AxiosInstance;
+    private readonly baseUrl: string;
+    private readonly slippageTolerance?: number;
+
+    constructor(config: RelayConfigs = {}) {
+        super();
+
+        try {
+            const parsed = RelayConfigSchema.parse(config);
+            this.baseUrl = parsed.baseUrl ?? RELAY_BASE_URL;
+            this.providerId = parsed.providerId ?? "relay";
+            this.slippageTolerance = parsed.slippageTolerance;
+
+            const headers: Record<string, string> = {};
+            if (parsed.apiKey) {
+                headers["Authorization"] = `Bearer ${parsed.apiKey}`;
+            }
+            this.http = axios.create({ baseURL: this.baseUrl, headers });
+        } catch (error) {
+            if (error instanceof ZodError) {
+                throw new ProviderConfigFailure(
+                    "Failed to parse Relay config",
+                    error.message,
+                    error.stack,
+                );
+            }
+            throw new ProviderConfigFailure(
+                "Failed to configure Relay provider",
+                String(error),
+                error instanceof Error ? error.stack : undefined,
+            );
+        }
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * Builds SDK Quote types directly from Relay API response.
+     */
+    async getQuotes(params: QuoteRequest): Promise<Quote[]> {
+        try {
+            const relayParams = this.toRelayParams(params);
+            const response = await this.getRelayQuote(relayParams);
+            return [this.toSdkQuote(params, response)];
+        } catch (error) {
+            if (error instanceof ProviderGetQuoteFailure) {
+                throw error;
+            }
+            throw new ProviderGetQuoteFailure(
+                "Failed to get Relay quotes",
+                error instanceof ZodError ? error.message : String(error),
+                error instanceof Error ? error.stack : undefined,
+            );
+        }
+    }
+
+    /**
+     * Check the status of a Relay intent via `/intents/status/v3`.
+     */
+    async getStatus(params: RelayIntentStatusRequest): Promise<RelayIntentStatusResponse> {
+        try {
+            const parsed = RelayIntentStatusRequestSchema.parse(params);
+            const response = await this.http.get("/intents/status/v3", {
+                params: parsed,
+            });
+            return RelayIntentStatusResponseSchema.parse(response.data);
+        } catch (error) {
+            if (error instanceof AxiosError) {
+                throw new ProviderGetStatusFailure(
+                    "Failed to get Relay intent status",
+                    error.message,
+                    error.stack,
+                );
+            }
+            throw error;
+        }
+    }
+
+    /**
+     * Get API-based fill watcher config for Relay.
+     * Uses the Relay `/intents/status/v3` endpoint to track order status.
+     *
+     * @see https://docs.relay.link/references/api/get-intent-status
+     */
+    static getFillWatcherConfig(
+        baseUrl: string = RELAY_BASE_URL,
+    ): APIBasedFillWatcherConfig<RelayIntentStatusResponse> {
+        return {
+            type: "api-based",
+            baseUrl,
+            pollingInterval: 5000,
+            retry: {
+                maxAttempts: 3,
+                initialDelay: 2000,
+                maxDelay: 15000,
+                backoffMultiplier: 2,
+            },
+            buildEndpoint: (params): string => `/intents/status/v3?requestId=${params.orderId}`,
+            extractFillEvent: (
+                response,
+                params,
+            ): {
+                event: FillEvent | null;
+                status: OrderStatus;
+                failureReason?: OrderFailureReason;
+            } => {
+                const { status, failureReason } = RELAY_STATUS_MAP[response.status] ?? {
+                    status: OrderStatus.Pending,
+                };
+
+                if (status !== OrderStatus.Finalized) {
+                    return { event: null, status, failureReason };
+                }
+
+                const fillTxHash = response.txHashes?.[0];
+                if (!fillTxHash) {
+                    return { event: null, status, failureReason };
+                }
+
+                return {
+                    event: {
+                        fillTxHash: fillTxHash as Hex,
+                        blockNumber: 0n,
+                        timestamp: response.updatedAt ?? 0,
+                        originChainId: params.originChainId,
+                        orderId: params.orderId,
+                        relayer: zeroAddress,
+                        recipient: zeroAddress,
+                    },
+                    status,
+                    failureReason,
+                };
+            },
+        };
+    }
+
+    /**
+     * @inheritdoc
+     * Returns API-based tracking config using Relay `/intents/status/v3`.
+     */
+    getTrackingConfig(): {
+        openedIntentParserConfig: OpenedIntentParserConfig;
+        fillWatcherConfig: FillWatcherConfig;
+    } {
+        return {
+            openedIntentParserConfig: {
+                type: "api",
+                config: {
+                    protocolName: RelayProvider.PROTOCOL_NAME,
+                    endpoint: `${this.baseUrl}/intents/status/v3`,
+                    extractOpenedIntent: (): never => {
+                        throw new Error(
+                            "Relay does not support parsing opened intents from transactions. " +
+                                "Use API-based tracking instead.",
+                        );
+                    },
+                },
+            },
+            fillWatcherConfig: RelayProvider.getFillWatcherConfig(
+                this.baseUrl,
+            ) as FillWatcherConfig,
+        };
+    }
+
+    /**
+     * Get a quote from the Relay API calling POST /quote/v2
+     */
+    private async getRelayQuote(params: RelayQuoteRequest): Promise<RelayQuoteResponse> {
+        try {
+            const response = await this.http.post("/quote/v2", params);
+            return RelayQuoteResponseSchema.parse(response.data);
+        } catch (error) {
+            if (error instanceof AxiosError) {
+                const parsed = RelayBadRequestResponseSchema.safeParse(error.response?.data);
+                const message = parsed.success
+                    ? parsed.data.message
+                    : (error.message ?? "Failed to get Relay quote");
+                throw new ProviderGetQuoteFailure(
+                    "Failed to get Relay quote",
+                    message,
+                    error.stack,
+                );
+            } else if (error instanceof ZodError) {
+                throw new ProviderGetQuoteFailure(
+                    "Failed to parse Relay quote",
+                    error.message,
+                    error.stack,
+                );
+            }
+            throw new ProviderGetQuoteFailure(
+                "Failed to get Relay quotes",
+                String(error),
+                error instanceof Error ? error.stack : undefined,
+            );
+        }
+    }
+
+    /**
+     * Convert SDK QuoteRequest to Relay API parameters.
+     */
+    private toRelayParams(params: QuoteRequest): RelayQuoteRequest {
+        const swapType = params.swapType ?? "exact-input";
+        const amount = swapType === "exact-input" ? params.input.amount : params.output.amount;
+
+        if (!amount) {
+            const side = swapType === "exact-input" ? "input" : "output";
+            throw new ProviderGetQuoteFailure(`${swapType} requires ${side}.amount to be defined`);
+        }
+
+        return RelayQuoteRequestSchema.parse({
+            user: params.user,
+            originChainId: params.input.chainId,
+            originCurrency: params.input.assetAddress,
+            destinationChainId: params.output.chainId,
+            destinationCurrency: params.output.assetAddress,
+            amount,
+            tradeType: swapType === "exact-input" ? "EXACT_INPUT" : "EXPECTED_OUTPUT",
+            recipient: params.output.recipient,
+            slippageTolerance:
+                this.slippageTolerance !== undefined ? String(this.slippageTolerance) : undefined,
+        });
+    }
+
+    /**
+     * Build an SDK Quote directly from Relay API response.
+     */
+    private toSdkQuote(params: QuoteRequest, response: RelayQuoteResponse): Quote {
+        const currencyIn = response.details?.currencyIn;
+        const currencyOut = response.details?.currencyOut;
+
+        return {
+            order: {
+                steps: response.steps.flatMap((step) => this.toSdkSteps(step)),
+            },
+            preview: {
+                inputs: [
+                    {
+                        chainId: currencyIn?.currency.chainId ?? params.input.chainId,
+                        accountAddress: params.user,
+                        assetAddress: currencyIn?.currency.address ?? params.input.assetAddress,
+                        amount: currencyIn?.amount ?? params.input.amount ?? "0",
+                    },
+                ],
+                outputs: [
+                    {
+                        chainId: currencyOut?.currency.chainId ?? params.output.chainId,
+                        accountAddress: params.output.recipient ?? params.user,
+                        assetAddress: currencyOut?.currency.address ?? params.output.assetAddress,
+                        amount: currencyOut?.amount ?? params.output.amount ?? "0",
+                    },
+                ],
+            },
+            quoteId: response.protocol?.v2?.orderId,
+            eta: response.details?.timeEstimate,
+            partialFill: false,
+            failureHandling: "refund-automatic",
+            provider: this.providerId,
+            metadata: { relayResponse: response },
+        };
+    }
+
+    /** Map a single Relay step to SDK Step entries (one per incomplete transaction item). */
+    private toSdkSteps(step: RelayQuoteStep): Step[] {
+        if (step.kind !== "transaction") {
+            return [];
+        }
+
+        return step.items
+            .filter((item) => item.status === "incomplete")
+            .map((item) => ({
+                kind: "transaction" as const,
+                chainId: item.data.chainId,
+                description: step.description,
+                transaction: {
+                    to: item.data.to,
+                    data: item.data.data,
+                    value: item.data.value,
+                    ...(item.data.gas &&
+                        item.data.gas !== "0" && {
+                            gas: item.data.gas,
+                        }),
+                    ...(item.data.maxFeePerGas && {
+                        maxFeePerGas: item.data.maxFeePerGas,
+                    }),
+                    ...(item.data.maxPriorityFeePerGas && {
+                        maxPriorityFeePerGas: item.data.maxPriorityFeePerGas,
+                    }),
+                },
+            }));
+    }
+}

--- a/packages/cross-chain/test/protocols/relay/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/provider.spec.ts
@@ -495,12 +495,50 @@ describe("RelayProvider", () => {
             expect(config.openedIntentParserConfig.type).toBe("api");
         });
 
-        it("extractOpenedIntent throws (Relay uses API-based tracking)", () => {
+        it("extractOpenedIntent maps valid API response to OpenedIntent", () => {
+            const { openedIntentParserConfig } = provider.getTrackingConfig();
+            if (openedIntentParserConfig.type === "api") {
+                const txHash = "0xabc123" as `0x${string}`;
+                const inTxHash = "0xorigin111" as `0x${string}`;
+                const result = openedIntentParserConfig.config.extractOpenedIntent(
+                    {
+                        status: "pending",
+                        originChainId: 11155111,
+                        destinationChainId: 84532,
+                        inTxHashes: [inTxHash],
+                    },
+                    txHash,
+                );
+                expect(result.orderId).toBe(txHash);
+                expect(result.txHash).toBe(inTxHash);
+                expect(result.originChainId).toBe(11155111);
+                expect(result.fillInstructions).toHaveLength(1);
+                expect(result.fillInstructions[0]?.destinationChainId).toBe(84532);
+            }
+        });
+
+        it("extractOpenedIntent falls back to txHash when inTxHashes is empty", () => {
+            const { openedIntentParserConfig } = provider.getTrackingConfig();
+            if (openedIntentParserConfig.type === "api") {
+                const txHash = "0xabc123" as `0x${string}`;
+                const result = openedIntentParserConfig.config.extractOpenedIntent(
+                    { status: "pending", originChainId: 11155111 },
+                    txHash,
+                );
+                expect(result.txHash).toBe(txHash);
+                expect(result.fillInstructions).toHaveLength(0);
+            }
+        });
+
+        it("extractOpenedIntent throws OpenedIntentNotFoundError on invalid response", () => {
             const { openedIntentParserConfig } = provider.getTrackingConfig();
             if (openedIntentParserConfig.type === "api") {
                 expect(() =>
-                    openedIntentParserConfig.config.extractOpenedIntent({} as never, "0x" as never),
-                ).toThrow("Relay does not support parsing opened intents");
+                    openedIntentParserConfig.config.extractOpenedIntent(
+                        { invalid: "data" },
+                        "0x123" as `0x${string}`,
+                    ),
+                ).toThrow("relay opened intent event not found");
             }
         });
 

--- a/packages/cross-chain/test/protocols/relay/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/provider.spec.ts
@@ -1,0 +1,574 @@
+import axios, { AxiosError } from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { QuoteRequest } from "../../../src/core/schemas/quoteRequest.js";
+import type {
+    RelayIntentStatusResponse,
+    RelayQuoteResponse,
+} from "../../../src/protocols/relay/schemas.js";
+import { ProviderGetQuoteFailure } from "../../../src/core/errors/ProviderGetQuoteFailure.exception.js";
+import { ProviderGetStatusFailure } from "../../../src/core/errors/ProviderGetStatusFailure.exception.js";
+import { OrderFailureReason, OrderStatus } from "../../../src/core/types/orderTracking.js";
+import { RelayProvider } from "../../../src/protocols/relay/provider.js";
+
+// ── Constants ────────────────────────────────────────────
+
+const VALID_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+const RECIPIENT_ADDRESS = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
+const ORIGIN_CHAIN_ID = 1;
+const DESTINATION_CHAIN_ID = 10;
+const INPUT_AMOUNT = "1000000";
+const OUTPUT_AMOUNT = "999000";
+const EXACT_OUTPUT_AMOUNT = "500000";
+const TX_DATA = "0xdeadbeef";
+const REQUEST_ID = "0xreq123";
+const ORDER_ID = "0xorder456";
+const TIME_ESTIMATE_SECONDS = 30;
+const ZERO_AMOUNT = "0";
+const PROTOCOL_NAME = "relay";
+const QUOTE_ENDPOINT = "/quote/v2";
+const STATUS_ENDPOINT = "/intents/status/v3";
+const SAMPLE_GAS = "21000";
+const SAMPLE_MAX_FEE_PER_GAS = "30000000000";
+const SAMPLE_MAX_PRIORITY_FEE_PER_GAS = "1000000000";
+const SAMPLE_TIMESTAMP = 1700000000;
+const SAMPLE_FILL_TX_HASH = "0xfillhash";
+const STEP_DESCRIPTION = "Approve and send";
+const API_KEY = "test-key";
+const HTTP_STATUS_BAD_REQUEST = 400;
+const RELAY_ERROR_AMOUNT_TOO_LOW = "AMOUNT_TOO_LOW";
+const RELAY_ERROR_ROUTE_NOT_FOUND = "ROUTE_NOT_FOUND";
+
+// ── Mock & Helpers ───────────────────────────────────────
+
+vi.mock("axios", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("axios")>();
+    return { ...actual, default: { ...actual.default, create: vi.fn() } };
+});
+
+const mockPost = vi.fn();
+const mockGet = vi.fn();
+
+function makeQuoteRequest(overrides?: Partial<QuoteRequest>): QuoteRequest {
+    return {
+        user: VALID_ADDRESS,
+        input: { chainId: ORIGIN_CHAIN_ID, assetAddress: VALID_ADDRESS, amount: INPUT_AMOUNT },
+        output: { chainId: DESTINATION_CHAIN_ID, assetAddress: VALID_ADDRESS },
+        ...overrides,
+    };
+}
+
+function makeRelayQuoteResponse(overrides?: Partial<RelayQuoteResponse>): RelayQuoteResponse {
+    return {
+        steps: [
+            {
+                id: "deposit",
+                action: "Confirm transaction",
+                description: STEP_DESCRIPTION,
+                kind: "transaction",
+                requestId: REQUEST_ID,
+                items: [
+                    {
+                        status: "incomplete",
+                        data: {
+                            to: VALID_ADDRESS,
+                            data: TX_DATA,
+                            value: INPUT_AMOUNT,
+                            chainId: ORIGIN_CHAIN_ID,
+                        },
+                    },
+                ],
+            },
+        ],
+        fees: {
+            gas: {
+                currency: {
+                    chainId: ORIGIN_CHAIN_ID,
+                    address: VALID_ADDRESS,
+                    symbol: "ETH",
+                    name: "Ether",
+                    decimals: 18,
+                },
+                amount: "100000",
+            },
+        },
+        details: {
+            operation: "bridge",
+            timeEstimate: TIME_ESTIMATE_SECONDS,
+            currencyIn: {
+                currency: {
+                    chainId: ORIGIN_CHAIN_ID,
+                    address: VALID_ADDRESS,
+                    symbol: "USDC",
+                    name: "USD Coin",
+                    decimals: 6,
+                },
+                amount: INPUT_AMOUNT,
+            },
+            currencyOut: {
+                currency: {
+                    chainId: DESTINATION_CHAIN_ID,
+                    address: VALID_ADDRESS,
+                    symbol: "USDC",
+                    name: "USD Coin",
+                    decimals: 6,
+                },
+                amount: OUTPUT_AMOUNT,
+            },
+        },
+        protocol: { v2: { orderId: ORDER_ID } },
+        ...overrides,
+    } as RelayQuoteResponse;
+}
+
+function makeAxiosError(data: unknown, status: number, message: string, code: string): AxiosError {
+    const error = new AxiosError(message, code);
+    error.response = { data, status, statusText: "", headers: {}, config: {} as never };
+    return error;
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+describe("RelayProvider", () => {
+    let provider: RelayProvider;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(axios.create).mockReturnValue({
+            post: mockPost,
+            get: mockGet,
+        } as unknown as ReturnType<typeof axios.create>);
+        provider = new RelayProvider();
+    });
+
+    describe("constructor", () => {
+        it("uses default config when none is provided", () => {
+            const p = new RelayProvider();
+            expect(p.protocolName).toBe(PROTOCOL_NAME);
+            expect(p.providerId).toBe(PROTOCOL_NAME);
+        });
+
+        it("accepts custom config", () => {
+            expect(
+                new RelayProvider({
+                    providerId: "relay-custom",
+                    baseUrl: "https://custom.relay.link",
+                }).providerId,
+            ).toBe("relay-custom");
+        });
+
+        it("sets Authorization header when apiKey is provided", () => {
+            new RelayProvider({ apiKey: API_KEY });
+            expect(axios.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    headers: expect.objectContaining({ Authorization: `Bearer ${API_KEY}` }),
+                }),
+            );
+        });
+    });
+
+    describe("getQuotes()", () => {
+        it("maps Relay response to SDK Quote with all fields", async () => {
+            mockPost.mockResolvedValue({ data: makeRelayQuoteResponse() });
+            const [quote] = await provider.getQuotes(makeQuoteRequest());
+            expect(quote!.provider).toBe(PROTOCOL_NAME);
+            expect(quote!.quoteId).toBe(ORDER_ID);
+            expect(quote!.eta).toBe(TIME_ESTIMATE_SECONDS);
+            expect(quote!.partialFill).toBe(false);
+            expect(quote!.failureHandling).toBe("refund-automatic");
+            expect(quote!.metadata!.relayResponse).toBeDefined();
+            expect(quote!.preview.inputs[0]!.accountAddress).toBe(VALID_ADDRESS);
+            expect(quote!.preview.inputs[0]!.amount).toBe(INPUT_AMOUNT);
+            expect(quote!.preview.outputs[0]!.amount).toBe(OUTPUT_AMOUNT);
+        });
+
+        it("maps transaction steps with description and tx data", async () => {
+            mockPost.mockResolvedValue({ data: makeRelayQuoteResponse() });
+            const [quote] = await provider.getQuotes(makeQuoteRequest());
+            expect(quote!.order.steps).toHaveLength(1);
+            const step = quote!.order.steps[0]!;
+            expect(step.kind).toBe("transaction");
+            if (step.kind === "transaction") {
+                expect(step.description).toBe(STEP_DESCRIPTION);
+                expect(step.transaction.to).toBe(VALID_ADDRESS);
+                expect(step.transaction.data).toBe(TX_DATA);
+            }
+        });
+
+        it("POSTs to /quote/v2 with mapped parameters", async () => {
+            mockPost.mockResolvedValue({ data: makeRelayQuoteResponse() });
+            await provider.getQuotes(
+                makeQuoteRequest({
+                    output: {
+                        chainId: DESTINATION_CHAIN_ID,
+                        assetAddress: VALID_ADDRESS,
+                        recipient: RECIPIENT_ADDRESS,
+                    },
+                }),
+            );
+            expect(mockPost).toHaveBeenCalledWith(
+                QUOTE_ENDPOINT,
+                expect.objectContaining({
+                    user: VALID_ADDRESS,
+                    originChainId: ORIGIN_CHAIN_ID,
+                    destinationChainId: DESTINATION_CHAIN_ID,
+                    tradeType: "EXACT_INPUT",
+                    recipient: RECIPIENT_ADDRESS,
+                }),
+            );
+        });
+
+        it("maps exact-output to EXPECTED_OUTPUT trade type", async () => {
+            mockPost.mockResolvedValue({ data: makeRelayQuoteResponse() });
+            await provider.getQuotes(
+                makeQuoteRequest({
+                    swapType: "exact-output",
+                    input: { chainId: ORIGIN_CHAIN_ID, assetAddress: VALID_ADDRESS },
+                    output: {
+                        chainId: DESTINATION_CHAIN_ID,
+                        assetAddress: VALID_ADDRESS,
+                        amount: EXACT_OUTPUT_AMOUNT,
+                    },
+                }),
+            );
+            expect(mockPost).toHaveBeenCalledWith(
+                QUOTE_ENDPOINT,
+                expect.objectContaining({
+                    tradeType: "EXPECTED_OUTPUT",
+                    amount: EXACT_OUTPUT_AMOUNT,
+                }),
+            );
+        });
+
+        it("sets outputs accountAddress to recipient when provided", async () => {
+            mockPost.mockResolvedValue({ data: makeRelayQuoteResponse() });
+            const [quote] = await provider.getQuotes(
+                makeQuoteRequest({
+                    output: {
+                        chainId: DESTINATION_CHAIN_ID,
+                        assetAddress: VALID_ADDRESS,
+                        recipient: RECIPIENT_ADDRESS,
+                    },
+                }),
+            );
+            expect(quote!.preview.outputs[0]!.accountAddress).toBe(RECIPIENT_ADDRESS);
+        });
+
+        it("throws when exact-input request has no input amount", async () => {
+            const params = makeQuoteRequest({
+                input: { chainId: ORIGIN_CHAIN_ID, assetAddress: VALID_ADDRESS },
+            });
+            await expect(provider.getQuotes(params)).rejects.toThrow(
+                "exact-input requires input.amount to be defined",
+            );
+        });
+
+        it("throws when exact-output request has no output amount", async () => {
+            const params = makeQuoteRequest({
+                swapType: "exact-output",
+                input: { chainId: ORIGIN_CHAIN_ID, assetAddress: VALID_ADDRESS },
+                output: { chainId: DESTINATION_CHAIN_ID, assetAddress: VALID_ADDRESS },
+            });
+            await expect(provider.getQuotes(params)).rejects.toThrow(
+                "exact-output requires output.amount to be defined",
+            );
+        });
+
+        it("falls back to request params when details is missing", async () => {
+            mockPost.mockResolvedValue({ data: makeRelayQuoteResponse({ details: undefined }) });
+            const [quote] = await provider.getQuotes(makeQuoteRequest());
+            expect(quote!.eta).toBeUndefined();
+            expect(quote!.preview.inputs[0]!.amount).toBe(INPUT_AMOUNT);
+            expect(quote!.preview.inputs[0]!.chainId).toBe(ORIGIN_CHAIN_ID);
+            expect(quote!.preview.outputs[0]!.amount).toBe(ZERO_AMOUNT);
+            expect(quote!.preview.outputs[0]!.chainId).toBe(DESTINATION_CHAIN_ID);
+        });
+
+        it("uses currencyIn from response for exact-output input preview", async () => {
+            mockPost.mockResolvedValue({ data: makeRelayQuoteResponse() });
+            const [quote] = await provider.getQuotes(
+                makeQuoteRequest({
+                    swapType: "exact-output",
+                    input: { chainId: ORIGIN_CHAIN_ID, assetAddress: VALID_ADDRESS },
+                    output: {
+                        chainId: DESTINATION_CHAIN_ID,
+                        assetAddress: VALID_ADDRESS,
+                        amount: EXACT_OUTPUT_AMOUNT,
+                    },
+                }),
+            );
+            expect(quote!.preview.inputs[0]!.amount).toBe(INPUT_AMOUNT);
+        });
+
+        it("falls back input amount to '0' when no details and no input amount", async () => {
+            mockPost.mockResolvedValue({ data: makeRelayQuoteResponse({ details: undefined }) });
+            const [quote] = await provider.getQuotes(
+                makeQuoteRequest({
+                    swapType: "exact-output",
+                    input: { chainId: ORIGIN_CHAIN_ID, assetAddress: VALID_ADDRESS },
+                    output: {
+                        chainId: DESTINATION_CHAIN_ID,
+                        assetAddress: VALID_ADDRESS,
+                        amount: EXACT_OUTPUT_AMOUNT,
+                    },
+                }),
+            );
+            expect(quote!.preview.inputs[0]!.amount).toBe(ZERO_AMOUNT);
+        });
+
+        it("sets quoteId to undefined when protocol.v2 is missing", async () => {
+            mockPost.mockResolvedValue({ data: makeRelayQuoteResponse({ protocol: undefined }) });
+            const [quote] = await provider.getQuotes(makeQuoteRequest());
+            expect(quote!.quoteId).toBeUndefined();
+        });
+
+        it("filters out complete items and keeps only incomplete ones", async () => {
+            const step = makeRelayQuoteResponse().steps[0]!;
+            const items = [
+                { ...step.items[0]!, status: "complete" as const },
+                { ...step.items[0]!, status: "incomplete" as const },
+            ];
+            mockPost.mockResolvedValue({
+                data: makeRelayQuoteResponse({ steps: [{ ...step, items }] }),
+            });
+            const [quote] = await provider.getQuotes(makeQuoteRequest());
+            expect(quote!.order.steps).toHaveLength(1);
+        });
+
+        it("maps multiple incomplete items from a single step into separate Steps", async () => {
+            const step = makeRelayQuoteResponse().steps[0]!;
+            const items = [
+                step.items[0]!,
+                {
+                    ...step.items[0]!,
+                    data: { ...step.items[0]!.data, chainId: DESTINATION_CHAIN_ID },
+                },
+            ];
+            mockPost.mockResolvedValue({
+                data: makeRelayQuoteResponse({ steps: [{ ...step, items }] }),
+            });
+            const [quote] = await provider.getQuotes(makeQuoteRequest());
+            expect(quote!.order.steps).toHaveLength(2);
+        });
+
+        it("skips signature steps", async () => {
+            const txStep = makeRelayQuoteResponse().steps[0]!;
+            const sigStep = {
+                ...txStep,
+                id: "authorize" as const,
+                kind: "signature" as const,
+                items: [{ status: "incomplete" as const, data: {} }],
+            };
+            mockPost.mockResolvedValue({
+                data: makeRelayQuoteResponse({ steps: [sigStep, txStep] }),
+            });
+            const [quote] = await provider.getQuotes(makeQuoteRequest());
+            expect(quote!.order.steps).toHaveLength(1);
+            expect(quote!.order.steps[0]!.kind).toBe("transaction");
+        });
+
+        it("maps gas parameters when present", async () => {
+            const step = makeRelayQuoteResponse().steps[0]!;
+            const itemWithGas = {
+                ...step.items[0]!,
+                data: {
+                    ...step.items[0]!.data,
+                    gas: SAMPLE_GAS,
+                    maxFeePerGas: SAMPLE_MAX_FEE_PER_GAS,
+                    maxPriorityFeePerGas: SAMPLE_MAX_PRIORITY_FEE_PER_GAS,
+                },
+            };
+            mockPost.mockResolvedValue({
+                data: makeRelayQuoteResponse({ steps: [{ ...step, items: [itemWithGas] }] }),
+            });
+            const [quote] = await provider.getQuotes(makeQuoteRequest());
+            const s = quote!.order.steps[0]!;
+            if (s.kind === "transaction") {
+                expect(s.transaction.gas).toBe(SAMPLE_GAS);
+                expect(s.transaction.maxFeePerGas).toBe(SAMPLE_MAX_FEE_PER_GAS);
+                expect(s.transaction.maxPriorityFeePerGas).toBe(SAMPLE_MAX_PRIORITY_FEE_PER_GAS);
+            }
+        });
+
+        it("passes slippageTolerance when configured", async () => {
+            mockPost.mockResolvedValue({ data: makeRelayQuoteResponse() });
+            await new RelayProvider({ slippageTolerance: 50 }).getQuotes(makeQuoteRequest());
+            expect(mockPost).toHaveBeenCalledWith(
+                QUOTE_ENDPOINT,
+                expect.objectContaining({ slippageTolerance: "50" }),
+            );
+        });
+    });
+
+    describe("getQuotes() — error handling", () => {
+        it("extracts message from Relay bad request response", async () => {
+            mockPost.mockRejectedValue(
+                makeAxiosError(
+                    { message: RELAY_ERROR_AMOUNT_TOO_LOW, errorCode: RELAY_ERROR_AMOUNT_TOO_LOW },
+                    HTTP_STATUS_BAD_REQUEST,
+                    "Request failed",
+                    "ERR_BAD_REQUEST",
+                ),
+            );
+            const rejection = expect(provider.getQuotes(makeQuoteRequest())).rejects;
+            await rejection.toThrow(ProviderGetQuoteFailure);
+            await rejection.toSatisfy(
+                (err: ProviderGetQuoteFailure) => err.cause === RELAY_ERROR_AMOUNT_TOO_LOW,
+            );
+        });
+
+        it("falls back to axios message when response body is not parseable", async () => {
+            mockPost.mockRejectedValue(
+                makeAxiosError("not json", 500, "Network Error", "ERR_NETWORK"),
+            );
+            const rejection = expect(provider.getQuotes(makeQuoteRequest())).rejects;
+            await rejection.toThrow(ProviderGetQuoteFailure);
+            await rejection.toSatisfy(
+                (err: ProviderGetQuoteFailure) => err.cause === "Network Error",
+            );
+        });
+
+        it("wraps ZodError from invalid response shape", async () => {
+            mockPost.mockResolvedValue({ data: { steps: "not-an-array" } });
+            await expect(provider.getQuotes(makeQuoteRequest())).rejects.toThrow(
+                ProviderGetQuoteFailure,
+            );
+        });
+
+        it("wraps unexpected error types", async () => {
+            mockPost.mockRejectedValue("unexpected string error");
+            await expect(provider.getQuotes(makeQuoteRequest())).rejects.toThrow(
+                ProviderGetQuoteFailure,
+            );
+        });
+
+        it("does not double-wrap ProviderGetQuoteFailure", async () => {
+            mockPost.mockRejectedValue(
+                makeAxiosError(
+                    {
+                        message: RELAY_ERROR_ROUTE_NOT_FOUND,
+                        errorCode: RELAY_ERROR_ROUTE_NOT_FOUND,
+                    },
+                    HTTP_STATUS_BAD_REQUEST,
+                    "bad request",
+                    "ERR_BAD_REQUEST",
+                ),
+            );
+            const rejection = expect(provider.getQuotes(makeQuoteRequest())).rejects;
+            await rejection.toBeInstanceOf(ProviderGetQuoteFailure);
+            await rejection.toSatisfy(
+                (err: ProviderGetQuoteFailure) => err.cause === RELAY_ERROR_ROUTE_NOT_FOUND,
+            );
+        });
+    });
+
+    describe("getStatus()", () => {
+        it("calls /intents/status/v3 and parses response", async () => {
+            mockGet.mockResolvedValue({
+                data: { status: "success", txHashes: [SAMPLE_FILL_TX_HASH] },
+            });
+            const result = await provider.getStatus({ requestId: REQUEST_ID });
+            expect(mockGet).toHaveBeenCalledWith(STATUS_ENDPOINT, {
+                params: { requestId: REQUEST_ID },
+            });
+            expect(result.status).toBe("success");
+            expect(result.txHashes).toEqual([SAMPLE_FILL_TX_HASH]);
+        });
+
+        it("throws on invalid status value", async () => {
+            mockGet.mockResolvedValue({ data: { status: "invalid-status" } });
+            await expect(provider.getStatus({ requestId: REQUEST_ID })).rejects.toThrow();
+        });
+
+        it("throws ProviderGetStatusFailure on API error", async () => {
+            mockGet.mockRejectedValue(new AxiosError("Network Error"));
+            await expect(provider.getStatus({ requestId: REQUEST_ID })).rejects.toThrow(
+                ProviderGetStatusFailure,
+            );
+        });
+    });
+
+    describe("getTrackingConfig()", () => {
+        it("returns api-based fill watcher and api intent parser", () => {
+            const config = provider.getTrackingConfig();
+            expect(config.fillWatcherConfig.type).toBe("api-based");
+            expect(config.openedIntentParserConfig.type).toBe("api");
+        });
+
+        it("extractOpenedIntent throws (Relay uses API-based tracking)", () => {
+            const { openedIntentParserConfig } = provider.getTrackingConfig();
+            if (openedIntentParserConfig.type === "api") {
+                expect(() =>
+                    openedIntentParserConfig.config.extractOpenedIntent({} as never, "0x" as never),
+                ).toThrow("Relay does not support parsing opened intents");
+            }
+        });
+
+        it("buildEndpoint includes requestId", () => {
+            const { fillWatcherConfig } = provider.getTrackingConfig();
+            if (fillWatcherConfig.type === "api-based") {
+                const endpoint = fillWatcherConfig.buildEndpoint({
+                    orderId: ORDER_ID,
+                    originChainId: ORIGIN_CHAIN_ID,
+                } as never);
+                expect(endpoint).toContain(`requestId=${ORDER_ID}`);
+            }
+        });
+    });
+
+    describe("extractFillEvent()", () => {
+        const fillParams = {
+            orderId: ORDER_ID,
+            originChainId: ORIGIN_CHAIN_ID,
+            openTxHash: "0xtx",
+        } as never;
+
+        function getExtract(): typeof config.extractFillEvent {
+            const { fillWatcherConfig } = provider.getTrackingConfig();
+            const config = fillWatcherConfig as {
+                type: "api-based";
+                extractFillEvent: (
+                    r: RelayIntentStatusResponse,
+                    p: never,
+                ) => { event: unknown; status: OrderStatus; failureReason?: OrderFailureReason };
+            };
+            return config.extractFillEvent;
+        }
+
+        it("maps 'success' with txHashes to Finalized with FillEvent", () => {
+            const response: RelayIntentStatusResponse = {
+                status: "success",
+                txHashes: [SAMPLE_FILL_TX_HASH],
+                updatedAt: SAMPLE_TIMESTAMP,
+            };
+            const result = getExtract()(response, fillParams);
+            expect(result.status).toBe(OrderStatus.Finalized);
+            expect(result.event).not.toBeNull();
+        });
+
+        it("returns null event when success has no txHashes", () => {
+            const extract = getExtract();
+            expect(extract({ status: "success" }, fillParams).event).toBeNull();
+            expect(extract({ status: "success", txHashes: [] }, fillParams).event).toBeNull();
+        });
+
+        it("maps 'failure' to Failed with Unknown reason", () => {
+            const result = getExtract()({ status: "failure" }, fillParams);
+            expect(result.status).toBe(OrderStatus.Failed);
+            expect(result.failureReason).toBe(OrderFailureReason.Unknown);
+            expect(result.event).toBeNull();
+        });
+
+        it("maps 'refund' to Refunded", () => {
+            const result = getExtract()({ status: "refund" }, fillParams);
+            expect(result.status).toBe(OrderStatus.Refunded);
+            expect(result.event).toBeNull();
+        });
+
+        it.each(["waiting", "pending", "submitted"] as const)("maps '%s' to Pending", (status) => {
+            const result = getExtract()({ status }, fillParams);
+            expect(result.status).toBe(OrderStatus.Pending);
+            expect(result.event).toBeNull();
+        });
+    });
+});

--- a/packages/cross-chain/test/protocols/relay/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/provider.spec.ts
@@ -603,9 +603,21 @@ describe("RelayProvider", () => {
             expect(result.event).toBeNull();
         });
 
-        it.each(["waiting", "pending", "submitted"] as const)("maps '%s' to Pending", (status) => {
-            const result = getExtract()({ status }, fillParams);
+        it("maps 'waiting' to Pending", () => {
+            const result = getExtract()({ status: "waiting" }, fillParams);
             expect(result.status).toBe(OrderStatus.Pending);
+            expect(result.event).toBeNull();
+        });
+
+        it("maps 'pending' to Executing", () => {
+            const result = getExtract()({ status: "pending" }, fillParams);
+            expect(result.status).toBe(OrderStatus.Executing);
+            expect(result.event).toBeNull();
+        });
+
+        it("maps 'submitted' to Settling", () => {
+            const result = getExtract()({ status: "submitted" }, fillParams);
+            expect(result.status).toBe(OrderStatus.Settling);
             expect(result.event).toBeNull();
         });
     });

--- a/packages/cross-chain/test/protocols/relay/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/provider.spec.ts
@@ -157,11 +157,11 @@ describe("RelayProvider", () => {
             ).toBe("relay-custom");
         });
 
-        it("sets Authorization header when apiKey is provided", () => {
+        it("sets x-api-key header when apiKey is provided", () => {
             new RelayProvider({ apiKey: API_KEY });
             expect(axios.create).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    headers: expect.objectContaining({ Authorization: `Bearer ${API_KEY}` }),
+                    headers: expect.objectContaining({ "x-api-key": API_KEY }),
                 }),
             );
         });

--- a/packages/cross-chain/test/services/APIOpenedIntentParser.spec.ts
+++ b/packages/cross-chain/test/services/APIOpenedIntentParser.spec.ts
@@ -1,0 +1,149 @@
+import { Address, Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+    APIOpenedIntentParser,
+    APIOpenedIntentParserConfig,
+    OpenedIntent,
+    OpenedIntentNotFoundError,
+} from "../../src/internal.js";
+
+const MOCK_BASE_URL = "https://api.test.com";
+
+const createMockConfig = (
+    overrides?: Partial<APIOpenedIntentParserConfig>,
+): APIOpenedIntentParserConfig => ({
+    protocolName: "test-protocol",
+    buildUrl: (txHash: Hex): string => `${MOCK_BASE_URL}/intents/status/v3?requestId=${txHash}`,
+    extractOpenedIntent: (_response: unknown, txHash: Hex): OpenedIntent => ({
+        orderId: txHash,
+        txHash,
+        blockNumber: 0n,
+        originContract: "0x0000000000000000000000000000000000000000" as Address,
+        user: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" as Address,
+        originChainId: 11155111,
+        openDeadline: 0,
+        fillDeadline: 0,
+        maxSpent: [],
+        minReceived: [],
+        fillInstructions: [],
+    }),
+    ...overrides,
+});
+
+const MOCK_TX_HASH = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" as Hex;
+const MOCK_CHAIN_ID = 11155111;
+
+describe("APIOpenedIntentParser", () => {
+    let parser: APIOpenedIntentParser;
+    let mockConfig: APIOpenedIntentParserConfig;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.restoreAllMocks();
+        mockConfig = createMockConfig();
+        parser = new APIOpenedIntentParser(mockConfig);
+    });
+
+    describe("getOpenedIntent", () => {
+        it("calls the API endpoint with txHash as requestId", async () => {
+            const mockResponse = { status: "pending", originChainId: 11155111 };
+            const fetchSpy = vi
+                .spyOn(globalThis, "fetch")
+                .mockResolvedValue(new Response(JSON.stringify(mockResponse), { status: 200 }));
+
+            await parser.getOpenedIntent(MOCK_TX_HASH, MOCK_CHAIN_ID);
+
+            expect(fetchSpy).toHaveBeenCalledWith(
+                `${MOCK_BASE_URL}/intents/status/v3?requestId=${MOCK_TX_HASH}`,
+                { headers: { "Content-Type": "application/json" } },
+            );
+        });
+
+        it("returns OpenedIntent from extractOpenedIntent", async () => {
+            const mockResponse = { status: "pending", originChainId: 11155111 };
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(JSON.stringify(mockResponse), { status: 200 }),
+            );
+
+            const result = await parser.getOpenedIntent(MOCK_TX_HASH, MOCK_CHAIN_ID);
+
+            expect(result.orderId).toBe(MOCK_TX_HASH);
+            expect(result.txHash).toBe(MOCK_TX_HASH);
+            expect(result.originChainId).toBe(11155111);
+        });
+
+        it("passes API response to extractOpenedIntent", async () => {
+            const mockResponse = { status: "success", originChainId: 42161 };
+            const extractSpy = vi.fn().mockReturnValue({
+                orderId: MOCK_TX_HASH,
+                txHash: MOCK_TX_HASH,
+                blockNumber: 0n,
+                originContract: "0x0000000000000000000000000000000000000000" as Address,
+                user: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" as Address,
+                originChainId: 42161,
+                openDeadline: 0,
+                fillDeadline: 0,
+                maxSpent: [],
+                minReceived: [],
+                fillInstructions: [],
+            });
+
+            const config = createMockConfig({ extractOpenedIntent: extractSpy });
+            const customParser = new APIOpenedIntentParser(config);
+
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(JSON.stringify(mockResponse), { status: 200 }),
+            );
+
+            await customParser.getOpenedIntent(MOCK_TX_HASH, MOCK_CHAIN_ID);
+
+            expect(extractSpy).toHaveBeenCalledWith(mockResponse, MOCK_TX_HASH);
+        });
+
+        it("throws OpenedIntentNotFoundError on non-OK response", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response("Not Found", { status: 404 }),
+            );
+
+            await expect(parser.getOpenedIntent(MOCK_TX_HASH, MOCK_CHAIN_ID)).rejects.toThrow(
+                OpenedIntentNotFoundError,
+            );
+        });
+
+        it("propagates errors thrown by extractOpenedIntent", async () => {
+            const config = createMockConfig({
+                extractOpenedIntent: () => {
+                    throw new OpenedIntentNotFoundError(MOCK_TX_HASH, "test-protocol");
+                },
+            });
+            const customParser = new APIOpenedIntentParser(config);
+
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(JSON.stringify({}), { status: 200 }),
+            );
+
+            await expect(customParser.getOpenedIntent(MOCK_TX_HASH, MOCK_CHAIN_ID)).rejects.toThrow(
+                OpenedIntentNotFoundError,
+            );
+        });
+
+        it("includes protocol name in error message", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response("Server Error", { status: 500 }),
+            );
+
+            await expect(parser.getOpenedIntent(MOCK_TX_HASH, MOCK_CHAIN_ID)).rejects.toThrow(
+                "test-protocol opened intent event not found",
+            );
+        });
+
+        it("propagates fetch errors", async () => {
+            vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Network failure"));
+
+            await expect(parser.getOpenedIntent(MOCK_TX_HASH, MOCK_CHAIN_ID)).rejects.toThrow(
+                "Network failure",
+            );
+        });
+    });
+});

--- a/packages/cross-chain/test/services/crossChainProviderFactory.spec.ts
+++ b/packages/cross-chain/test/services/crossChainProviderFactory.spec.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createCrossChainProvider } from "../../src/factories/crossChainProviderFactory.js";
-import { AcrossProvider, CrossChainProvider, UnsupportedProtocol } from "../../src/internal.js";
+import {
+    AcrossProvider,
+    CrossChainProvider,
+    RelayProvider,
+    UnsupportedProtocol,
+} from "../../src/internal.js";
 
 const MOCK_ACROSS_CONFIG = {
     apiUrl: "https://across.to/api",
@@ -29,6 +34,19 @@ describe("createCrossChainProvider", () => {
         const provider = createCrossChainProvider("across");
 
         expect(provider).toBeInstanceOf(AcrossProvider);
+    });
+
+    it("creates a RelayProvider with default config", () => {
+        const provider = createCrossChainProvider("relay");
+
+        expect(provider).toBeInstanceOf(RelayProvider);
+    });
+
+    it("creates a RelayProvider with custom config", () => {
+        const provider = createCrossChainProvider("relay", { providerId: "relay-custom" });
+
+        expect(provider).toBeInstanceOf(RelayProvider);
+        expect(provider.providerId).toBe("relay-custom");
     });
 
     it("throws an UnsupportedProtocol error for unsupported protocols", () => {


### PR DESCRIPTION
## Summary
- Add `RelayProvider` class implementing `CrossChainProvider` with quote (`POST /quote/v2`), status (`GET /intents/status/v3`), and API-based fill tracking
- Add `ProviderGetStatusFailure` error class for semantic error handling in `getStatus()`
- Register Relay in the provider factory with typed overloads
- Export `RelayProvider` and `RelayConfigs` from the public API

## Test plan
- [x] 37 unit tests covering quote mapping, fallbacks, error handling, status, tracking config, and fill event extraction
- [x] All 520 package tests pass
- [x] Lint, prettier, and `check-types` pass

> Depends on #196 (`feat/relay-types`)