### PR TITLE
refactor(cross-chain): plain addresses and numeric chain IDs in asset discovery

### DIFF
--- a/.changeset/refactor-asset-discovery-plain-addresses.md
+++ b/.changeset/refactor-asset-discovery-plain-addresses.md
@@ -1,0 +1,12 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Refactor asset discovery to use plain addresses and numeric chain IDs
+
+-   `DiscoveredAssets.tokensByChain` now uses numeric chain ID keys (e.g. `1`) instead of CAIP-350 strings (e.g. `"eip155:1"`)
+-   `DiscoveredAssets.tokenMetadata` is now nested by chain ID then lowercase address to prevent cross-chain collisions
+-   `AssetInfo.address` uses plain `0x` format instead of EIP-7930 interop encoding
+-   `RouteQuery` now takes `originChainId`, `originAsset`, `destinationChainId`, `destinationAsset` (4 fields) instead of two EIP-7930 addresses
+-   Removed `encodeAddress`/`toChainIdentifier` dependencies from asset discovery pipeline
+-   Removed `toEVMInteropAddress` helper (no longer needed)

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -92,24 +92,24 @@ An abstract class that defines the interface for cross-chain protocol providers.
     const config = provider.getTrackingConfig();
     ```
 
-### Provider Executor
+### Aggregator
 
 A utility for managing multiple cross-chain providers and executing operations across them.
 
 #### Methods
 
--   **createProviderExecutor**(config: ProviderExecutorConfig): ProviderExecutor
+-   **createAggregator**(config: AggregatorConfig): Aggregator
 
-    Creates an executor instance for managing multiple providers.
+    Creates an aggregator instance for managing multiple providers.
 
     ```typescript
     import {
-        createProviderExecutor,
+        createAggregator,
         OrderTrackerFactory,
         SortingStrategyFactory,
     } from "@wonderland/interop-cross-chain";
 
-    const executor = createProviderExecutor({
+    const aggregator = createAggregator({
         providers: [acrossProvider],
         sortingStrategy: SortingStrategyFactory.createStrategy("bestOutput"), // optional
         timeoutMs: 15000, // optional
@@ -117,7 +117,7 @@ A utility for managing multiple cross-chain providers and executing operations a
     });
     ```
 
-#### ProviderExecutor Class
+#### Aggregator Class
 
 A class that manages multiple cross-chain providers and coordinates their operations.
 
@@ -126,7 +126,7 @@ A class that manages multiple cross-chain providers and coordinates their operat
     Retrieves quotes from all available providers for a given operation.
 
     ```typescript
-    const response = await executor.getQuotes({
+    const response = await aggregator.getQuotes({
         user: USER_INTEROP_ADDRESS, // user's interop address (binary format)
         intent: {
             intentType: "oif-swap",
@@ -162,7 +162,7 @@ A class that manages multiple cross-chain providers and coordinates their operat
     ```typescript
     import { OrderStatus } from "@wonderland/interop-cross-chain";
 
-    const tracker = executor.track({
+    const tracker = aggregator.track({
         txHash: hash,
         providerId: quote.provider,
         originChainId: 11155111,
@@ -178,7 +178,7 @@ A class that manages multiple cross-chain providers and coordinates their operat
     Gets the current status of an order without watching.
 
     ```typescript
-    const status = await executor.getOrderStatus({
+    const status = await aggregator.getOrderStatus({
         txHash: "0x...",
         providerId: "across",
         originChainId: 11155111,

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -186,6 +186,39 @@ A class that manages multiple cross-chain providers and coordinates their operat
     console.log(status.status); // OrderStatus
     ```
 
+-   **prepareTracking**(providerId: string): OrderTracker
+
+    Returns an OrderTracker instance for a provider. Use this to set up event listeners _before_ sending a transaction.
+
+    ```typescript
+    const tracker = aggregator.prepareTracking(quote._providerId);
+    tracker.on(OrderStatus.Finalized, (update) => console.log("Done!", update.fillTxHash));
+    // ...then send the transaction and call tracker.startTracking(...)
+    ```
+
+-   **discoverAssets**(options?: AssetDiscoveryOptions): Promise\<DiscoveredAssets\>
+
+    Discovers supported assets from all configured providers.
+
+    ```typescript
+    const discovered = await aggregator.discoverAssets({ chainIds: [1, 42161] });
+    // discovered.tokensByChain — token addresses grouped by numeric chain ID
+    // discovered.tokenMetadata — token metadata nested by chain ID then lowercase address
+    ```
+
+-   **getProvidersForRoute**(query: RouteQuery): Promise\<string[]\>
+
+    Returns provider IDs that support a given origin/destination asset pair. Uses plain 0x addresses and numeric chain IDs.
+
+    ```typescript
+    const providers = await aggregator.getProvidersForRoute({
+        originChainId: 1,
+        originAsset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        destinationChainId: 42161,
+        destinationAsset: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+    });
+    ```
+
 ### Sorting Strategies
 
 #### SortingStrategyFactory

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -97,6 +97,7 @@ A utility for managing multiple cross-chain providers and executing operations a
 
     ```typescript
     import {
+        AssetDiscoveryFactory,
         createAggregator,
         OrderTrackerFactory,
         SortingStrategyFactory,

--- a/examples/ui/app/cross-chain/hooks/useAssetDiscovery.ts
+++ b/examples/ui/app/cross-chain/hooks/useAssetDiscovery.ts
@@ -1,11 +1,9 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { type ChainIdentifier, decodeAddress, fromChainIdentifier } from '@wonderland/interop-addresses';
 import { crossChainExecutor } from '../services/sdk';
 import type { DiscoveredAssets, UITokenInfo } from '../types/assets';
 import type { DiscoveredAssets as SdkDiscoveredAssets } from '@wonderland/interop-cross-chain';
-import type { Hex } from 'viem';
 
 interface UseAssetDiscoveryResult {
   /** Discovered assets, null if not yet loaded */
@@ -19,51 +17,33 @@ interface UseAssetDiscoveryResult {
 }
 
 /**
- * Transform SDK DiscoveredAssets (CAIP-350 keyed, EIP-7930 addresses) to UI-friendly format
- * (numeric chain IDs, decoded EVM addresses). Provider attribution is read directly from
- * tokenMetadata[addr].providers.
+ * Transform SDK DiscoveredAssets (numeric chain ID keys, plain 0x addresses)
+ * to the UI-friendly format. Provider attribution is read directly from
+ * tokenMetadata[chainId][addr].providers.
  */
 function transformToUiAssets(sdkAssets: SdkDiscoveredAssets): DiscoveredAssets {
   const supportedTokensByChain: Record<number, string[]> = {};
   const tokenInfo: Record<number, Record<string, UITokenInfo>> = {};
   const chainIdSet = new Set<number>();
 
-  for (const chainIdentifier of Object.keys(sdkAssets.tokensByChain) as ChainIdentifier[]) {
-    let numericChainId: number;
-    try {
-      numericChainId = fromChainIdentifier(chainIdentifier).chainReference;
-    } catch {
-      continue;
-    }
+  for (const [chainIdStr, addresses] of Object.entries(sdkAssets.tokensByChain)) {
+    const chainId = Number(chainIdStr);
+    chainIdSet.add(chainId);
 
-    chainIdSet.add(numericChainId);
+    supportedTokensByChain[chainId] ??= [];
+    tokenInfo[chainId] ??= {};
 
-    const interopAddresses = sdkAssets.tokensByChain[chainIdentifier] ?? [];
+    const chainMeta = sdkAssets.tokenMetadata[chainId] ?? {};
 
-    if (!supportedTokensByChain[numericChainId]) {
-      supportedTokensByChain[numericChainId] = [];
-    }
-    if (!tokenInfo[numericChainId]) {
-      tokenInfo[numericChainId] = {};
-    }
-
-    for (const interopAddress of interopAddresses) {
-      let rawAddress: string;
-      try {
-        const decoded = decodeAddress(interopAddress as Hex);
-        rawAddress = decoded.address ?? interopAddress;
-      } catch {
-        rawAddress = interopAddress;
+    for (const addr of addresses) {
+      if (!supportedTokensByChain[chainId].includes(addr)) {
+        supportedTokensByChain[chainId].push(addr);
       }
 
-      if (!supportedTokensByChain[numericChainId].includes(rawAddress)) {
-        supportedTokensByChain[numericChainId].push(rawAddress);
-      }
+      const sdkMeta = chainMeta[addr.toLowerCase()];
 
-      const sdkMeta = sdkAssets.tokenMetadata[interopAddress];
-
-      if (!tokenInfo[numericChainId][rawAddress]) {
-        tokenInfo[numericChainId][rawAddress] = {
+      if (!tokenInfo[chainId][addr]) {
+        tokenInfo[chainId][addr] = {
           symbol: sdkMeta?.symbol ?? 'UNKNOWN',
           decimals: sdkMeta?.decimals ?? 18,
           providers: sdkMeta?.providers ? [...sdkMeta.providers] : [],

--- a/examples/ui/app/cross-chain/services/assetService.ts
+++ b/examples/ui/app/cross-chain/services/assetService.ts
@@ -1,17 +1,8 @@
-import { decodeAddress } from '@wonderland/interop-addresses';
 import { isNativeAddress } from '@wonderland/interop-cross-chain';
-import { type Address, erc20Abi, formatUnits, type Hex, isAddress } from 'viem';
+import { type Address, erc20Abi, formatUnits, isAddress } from 'viem';
 import { getPublicClient } from '../config/publicClient';
 import type { BalanceTarget, TokenBalance } from '../stores/balanceStore';
 import type { DiscoveredAssets } from '../types/assets';
-
-// TODO: SDK will return EIP-7930 interop addresses — all addresses will need decoding
-function resolveEvmAddress(address: string): Address {
-  if (isAddress(address)) return address;
-
-  const decoded = decodeAddress(address as Hex);
-  return decoded.address as Address;
-}
 
 export class AssetService {
   private getClient(chainId: number) {
@@ -74,7 +65,10 @@ export class AssetService {
   ): Promise<Record<string, TokenBalance>> {
     if (tokens.length === 0) return {};
 
-    const owner = resolveEvmAddress(userAddress);
+    if (!isAddress(userAddress)) {
+      throw new Error(`Invalid user address: ${userAddress}`);
+    }
+    const owner = userAddress as Address;
     const nativeTokens = tokens.filter((t) => isNativeAddress(t, 'eip155'));
     const erc20Tokens = tokens.filter((t) => !isNativeAddress(t, 'eip155'));
     const balances: Record<string, TokenBalance> = {};
@@ -94,7 +88,7 @@ export class AssetService {
     if (erc20Tokens.length === 0) return balances;
 
     const contracts = erc20Tokens.map((token) => ({
-      address: resolveEvmAddress(token),
+      address: token as Address,
       abi: erc20Abi,
       functionName: 'balanceOf' as const,
       args: [owner] as const,

--- a/examples/ui/app/cross-chain/services/assetService.ts
+++ b/examples/ui/app/cross-chain/services/assetService.ts
@@ -85,9 +85,10 @@ export class AssetService {
       }
     }
 
-    if (erc20Tokens.length === 0) return balances;
+    const validErc20Tokens = erc20Tokens.filter((token) => isAddress(token));
+    if (validErc20Tokens.length === 0) return balances;
 
-    const contracts = erc20Tokens.map((token) => ({
+    const contracts = validErc20Tokens.map((token) => ({
       address: token as Address,
       abi: erc20Abi,
       functionName: 'balanceOf' as const,
@@ -96,7 +97,7 @@ export class AssetService {
 
     const results = await client.multicall({ contracts });
 
-    erc20Tokens.forEach((token, i) => {
+    validErc20Tokens.forEach((token, i) => {
       const result = results[i];
       if (result.status === 'success' && result.result !== undefined) {
         const decimals = chainInfo[token]?.decimals ?? 18;

--- a/examples/ui/tests/mint.spec.ts
+++ b/examples/ui/tests/mint.spec.ts
@@ -1,35 +1,12 @@
 import { test, expect } from '@playwright/test';
 
-/**
- * Mock OIF solver response including OP Sepolia and Base Sepolia USDC.
- * The mint button only appears for tokens with the 'oif' provider.
- */
-const MOCK_OIF_SOLVER_RESPONSE = {
-  supportedAssets: {
-    assets: [
-      { address: '0x5fd84259d66Cd46123540766Be93DFE6D43130D7', chainId: 11155420, symbol: 'USDC', decimals: 6 },
-      { address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e', chainId: 84532, symbol: 'USDC', decimals: 6 },
-    ],
-  },
-};
-
 test.describe('Mint mockUSDC', () => {
-  test.beforeEach(async ({ page, context }) => {
-    // Mock OIF solver discovery to include OP Sepolia and Base Sepolia
-    await context.route('**/oif-api.openzeppelin.com/**', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(MOCK_OIF_SOLVER_RESPONSE),
-      });
-    });
-
+  test.beforeEach(async ({ page }) => {
     await page.goto('/cross-chain?testnet=true');
   });
 
   test('mints and updates balance in UI', async ({ page }) => {
-    // Wait for asset discovery to populate chain selects
-    await expect(page.locator('#output-chain-select > option')).not.toHaveCount(0, { timeout: 15_000 });
+    await expect(page.getByRole('textbox', { name: 'Amount' })).toBeVisible({ timeout: 15_000 });
 
     await page.locator('#output-chain-select').selectOption({ label: 'OP Sepolia' });
     await page.locator('#input-chain-select').selectOption({ label: 'Base Sepolia' });

--- a/examples/ui/tests/mint.spec.ts
+++ b/examples/ui/tests/mint.spec.ts
@@ -1,12 +1,35 @@
 import { test, expect } from '@playwright/test';
 
+/**
+ * Mock OIF solver response including OP Sepolia and Base Sepolia USDC.
+ * The mint button only appears for tokens with the 'oif' provider.
+ */
+const MOCK_OIF_SOLVER_RESPONSE = {
+  supportedAssets: {
+    assets: [
+      { address: '0x5fd84259d66Cd46123540766Be93DFE6D43130D7', chainId: 11155420, symbol: 'USDC', decimals: 6 },
+      { address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e', chainId: 84532, symbol: 'USDC', decimals: 6 },
+    ],
+  },
+};
+
 test.describe('Mint mockUSDC', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, context }) => {
+    // Mock OIF solver discovery to include OP Sepolia and Base Sepolia
+    await context.route('**/oif-api.openzeppelin.com/**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_OIF_SOLVER_RESPONSE),
+      });
+    });
+
     await page.goto('/cross-chain?testnet=true');
   });
 
   test('mints and updates balance in UI', async ({ page }) => {
-    await expect(page.getByRole('textbox', { name: 'Amount' })).toBeVisible({ timeout: 15_000 });
+    // Wait for asset discovery to populate chain selects
+    await expect(page.locator('#output-chain-select > option')).not.toHaveCount(0, { timeout: 15_000 });
 
     await page.locator('#output-chain-select').selectOption({ label: 'OP Sepolia' });
     await page.locator('#input-chain-select').selectOption({ label: 'Base Sepolia' });

--- a/packages/cross-chain/README.md
+++ b/packages/cross-chain/README.md
@@ -149,8 +149,8 @@ const ethTokens = discovered.tokensByChain[1];
 
 // Get metadata for a specific token (nested by chainId then lowercase address)
 const usdc = discovered.tokenMetadata[1]?.["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"];
-console.log(usdc.symbol); // "USDC"
-console.log(usdc.decimals); // 6
+console.log(usdc?.symbol); // "USDC"
+console.log(usdc?.decimals); // 6
 ```
 
 **Via individual service:**

--- a/packages/cross-chain/README.md
+++ b/packages/cross-chain/README.md
@@ -138,7 +138,6 @@ The SDK provides utilities to discover supported assets from providers. All disc
 **Via ProviderExecutor (recommended):**
 
 ```typescript
-import { toChainIdentifier } from "@wonderland/interop-addresses";
 import { createProviderExecutor } from "@wonderland/interop-cross-chain";
 
 const executor = createProviderExecutor({ providers: [acrossProvider] });
@@ -146,11 +145,11 @@ const executor = createProviderExecutor({ providers: [acrossProvider] });
 // Discover assets from all configured providers
 const discovered = await executor.discoverAssets({ chainIds: [1, 42161] });
 
-// Get tokens for Ethereum using CAIP-350 chain identifier
-const ethTokens = discovered.tokensByChain[toChainIdentifier(1)]; // "eip155:1"
+// Get tokens for Ethereum using numeric chain ID
+const ethTokens = discovered.tokensByChain[1];
 
-// Get metadata for a specific token (flat lookup by interop address)
-const usdc = discovered.tokenMetadata["0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"];
+// Get metadata for a specific token (nested by chainId then lowercase address)
+const usdc = discovered.tokenMetadata[1]?.["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"];
 console.log(usdc.symbol); // "USDC"
 console.log(usdc.decimals); // 6
 ```
@@ -158,24 +157,23 @@ console.log(usdc.decimals); // 6
 **Via individual service:**
 
 ```typescript
-import { toChainIdentifier } from "@wonderland/interop-addresses";
 import { createAssetDiscoveryService } from "@wonderland/interop-cross-chain";
 
 const service = createAssetDiscoveryService(provider);
 const discovered = await service.getSupportedAssets(); // Returns DiscoveredAssets directly
 
-const ethTokens = discovered.tokensByChain[toChainIdentifier(1)];
+const ethTokens = discovered.tokensByChain[1];
 ```
 
 **Key concepts:**
 
--   **CAIP-350 chain identifiers**: Chain identifiers use CAIP-350 format (e.g., `"eip155:1"` for Ethereum mainnet). Use `toChainIdentifier(numericChainId)` from `@wonderland/interop-addresses` to convert from viem's numeric chain ID.
--   **EIP-7930 interop addresses**: All addresses in `tokensByChain` and `tokenMetadata` use the EIP-7930 interoperable format. Use `decodeAddress` from `@wonderland/interop-addresses` when you need the plain `0x` address for display or wallet interaction.
--   **Flat metadata**: `tokenMetadata` is keyed directly by interop address (globally unique), not nested by chain.
+-   **Numeric chain IDs**: Chain keys are plain numbers (e.g., `1` for Ethereum, `42161` for Arbitrum) — the same format used by viem and the rest of the SDK.
+-   **Plain addresses**: All addresses in `tokensByChain` and `tokenMetadata` use standard `0x`-prefixed format, ready for display or wallet interaction.
+-   **Nested metadata**: `tokenMetadata` is nested by chain ID then lowercase address to prevent cross-chain address collisions.
 
 **Types:**
 
--   `DiscoveredAssets` – Aggregated discovery result with `tokensByChain`, `tokenMetadata`, and `chainIds`.
+-   `DiscoveredAssets` – Aggregated discovery result with `tokensByChain` and `tokenMetadata`.
 -   `AssetInfo` – Token metadata: `{ address, symbol, decimals }`.
 
 ### Types

--- a/packages/cross-chain/src/core/interfaces/assetDiscovery.interface.ts
+++ b/packages/cross-chain/src/core/interfaces/assetDiscovery.interface.ts
@@ -28,8 +28,8 @@ export interface AssetDiscoveryService {
      * Get all supported assets across all chains
      *
      * Returns a pre-processed DiscoveredAssets structure with:
-     * - tokensByChain: CAIP-350 chain identifier keys → EIP-7930 token addresses
-     * - tokenMetadata: flat lookup by interop address → AssetInfo
+     * - tokensByChain: numeric chain ID keys → plain 0x token addresses
+     * - tokenMetadata: nested lookup by chain ID → lowercase address → AssetInfo
      *
      * @param options - Discovery options (filtering)
      * @returns Aggregated discovery result ready for consumption
@@ -50,7 +50,7 @@ export interface AssetDiscoveryService {
      * Check if a specific asset is supported
      *
      * @param chainId - Chain ID where the asset exists
-     * @param assetAddress - Asset address (EIP-7930 format)
+     * @param assetAddress - Asset address (plain 0x format)
      * @param options - Discovery options
      * @returns Asset info if supported, null otherwise
      */

--- a/packages/cross-chain/src/core/schemas/address.ts
+++ b/packages/cross-chain/src/core/schemas/address.ts
@@ -11,7 +11,7 @@ export const AddressSchema = z
         "Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for\nunambiguous cross-chain identification.",
     );
 
-export const HexAddressSchema = z.string().refine((val) => isAddress(val), {
+export const HexAddressSchema = z.string().refine((val) => isAddress(val, { strict: false }), {
     message: "Invalid hex address",
 });
 

--- a/packages/cross-chain/src/core/schemas/assetDiscovery.ts
+++ b/packages/cross-chain/src/core/schemas/assetDiscovery.ts
@@ -7,19 +7,15 @@
  * @note The API returns snake_case (chain_id), but the SDK transforms to camelCase (chainId).
  */
 
-import { isAddress } from "viem";
 import { z } from "zod";
+
+import { HexAddressSchema } from "./address.js";
 
 /**
  * Schema for asset metadata
  */
 export const assetInfoSchema = z.object({
-    address: z
-        .string()
-        .refine((val) => isAddress(val, { strict: false }), {
-            message: "Invalid address: expected a 0x-prefixed hex address",
-        })
-        .describe("Asset address in plain 0x format"),
+    address: HexAddressSchema.describe("Asset address in plain 0x format"),
     symbol: z.string().describe('Asset symbol for display purposes (e.g., "USDC", "WETH", "USDT")'),
     decimals: z
         .number()

--- a/packages/cross-chain/src/core/schemas/assetDiscovery.ts
+++ b/packages/cross-chain/src/core/schemas/assetDiscovery.ts
@@ -7,17 +7,19 @@
  * @note The API returns snake_case (chain_id), but the SDK transforms to camelCase (chainId).
  */
 
+import { isAddress } from "viem";
 import { z } from "zod";
-
-import { AddressSchema } from "./address.js";
 
 /**
  * Schema for asset metadata
  */
 export const assetInfoSchema = z.object({
-    address: AddressSchema.describe(
-        "Asset address in EIP-7930 interoperable format for cross-chain compatibility.\nAll addresses are formatted with the 0x prefix.",
-    ),
+    address: z
+        .string()
+        .refine((val) => isAddress(val, { strict: false }), {
+            message: "Invalid address: expected a 0x-prefixed hex address",
+        })
+        .describe("Asset address in plain 0x format"),
     symbol: z.string().describe('Asset symbol for display purposes (e.g., "USDC", "WETH", "USDT")'),
     decimals: z
         .number()

--- a/packages/cross-chain/src/core/schemas/common.ts
+++ b/packages/cross-chain/src/core/schemas/common.ts
@@ -1,9 +1,11 @@
 import { isAddress } from "viem";
 import { z } from "zod";
 
-export const addressString = z.string().refine((val): boolean => isAddress(val), {
-    message: "Invalid hex address",
-});
+export const addressString = z
+    .string()
+    .refine((val): boolean => isAddress(val, { strict: false }), {
+        message: "Invalid hex address",
+    });
 
 export const amountSchema = z
     .string()

--- a/packages/cross-chain/src/core/services/aggregator.ts
+++ b/packages/cross-chain/src/core/services/aggregator.ts
@@ -21,7 +21,6 @@ import { ProviderTimeout } from "../errors/ProviderTimeout.exception.js";
 import { CrossChainProvider } from "../interfaces/crossChainProvider.interface.js";
 import { SortingStrategy } from "../interfaces/sortingStrategy.interface.js";
 import { BestOutputStrategy } from "../sorting_strategies/bestOutput.strategy.js";
-import { fromInteropAccountId } from "../utils/interopAccountId.js";
 import { mergeDiscoveredAssets } from "../utils/toDiscoveredAssets.js";
 import { OrderTracker } from "./OrderTracker.js";
 
@@ -107,9 +106,7 @@ class Aggregator {
             ];
 
             const checks = assets.map((asset) => {
-                // Need ERC-7930 for discovery service (it still uses wire format)
-                const hex = fromInteropAccountId(asset);
-                return discovery.isAssetSupported(asset.chainId, hex);
+                return discovery.isAssetSupported(asset.chainId, asset.address);
             });
 
             const results = await Promise.all(checks);
@@ -304,8 +301,10 @@ class Aggregator {
     async getProvidersForRoute(query: RouteQuery): Promise<string[]> {
         const assets = await this.discoverAssets();
 
-        const originMeta = assets.tokenMetadata[query.originAsset];
-        const destMeta = assets.tokenMetadata[query.destinationAsset];
+        const originMeta =
+            assets.tokenMetadata[query.originChainId]?.[query.originAsset.toLowerCase()];
+        const destMeta =
+            assets.tokenMetadata[query.destinationChainId]?.[query.destinationAsset.toLowerCase()];
 
         if (!originMeta || !destMeta) {
             return [];

--- a/packages/cross-chain/src/core/types/assetDiscovery.ts
+++ b/packages/cross-chain/src/core/types/assetDiscovery.ts
@@ -9,22 +9,19 @@
  * - GET /api/tokens/{chain_id} - Returns assets for a specific chain
  */
 
-import type { Address } from "@openintentsframework/oif-specs";
-import type { ChainIdentifier } from "@wonderland/interop-addresses";
-
 /**
  * Asset metadata information
  *
  * @example
  * {
- *   address: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Ethereum (EIP-7930)
+ *   address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Ethereum
  *   symbol: "USDC",
  *   decimals: 6
  * }
  */
 export interface AssetInfo {
-    /** Asset address in EIP-7930 interoperable format */
-    address: Address;
+    /** Asset address in plain 0x format */
+    address: string;
     /** Human-readable asset symbol */
     symbol: string;
     /** Number of decimal places for the asset */
@@ -82,32 +79,31 @@ export interface DiscoveredAssetInfo extends AssetInfo {
 
 /**
  * Aggregated view of discovered assets from one or more providers,
- * indexed for fast lookup by chain and interop address.
+ * indexed for fast lookup by chain and address.
  *
- * Chain keys use CAIP-350 format (e.g. "eip155:1", "eip155:42161").
- * All addresses use the EIP-7930 interop format.
+ * Chain keys are numeric chain IDs (e.g. `1`, `42161`).
+ * All addresses use plain `0x` format.
  *
- * Use `toChainIdentifier(chainId)` from `@wonderland/interop-addresses` to
- * convert a numeric chain ID to a CAIP-350 identifier.
- * Use `decodeAddress` from `@wonderland/interop-addresses` to get the
- * plain address when needed for display or wallet interaction.
+ * Token metadata is nested by chain ID to prevent cross-chain address
+ * collisions (the same contract address can exist on multiple chains).
  */
 export interface DiscoveredAssets {
-    /** Token interop addresses grouped by CAIP-350 chain identifier */
-    tokensByChain: Record<ChainIdentifier, readonly Address[]>;
-    /** Token metadata keyed by interop address (globally unique), with provider attribution */
-    tokenMetadata: Record<Address, DiscoveredAssetInfo>;
+    /** Token addresses grouped by numeric chain ID */
+    tokensByChain: Record<number, readonly string[]>;
+    /** Token metadata nested by chain ID then lowercase address, with provider attribution */
+    tokenMetadata: Record<number, Record<string, DiscoveredAssetInfo>>;
 }
 
 /**
  * Query parameters for finding providers that support a specific route.
- *
- * Both addresses use EIP-7930 interop format, which encodes the chain ID
- * inside the address itself -- so only two params are needed.
  */
 export interface RouteQuery {
-    /** Origin asset in EIP-7930 interop address format */
-    originAsset: Address;
-    /** Destination asset in EIP-7930 interop address format */
-    destinationAsset: Address;
+    /** Origin chain ID */
+    originChainId: number;
+    /** Origin asset address in plain 0x format */
+    originAsset: string;
+    /** Destination chain ID */
+    destinationChainId: number;
+    /** Destination asset address in plain 0x format */
+    destinationAsset: string;
 }

--- a/packages/cross-chain/src/core/utils/addressHelpers.ts
+++ b/packages/cross-chain/src/core/utils/addressHelpers.ts
@@ -1,5 +1,5 @@
-import { encodeAddress } from "@wonderland/interop-addresses";
-import { Address, Hex } from "viem";
+import type { Address } from "viem";
+import { Hex } from "viem";
 
 /**
  * Convert a bytes32 value to an Ethereum address
@@ -20,14 +20,4 @@ import { Address, Hex } from "viem";
 export function bytes32ToAddress(bytes32: Hex): Address {
     // Take the last 40 characters (20 bytes = 40 hex chars)
     return `0x${bytes32.slice(-40)}` as Address;
-}
-
-/**
- * Encode a raw address + chain ID into an EIP-7930 interoperable address (hex format).
- */
-export function toEVMInteropAddress(chainId: number, address: Address): Address {
-    return encodeAddress(
-        { version: 1, chainType: "eip155", chainReference: chainId.toString(), address },
-        { format: "hex" },
-    ) as Address;
 }

--- a/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
+++ b/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
@@ -1,5 +1,3 @@
-import { toChainIdentifier } from "@wonderland/interop-addresses";
-
 import type {
     AssetDiscoveryResult,
     DiscoveredAssetInfo,
@@ -10,8 +8,9 @@ import type {
  * Convert one or more AssetDiscoveryResults into a lookup-friendly
  * DiscoveredAssets structure.
  *
- * Chain grouping uses CAIP-350 keys. Token metadata is flat (interop
- * addresses are globally unique). Addresses are kept in EIP-7930 format.
+ * Chain grouping uses numeric chain IDs. Token metadata is nested by
+ * chain ID then lowercase address to prevent cross-chain collisions.
+ * All addresses use plain 0x format.
  * Each metadata entry includes a `providers` array listing which provider IDs
  * reported the asset.
  *
@@ -23,31 +22,32 @@ export function toDiscoveredAssets(
     results: AssetDiscoveryResult[],
     filterChainIds?: number[],
 ): DiscoveredAssets {
-    const tokensByChain: Record<string, string[]> = {};
-    const tokenMetadata: Record<string, DiscoveredAssetInfo> = {};
+    const tokensByChain: Record<number, string[]> = {};
+    const tokenMetadata: Record<number, Record<string, DiscoveredAssetInfo>> = {};
 
     for (const result of results) {
         for (const network of result.networks) {
             const { chainId, assets } = network;
             if (filterChainIds && !filterChainIds.includes(chainId)) continue;
 
-            const key = toChainIdentifier(chainId) as string;
-            tokensByChain[key] ??= [];
+            tokensByChain[chainId] ??= [];
+            tokenMetadata[chainId] ??= {};
 
             for (const asset of assets) {
                 const addr = asset.address;
+                const addrLower = addr.toLowerCase();
 
-                if (!tokensByChain[key].includes(addr)) {
-                    tokensByChain[key].push(addr);
+                if (!tokensByChain[chainId].includes(addr)) {
+                    tokensByChain[chainId].push(addr);
                 }
 
-                const existing = tokenMetadata[addr];
+                const existing = tokenMetadata[chainId][addrLower];
                 if (existing) {
                     if (!existing.providers.includes(result.providerId)) {
                         existing.providers.push(result.providerId);
                     }
                 } else {
-                    tokenMetadata[addr] = {
+                    tokenMetadata[chainId][addrLower] = {
                         address: asset.address,
                         symbol: asset.symbol,
                         decimals: asset.decimals,
@@ -75,29 +75,34 @@ export function toDiscoveredAssets(
  * @param sources - Array of DiscoveredAssets to merge
  */
 export function mergeDiscoveredAssets(sources: DiscoveredAssets[]): DiscoveredAssets {
-    const tokensByChain: Record<string, string[]> = {};
-    const tokenMetadata: Record<string, DiscoveredAssetInfo> = {};
+    const tokensByChain: Record<number, string[]> = {};
+    const tokenMetadata: Record<number, Record<string, DiscoveredAssetInfo>> = {};
 
     for (const source of sources) {
-        for (const [chainKey, tokens] of Object.entries(source.tokensByChain)) {
-            tokensByChain[chainKey] ??= [];
+        for (const [chainKeyStr, tokens] of Object.entries(source.tokensByChain)) {
+            const chainId = Number(chainKeyStr);
+            tokensByChain[chainId] ??= [];
             for (const token of tokens) {
-                if (!tokensByChain[chainKey].includes(token)) {
-                    tokensByChain[chainKey].push(token);
+                if (!tokensByChain[chainId].includes(token)) {
+                    tokensByChain[chainId].push(token);
                 }
             }
         }
 
-        for (const [addr, meta] of Object.entries(source.tokenMetadata)) {
-            const existing = tokenMetadata[addr];
-            if (existing) {
-                for (const pid of meta.providers) {
-                    if (!existing.providers.includes(pid)) {
-                        existing.providers.push(pid);
+        for (const [chainKeyStr, chainMeta] of Object.entries(source.tokenMetadata)) {
+            const chainId = Number(chainKeyStr);
+            tokenMetadata[chainId] ??= {};
+            for (const [addr, meta] of Object.entries(chainMeta)) {
+                const existing = tokenMetadata[chainId][addr];
+                if (existing) {
+                    for (const pid of meta.providers) {
+                        if (!existing.providers.includes(pid)) {
+                            existing.providers.push(pid);
+                        }
                     }
+                } else {
+                    tokenMetadata[chainId][addr] = { ...meta, providers: [...meta.providers] };
                 }
-            } else {
-                tokenMetadata[addr] = { ...meta, providers: [...meta.providers] };
             }
         }
     }

--- a/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
+++ b/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
@@ -37,8 +37,8 @@ export function toDiscoveredAssets(
                 const addr = asset.address;
                 const addrLower = addr.toLowerCase();
 
-                if (!tokensByChain[chainId].includes(addr)) {
-                    tokensByChain[chainId].push(addr);
+                if (!tokensByChain[chainId].includes(addrLower)) {
+                    tokensByChain[chainId].push(addrLower);
                 }
 
                 const existing = tokenMetadata[chainId][addrLower];

--- a/packages/cross-chain/src/protocols/across/constants.ts
+++ b/packages/cross-chain/src/protocols/across/constants.ts
@@ -2,7 +2,6 @@ import { getAddress, Hex } from "viem";
 import { arbitrum, arbitrumSepolia, base, baseSepolia, sepolia } from "viem/chains";
 
 import type { NetworkAssets } from "../../core/types/assetDiscovery.js";
-import { toEVMInteropAddress } from "../../core/utils/addressHelpers.js";
 
 export const ACROSS_ORDER_DATA_TYPE =
     "0x9df4b782e7bbc178b3b93bfe8aafb909e84e39484d7f3c59f400f1b4691f85e2";
@@ -184,18 +183,12 @@ export const ACROSS_TESTNET_TOKENS: NetworkAssets[] = [
         chainId: 11155111, // Sepolia
         assets: [
             {
-                address: toEVMInteropAddress(
-                    11155111,
-                    "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14",
-                ),
+                address: "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14",
                 symbol: "WETH",
                 decimals: 18,
             },
             {
-                address: toEVMInteropAddress(
-                    11155111,
-                    "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
-                ),
+                address: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
                 symbol: "USDC",
                 decimals: 6,
             },
@@ -205,12 +198,12 @@ export const ACROSS_TESTNET_TOKENS: NetworkAssets[] = [
         chainId: 84532, // Base Sepolia
         assets: [
             {
-                address: toEVMInteropAddress(84532, "0x4200000000000000000000000000000000000006"),
+                address: "0x4200000000000000000000000000000000000006",
                 symbol: "WETH",
                 decimals: 18,
             },
             {
-                address: toEVMInteropAddress(84532, "0x036CbD53842c5426634e7929541eC2318f3dCF7e"),
+                address: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
                 symbol: "USDC",
                 decimals: 6,
             },
@@ -220,12 +213,12 @@ export const ACROSS_TESTNET_TOKENS: NetworkAssets[] = [
         chainId: 421614, // Arbitrum Sepolia
         assets: [
             {
-                address: toEVMInteropAddress(421614, "0x980B62Da83eFf3D4576C647993b0c1D7faf17c73"),
+                address: "0x980B62Da83eFf3D4576C647993b0c1D7faf17c73",
                 symbol: "WETH",
                 decimals: 18,
             },
             {
-                address: toEVMInteropAddress(421614, "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d"),
+                address: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
                 symbol: "USDC",
                 decimals: 6,
             },

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -1,4 +1,3 @@
-import { encodeAddress } from "@wonderland/interop-addresses";
 import axios, { AxiosError } from "axios";
 import { AbiEvent, Address, Hex, isAddressEqual, Log, numberToHex, pad } from "viem";
 import { ZodError } from "zod";
@@ -626,18 +625,8 @@ export class AcrossProvider extends CrossChainProvider {
                 continue;
             }
 
-            const encoded = encodeAddress(
-                {
-                    version: 1,
-                    chainType: "eip155",
-                    chainReference: token.chainId.toString(),
-                    address: token.address as Address,
-                },
-                { format: "hex" },
-            );
-
             const asset: AssetInfo = {
-                address: encoded as Address,
+                address: token.address,
                 symbol: token.symbol,
                 decimals: token.decimals,
             };

--- a/packages/cross-chain/src/protocols/oif/adapters/assetDiscoveryAdapter.ts
+++ b/packages/cross-chain/src/protocols/oif/adapters/assetDiscoveryAdapter.ts
@@ -3,8 +3,6 @@
  * @see https://github.com/openintentsframework/oif-solver/issues/295
  */
 
-import { encodeAddress } from "@wonderland/interop-addresses";
-
 import type { NetworkAssets } from "../../../core/types/assetDiscovery.js";
 
 interface AggregatorSolverResponse {
@@ -33,15 +31,7 @@ export function parseAggregatorSolverResponse(data: unknown): NetworkAssets[] {
         }
 
         chain.assets.push({
-            address: encodeAddress(
-                {
-                    version: 1,
-                    chainType: "eip155",
-                    chainReference: asset.chainId.toString(),
-                    address: asset.address as `0x${string}`,
-                },
-                { format: "hex" },
-            ) as `0x${string}`,
+            address: asset.address,
             symbol: asset.symbol,
             decimals: asset.decimals,
         });

--- a/packages/cross-chain/test/providers/AcrossProvider.discovery.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.discovery.spec.ts
@@ -116,7 +116,7 @@ describe("AcrossProvider.discovery", () => {
             expect(polygon?.assets).toHaveLength(1);
         });
 
-        it("should return plain 0x addresses (not EIP-7930 encoded)", () => {
+        it("returns plain 0x addresses (not EIP-7930 encoded)", () => {
             const mockTokens = [
                 {
                     chainId: 1,

--- a/packages/cross-chain/test/providers/AcrossProvider.discovery.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.discovery.spec.ts
@@ -116,7 +116,7 @@ describe("AcrossProvider.discovery", () => {
             expect(polygon?.assets).toHaveLength(1);
         });
 
-        it("should correctly encode addresses to EIP-7930 format", () => {
+        it("should return plain 0x addresses (not EIP-7930 encoded)", () => {
             const mockTokens = [
                 {
                     chainId: 1,
@@ -129,10 +129,9 @@ describe("AcrossProvider.discovery", () => {
             const result: NetworkAssets[] = parseResponse(mockTokens);
             const asset = result[0]?.assets[0];
 
-            // EIP-7930 address format should include chain info
-            // Format: 0x + version (2) + chainType (4) + chainReference (variable) + address
+            // Should be a plain 0x address (42 chars)
             expect(asset?.address).toMatch(/^0x/);
-            expect(asset?.address.length).toBeGreaterThan(42); // Longer than plain address
+            expect(asset?.address.length).toBe(42);
         });
 
         it("should handle empty array", () => {

--- a/packages/cross-chain/test/services/BaseAssetDiscoveryService.spec.ts
+++ b/packages/cross-chain/test/services/BaseAssetDiscoveryService.spec.ts
@@ -1,4 +1,3 @@
-import { toChainIdentifier } from "@wonderland/interop-addresses";
 import { AxiosError } from "axios";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -34,12 +33,12 @@ describe("BaseAssetDiscoveryService", () => {
             chainId: 1,
             assets: [
                 {
-                    address: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                     symbol: "USDC",
                     decimals: 6,
                 },
                 {
-                    address: "0x000100000101C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
                     symbol: "WETH",
                     decimals: 18,
                 },
@@ -49,7 +48,7 @@ describe("BaseAssetDiscoveryService", () => {
             chainId: 137,
             assets: [
                 {
-                    address: "0x00010000018902791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                    address: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
                     symbol: "USDC",
                     decimals: 6,
                 },
@@ -194,15 +193,15 @@ describe("BaseAssetDiscoveryService", () => {
             const result = await service.getSupportedAssets({ chainIds: [1] });
 
             expect(Object.keys(result.tokensByChain)).toHaveLength(1);
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(1));
+            expect(Object.keys(result.tokensByChain)).toContain(String(1));
         });
 
         it("should return all chains when chainIds is not provided", async () => {
             const result = await service.getSupportedAssets();
 
             expect(Object.keys(result.tokensByChain)).toHaveLength(2);
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(1));
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(137));
+            expect(Object.keys(result.tokensByChain)).toContain(String(1));
+            expect(Object.keys(result.tokensByChain)).toContain(String(137));
         });
 
         it("should return empty when chainIds matches nothing", async () => {
@@ -219,7 +218,7 @@ describe("BaseAssetDiscoveryService", () => {
             // Second call with filter should return filtered cached result
             const filtered = await service.getSupportedAssets({ chainIds: [137] });
             expect(Object.keys(filtered.tokensByChain)).toHaveLength(1);
-            expect(Object.keys(filtered.tokensByChain)).toContain(toChainIdentifier(137));
+            expect(Object.keys(filtered.tokensByChain)).toContain(String(137));
 
             // Only one fetch should have occurred
             expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -284,10 +283,10 @@ describe("BaseAssetDiscoveryService", () => {
             expect(fetchMock).toHaveBeenCalledTimes(1);
 
             expect(Object.keys(result1.tokensByChain)).toHaveLength(1);
-            expect(Object.keys(result1.tokensByChain)).toContain(toChainIdentifier(1));
+            expect(Object.keys(result1.tokensByChain)).toContain(String(1));
 
             expect(Object.keys(result2.tokensByChain)).toHaveLength(1);
-            expect(Object.keys(result2.tokensByChain)).toContain(toChainIdentifier(137));
+            expect(Object.keys(result2.tokensByChain)).toContain(String(137));
         });
     });
 
@@ -311,7 +310,7 @@ describe("BaseAssetDiscoveryService", () => {
             it("should find asset with exact address match", async () => {
                 const result = await service.isAssetSupported(
                     1,
-                    "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                 );
 
                 expect(result?.symbol).toBe("USDC");
@@ -320,7 +319,7 @@ describe("BaseAssetDiscoveryService", () => {
             it("should find asset with case-insensitive address match", async () => {
                 const result = await service.isAssetSupported(
                     1,
-                    "0x000100000101a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
                 );
 
                 expect(result?.symbol).toBe("USDC");
@@ -329,7 +328,7 @@ describe("BaseAssetDiscoveryService", () => {
             it("should return null for non-existent asset", async () => {
                 const result = await service.isAssetSupported(
                     1,
-                    "0x0001000001010000000000000000000000000000000000000000",
+                    "0x0000000000000000000000000000000000000000",
                 );
 
                 expect(result).toBeNull();
@@ -338,7 +337,7 @@ describe("BaseAssetDiscoveryService", () => {
             it("should return null for unsupported chain", async () => {
                 const result = await service.isAssetSupported(
                     999,
-                    "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                 );
 
                 expect(result).toBeNull();

--- a/packages/cross-chain/test/services/CustomApiAssetDiscoveryService.spec.ts
+++ b/packages/cross-chain/test/services/CustomApiAssetDiscoveryService.spec.ts
@@ -1,4 +1,3 @@
-import { toChainIdentifier } from "@wonderland/interop-addresses";
 import axios, { AxiosError } from "axios";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ZodError } from "zod";
@@ -80,11 +79,11 @@ describe("CustomApiAssetDiscoveryService", () => {
 
             // Returns DiscoveredAssets format
             expect(Object.keys(result.tokensByChain)).toHaveLength(2);
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(1));
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(137));
+            expect(Object.keys(result.tokensByChain)).toContain(String(1));
+            expect(Object.keys(result.tokensByChain)).toContain(String(137));
 
             // Verify tokensByChain has the expected tokens
-            const ethTokens = result.tokensByChain[toChainIdentifier(1) as string];
+            const ethTokens = result.tokensByChain[1];
             expect(ethTokens).toHaveLength(2);
         });
 
@@ -112,7 +111,7 @@ describe("CustomApiAssetDiscoveryService", () => {
             const result = await service.getSupportedAssets({ chainIds: [1] });
 
             expect(Object.keys(result.tokensByChain)).toHaveLength(1);
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(1));
+            expect(Object.keys(result.tokensByChain)).toContain(String(1));
         });
 
         it("should handle empty response array", async () => {
@@ -459,10 +458,10 @@ describe("CustomApiAssetDiscoveryService", () => {
 
             // Each result should have its own filter applied
             expect(Object.keys(result1.tokensByChain)).toHaveLength(1);
-            expect(Object.keys(result1.tokensByChain)).toContain(toChainIdentifier(1));
+            expect(Object.keys(result1.tokensByChain)).toContain(String(1));
 
             expect(Object.keys(result2.tokensByChain)).toHaveLength(1);
-            expect(Object.keys(result2.tokensByChain)).toContain(toChainIdentifier(137));
+            expect(Object.keys(result2.tokensByChain)).toContain(String(137));
         });
     });
 });

--- a/packages/cross-chain/test/services/OIFAssetDiscoveryService.spec.ts
+++ b/packages/cross-chain/test/services/OIFAssetDiscoveryService.spec.ts
@@ -1,4 +1,3 @@
-import { toChainIdentifier } from "@wonderland/interop-addresses";
 import axios, { AxiosError } from "axios";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -18,12 +17,12 @@ describe("OIFAssetDiscoveryService", () => {
                 chain_id: 1,
                 assets: [
                     {
-                        address: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                        address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                         symbol: "USDC",
                         decimals: 6,
                     },
                     {
-                        address: "0x000100000101C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                        address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
                         symbol: "WETH",
                         decimals: 18,
                     },
@@ -33,7 +32,7 @@ describe("OIFAssetDiscoveryService", () => {
                 chain_id: 137,
                 assets: [
                     {
-                        address: "0x00010000018902791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                        address: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
                         symbol: "USDC",
                         decimals: 6,
                     },
@@ -63,15 +62,17 @@ describe("OIFAssetDiscoveryService", () => {
 
             // Returns DiscoveredAssets format
             expect(Object.keys(result.tokensByChain)).toHaveLength(2);
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(1));
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(137));
+            expect(Object.keys(result.tokensByChain)).toContain(String(1));
+            expect(Object.keys(result.tokensByChain)).toContain(String(137));
 
             // Verify tokensByChain has the expected tokens
-            const ethTokens = result.tokensByChain[toChainIdentifier(1) as string];
+            const ethTokens = result.tokensByChain[1];
             expect(ethTokens).toHaveLength(2);
 
-            // Verify tokenMetadata is populated
-            expect(Object.keys(result.tokenMetadata)).toHaveLength(3); // 2 on chain 1 + 1 on chain 137
+            // Verify tokenMetadata is populated (nested by chain)
+            expect(Object.keys(result.tokenMetadata)).toHaveLength(2); // chain 1 and chain 137
+            expect(Object.keys(result.tokenMetadata[1]!)).toHaveLength(2);
+            expect(Object.keys(result.tokenMetadata[137]!)).toHaveLength(1);
         });
 
         it("should cache results permanently after first fetch", async () => {
@@ -102,7 +103,7 @@ describe("OIFAssetDiscoveryService", () => {
             const result = await service.getSupportedAssets({ chainIds: [1] });
 
             expect(Object.keys(result.tokensByChain)).toHaveLength(1);
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(1));
+            expect(Object.keys(result.tokensByChain)).toContain(String(1));
         });
     });
 
@@ -132,21 +133,21 @@ describe("OIFAssetDiscoveryService", () => {
             // Uppercase (as stored)
             const upper = await service.isAssetSupported(
                 1,
-                "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
             );
             expect(upper?.symbol).toBe("USDC");
 
             // Lowercase (user might provide)
             const lower = await service.isAssetSupported(
                 1,
-                "0x000100000101a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
             );
             expect(lower?.symbol).toBe("USDC");
 
             // Non-existent asset
             const notFound = await service.isAssetSupported(
                 1,
-                "0x0001000001010000000000000000000000000000000000000000",
+                "0x0000000000000000000000000000000000000000",
             );
             expect(notFound).toBeNull();
         });
@@ -189,8 +190,7 @@ describe("OIFAssetDiscoveryService", () => {
                             chain_id: 1,
                             assets: [
                                 {
-                                    address:
-                                        "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                                    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                                     decimals: 6,
                                 },
                             ],
@@ -218,8 +218,7 @@ describe("OIFAssetDiscoveryService", () => {
                             chain_id: 1,
                             assets: [
                                 {
-                                    address:
-                                        "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                                    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                                     symbol: "FAKE",
                                     decimals: 256,
                                 },
@@ -369,10 +368,10 @@ describe("OIFAssetDiscoveryService", () => {
 
             // Each result should have its own filter applied
             expect(Object.keys(result1.tokensByChain)).toHaveLength(1);
-            expect(Object.keys(result1.tokensByChain)).toContain(toChainIdentifier(1));
+            expect(Object.keys(result1.tokensByChain)).toContain(String(1));
 
             expect(Object.keys(result2.tokensByChain)).toHaveLength(1);
-            expect(Object.keys(result2.tokensByChain)).toContain(toChainIdentifier(137));
+            expect(Object.keys(result2.tokensByChain)).toContain(String(137));
         });
     });
 });

--- a/packages/cross-chain/test/services/aggregator.discovery.spec.ts
+++ b/packages/cross-chain/test/services/aggregator.discovery.spec.ts
@@ -2,10 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createAggregator, CrossChainProvider } from "../../src/internal.js";
 
-// EIP-7930 test addresses
-const USDC_ETH = "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
-const WETH_ETH = "0x000100000101C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
-const USDC_ARB = "0x00010000A4B10101af88d065e77c8cC2239327C5EDb3A432268e5831";
+// Plain 0x test addresses
+const USDC_ETH = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const WETH_ETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+const USDC_ARB = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
 
 function createMockProvider(
     providerId: string,
@@ -63,10 +63,10 @@ describe("Aggregator - Asset Discovery", () => {
 
             const result = await executor.discoverAssets();
 
-            expect(result.tokensByChain["eip155:1"]).toHaveLength(2);
-            expect(result.tokenMetadata[USDC_ETH].providers).toContain("across");
-            expect(result.tokenMetadata[USDC_ETH].providers).toContain("oif");
-            expect(result.tokenMetadata[WETH_ETH].providers).toEqual(["oif"]);
+            expect(result.tokensByChain[1]).toHaveLength(2);
+            expect(result.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.providers).toContain("across");
+            expect(result.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.providers).toContain("oif");
+            expect(result.tokenMetadata[1]![WETH_ETH.toLowerCase()]!.providers).toEqual(["oif"]);
         });
 
         it("should skip providers without discovery config", async () => {
@@ -90,8 +90,8 @@ describe("Aggregator - Asset Discovery", () => {
 
             const result = await executor.discoverAssets();
 
-            expect(result.tokensByChain["eip155:1"]).toHaveLength(1);
-            expect(result.tokenMetadata[USDC_ETH].providers).toEqual(["across"]);
+            expect(result.tokensByChain[1]).toHaveLength(1);
+            expect(result.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.providers).toEqual(["across"]);
         });
 
         it("should return empty result when no providers support discovery", async () => {
@@ -143,8 +143,8 @@ describe("Aggregator - Asset Discovery", () => {
 
             const result = await executor.discoverAssets();
 
-            expect(result.tokensByChain["eip155:1"]).toBeDefined();
-            expect(result.tokenMetadata[USDC_ETH].providers).toEqual(["across"]);
+            expect(result.tokensByChain[1]).toBeDefined();
+            expect(result.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.providers).toEqual(["across"]);
         });
 
         it("should deduplicate same token from same provider", async () => {
@@ -169,8 +169,8 @@ describe("Aggregator - Asset Discovery", () => {
 
             const result = await executor.discoverAssets();
 
-            expect(result.tokensByChain["eip155:1"]).toHaveLength(1);
-            expect(result.tokenMetadata[USDC_ETH].providers).toEqual(["across"]);
+            expect(result.tokensByChain[1]).toHaveLength(1);
+            expect(result.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.providers).toEqual(["across"]);
         });
     });
 
@@ -197,7 +197,9 @@ describe("Aggregator - Asset Discovery", () => {
             });
 
             const providers = await executor.getProvidersForRoute({
+                originChainId: 1,
                 originAsset: USDC_ETH,
+                destinationChainId: 42161,
                 destinationAsset: USDC_ARB,
             });
 
@@ -222,7 +224,9 @@ describe("Aggregator - Asset Discovery", () => {
             });
 
             const providers = await executor.getProvidersForRoute({
+                originChainId: 1,
                 originAsset: USDC_ETH,
+                destinationChainId: 42161,
                 destinationAsset: USDC_ARB,
             });
 
@@ -247,7 +251,9 @@ describe("Aggregator - Asset Discovery", () => {
             });
 
             const providers = await executor.getProvidersForRoute({
+                originChainId: 1,
                 originAsset: USDC_ETH,
+                destinationChainId: 42161,
                 destinationAsset: USDC_ARB,
             });
 
@@ -286,7 +292,9 @@ describe("Aggregator - Asset Discovery", () => {
             // across only has USDC_ETH, oif only has USDC_ARB
             // No single provider supports both
             const providers = await executor.getProvidersForRoute({
+                originChainId: 1,
                 originAsset: USDC_ETH,
+                destinationChainId: 42161,
                 destinationAsset: USDC_ARB,
             });
 
@@ -331,7 +339,9 @@ describe("Aggregator - Asset Discovery", () => {
             });
 
             const providers = await executor.getProvidersForRoute({
+                originChainId: 1,
                 originAsset: USDC_ETH,
+                destinationChainId: 42161,
                 destinationAsset: USDC_ARB,
             });
 

--- a/packages/cross-chain/test/services/assetDiscoveryFactory.spec.ts
+++ b/packages/cross-chain/test/services/assetDiscoveryFactory.spec.ts
@@ -1,4 +1,3 @@
-import { toChainIdentifier } from "@wonderland/interop-addresses";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -47,7 +46,7 @@ describe("AssetDiscoveryFactory", () => {
             chainId: 1,
             assets: [
                 {
-                    address: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                     symbol: "USDC",
                     decimals: 6,
                 },
@@ -57,7 +56,7 @@ describe("AssetDiscoveryFactory", () => {
             chainId: 137,
             assets: [
                 {
-                    address: "0x00010000018902791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                    address: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
                     symbol: "USDC",
                     decimals: 6,
                 },
@@ -152,8 +151,8 @@ describe("AssetDiscoveryFactory", () => {
 
             // Verify it returns DiscoveredAssets
             const result = await service.getSupportedAssets();
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(1));
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(137));
+            expect(Object.keys(result.tokensByChain)).toContain(String(1));
+            expect(Object.keys(result.tokensByChain)).toContain(String(137));
         });
     });
 });
@@ -164,12 +163,12 @@ describe("Static Asset Discovery Service", () => {
             chainId: 1,
             assets: [
                 {
-                    address: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                     symbol: "USDC",
                     decimals: 6,
                 },
                 {
-                    address: "0x000100000101C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
                     symbol: "WETH",
                     decimals: 18,
                 },
@@ -191,8 +190,8 @@ describe("Static Asset Discovery Service", () => {
         const result = await service.getSupportedAssets();
 
         expect(Object.keys(result.tokensByChain)).toHaveLength(1);
-        expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(1));
-        expect(result.tokensByChain[toChainIdentifier(1) as string]).toHaveLength(2);
+        expect(Object.keys(result.tokensByChain)).toContain(String(1));
+        expect(result.tokensByChain[1]).toHaveLength(2);
     });
 
     it("should return assets for a specific chain", async () => {
@@ -211,7 +210,7 @@ describe("Static Asset Discovery Service", () => {
     it("should check if asset is supported", async () => {
         const result = await service.isAssetSupported(
             1,
-            "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         );
 
         expect(result).not.toBeNull();
@@ -261,7 +260,7 @@ describe("Static Asset Discovery Service with AssetDiscoveryOptions", () => {
             chainId: 1,
             assets: [
                 {
-                    address: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                     symbol: "USDC",
                     decimals: 6,
                 },
@@ -271,7 +270,7 @@ describe("Static Asset Discovery Service with AssetDiscoveryOptions", () => {
             chainId: 137,
             assets: [
                 {
-                    address: "0x00010000018902791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                    address: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
                     symbol: "USDC",
                     decimals: 6,
                 },
@@ -281,7 +280,7 @@ describe("Static Asset Discovery Service with AssetDiscoveryOptions", () => {
             chainId: 42161,
             assets: [
                 {
-                    address: "0x0001000000a5af449f9385dc8d884c99e6836a3fae51acad7f0d9fe9",
+                    address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
                     symbol: "USDC",
                     decimals: 6,
                 },
@@ -304,17 +303,17 @@ describe("Static Asset Discovery Service with AssetDiscoveryOptions", () => {
             const result = await service.getSupportedAssets();
 
             expect(Object.keys(result.tokensByChain)).toHaveLength(3);
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(1));
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(137));
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(42161));
+            expect(Object.keys(result.tokensByChain)).toContain(String(1));
+            expect(Object.keys(result.tokensByChain)).toContain(String(137));
+            expect(Object.keys(result.tokensByChain)).toContain(String(42161));
         });
 
         it("should filter by chainIds when provided", async () => {
             const result = await service.getSupportedAssets({ chainIds: [1, 42161] });
 
             expect(Object.keys(result.tokensByChain)).toHaveLength(2);
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(1));
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(42161));
+            expect(Object.keys(result.tokensByChain)).toContain(String(1));
+            expect(Object.keys(result.tokensByChain)).toContain(String(42161));
         });
 
         it("should return empty when chainIds filter matches nothing", async () => {
@@ -327,7 +326,7 @@ describe("Static Asset Discovery Service with AssetDiscoveryOptions", () => {
             const result = await service.getSupportedAssets({ chainIds: [137] });
 
             expect(Object.keys(result.tokensByChain)).toHaveLength(1);
-            expect(Object.keys(result.tokensByChain)).toContain(toChainIdentifier(137));
+            expect(Object.keys(result.tokensByChain)).toContain(String(137));
         });
 
         it("should include tokenMetadata in filtered result", async () => {

--- a/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
+++ b/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
@@ -28,16 +28,16 @@ describe("toDiscoveredAssets", () => {
     const mockResult = result("test-provider", { chainId: 1, assets: [usdcEth, wethEth] });
 
     describe("single provider, single chain", () => {
-        it("should populate tokensByChain with numeric chain ID key", () => {
+        it("populate tokensByChain with numeric chain ID key", () => {
             const out = toDiscoveredAssets([mockResult]);
 
             expect(out.tokensByChain[1]).toBeDefined();
             expect(out.tokensByChain[1]).toHaveLength(2);
-            expect(out.tokensByChain[1]).toContain(USDC_ETH);
-            expect(out.tokensByChain[1]).toContain(WETH_ETH);
+            expect(out.tokensByChain[1]).toContain(USDC_ETH.toLowerCase());
+            expect(out.tokensByChain[1]).toContain(WETH_ETH.toLowerCase());
         });
 
-        it("should populate nested tokenMetadata keyed by chainId and lowercase address with providers", () => {
+        it("populate nested tokenMetadata keyed by chainId and lowercase address with providers", () => {
             const out = toDiscoveredAssets([mockResult]);
 
             expect(out.tokenMetadata[1]?.[USDC_ETH.toLowerCase()]).toEqual({
@@ -50,7 +50,7 @@ describe("toDiscoveredAssets", () => {
             });
         });
 
-        it("should populate tokensByChain keys with numeric chain IDs", () => {
+        it("populate tokensByChain keys with numeric chain IDs", () => {
             const out = toDiscoveredAssets([mockResult]);
 
             expect(Object.keys(out.tokensByChain).map(Number)).toEqual([1]);
@@ -58,7 +58,7 @@ describe("toDiscoveredAssets", () => {
     });
 
     describe("multiple providers, overlapping chains/assets", () => {
-        it("should deduplicate assets by address", () => {
+        it("deduplicate assets by address", () => {
             const out = toDiscoveredAssets([
                 result("provider-1", { chainId: 1, assets: [usdcEth] }),
                 result("provider-2", { chainId: 1, assets: [usdcEth, wethEth] }),
@@ -68,7 +68,7 @@ describe("toDiscoveredAssets", () => {
             expect(Object.keys(out.tokenMetadata[1]!)).toHaveLength(2);
         });
 
-        it("should use first-write-wins for metadata and merge providers", () => {
+        it("use first-write-wins for metadata and merge providers", () => {
             const out = toDiscoveredAssets([
                 result("provider-1", { chainId: 1, assets: [{ ...usdcEth, symbol: "USDC-OLD" }] }),
                 result("provider-2", { chainId: 1, assets: [{ ...usdcEth, symbol: "USDC-NEW" }] }),
@@ -79,7 +79,7 @@ describe("toDiscoveredAssets", () => {
             expect(meta.providers).toEqual(["provider-1", "provider-2"]);
         });
 
-        it("should not duplicate same provider in providers array", () => {
+        it("not duplicate same provider in providers array", () => {
             const out = toDiscoveredAssets([
                 result(
                     "provider-1",
@@ -95,7 +95,7 @@ describe("toDiscoveredAssets", () => {
     });
 
     describe("filterChainIds", () => {
-        it("should only include matching chains", () => {
+        it("only include matching chains", () => {
             const out = toDiscoveredAssets(
                 [
                     result(
@@ -113,7 +113,7 @@ describe("toDiscoveredAssets", () => {
             expect(out.tokenMetadata[42161]).toBeUndefined();
         });
 
-        it("should return empty result when no chains match filter", () => {
+        it("return empty result when no chains match filter", () => {
             const out = toDiscoveredAssets([mockResult], [999]);
 
             expect(Object.keys(out.tokensByChain)).toHaveLength(0);
@@ -122,7 +122,7 @@ describe("toDiscoveredAssets", () => {
     });
 
     describe("empty results array", () => {
-        it("should return empty structure", () => {
+        it("return empty structure", () => {
             const out = toDiscoveredAssets([]);
 
             expect(out.tokensByChain).toEqual({});
@@ -131,7 +131,7 @@ describe("toDiscoveredAssets", () => {
     });
 
     describe("multiple chains", () => {
-        it("should have chain keys in tokensByChain", () => {
+        it("have chain keys in tokensByChain", () => {
             const out = toDiscoveredAssets([
                 result(
                     "test-provider",
@@ -140,10 +140,14 @@ describe("toDiscoveredAssets", () => {
                 ),
             ]);
 
-            expect(Object.keys(out.tokensByChain).map(Number).sort()).toEqual([1, 42161]);
+            expect(
+                Object.keys(out.tokensByChain)
+                    .map(Number)
+                    .sort((a, b) => a - b),
+            ).toEqual([1, 42161]);
         });
 
-        it("should maintain separate token lists per chain", () => {
+        it("maintain separate token lists per chain", () => {
             const out = toDiscoveredAssets([
                 result(
                     "test-provider",
@@ -161,7 +165,7 @@ describe("toDiscoveredAssets", () => {
 });
 
 describe("mergeDiscoveredAssets", () => {
-    it("should merge tokens from different chains", () => {
+    it("merge tokens from different chains", () => {
         const sourceA = toDiscoveredAssets([
             result("provider-a", { chainId: 1, assets: [usdcEth] }),
         ]);
@@ -171,14 +175,18 @@ describe("mergeDiscoveredAssets", () => {
 
         const merged = mergeDiscoveredAssets([sourceA, sourceB]);
 
-        expect(Object.keys(merged.tokensByChain).map(Number).sort()).toEqual([1, 42161]);
+        expect(
+            Object.keys(merged.tokensByChain)
+                .map(Number)
+                .sort((a, b) => a - b),
+        ).toEqual([1, 42161]);
         expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.providers).toEqual(["provider-a"]);
         expect(merged.tokenMetadata[42161]![USDC_ARB.toLowerCase()]!.providers).toEqual([
             "provider-b",
         ]);
     });
 
-    it("should merge providers for the same token", () => {
+    it("merge providers for the same token", () => {
         const sourceA = toDiscoveredAssets([
             result("provider-a", { chainId: 1, assets: [usdcEth] }),
         ]);
@@ -195,7 +203,7 @@ describe("mergeDiscoveredAssets", () => {
         ]);
     });
 
-    it("should use first-write-wins for metadata fields", () => {
+    it("use first-write-wins for metadata fields", () => {
         const sourceA = toDiscoveredAssets([
             result("provider-a", { chainId: 1, assets: [{ ...usdcEth, symbol: "USDC-FIRST" }] }),
         ]);
@@ -212,7 +220,7 @@ describe("mergeDiscoveredAssets", () => {
         expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.decimals).toBe(6);
     });
 
-    it("should not duplicate providers when same provider appears in multiple sources", () => {
+    it("not duplicate providers when same provider appears in multiple sources", () => {
         const sourceA = toDiscoveredAssets([
             result("provider-a", { chainId: 1, assets: [usdcEth] }),
         ]);
@@ -225,7 +233,7 @@ describe("mergeDiscoveredAssets", () => {
         expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.providers).toEqual(["provider-a"]);
     });
 
-    it("should handle empty sources array", () => {
+    it("handle empty sources array", () => {
         const merged = mergeDiscoveredAssets([]);
 
         expect(merged.tokensByChain).toEqual({});

--- a/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
+++ b/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
@@ -10,10 +10,10 @@ import {
     toDiscoveredAssets,
 } from "../../src/core/utils/toDiscoveredAssets.js";
 
-const USDC_ETH = "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
-const WETH_ETH = "0x000100000101C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
-const USDC_ARB = "0x00010000A4B10101af88d065e77c8cC2239327C5EDb3A432268e5831";
-const WETH_ARB = "0x00010000A4B1010182aF49447D8a07e3bd95BD0d56f35241523fBab1";
+const USDC_ETH = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const WETH_ETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+const USDC_ARB = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
+const WETH_ARB = "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1";
 
 const usdcEth: AssetInfo = { address: USDC_ETH, symbol: "USDC", decimals: 6 };
 const wethEth: AssetInfo = { address: WETH_ETH, symbol: "WETH", decimals: 18 };
@@ -28,44 +28,44 @@ describe("toDiscoveredAssets", () => {
     const mockResult = result("test-provider", { chainId: 1, assets: [usdcEth, wethEth] });
 
     describe("single provider, single chain", () => {
-        it("should populate tokensByChain with CAIP-2 key", () => {
+        it("should populate tokensByChain with numeric chain ID key", () => {
             const out = toDiscoveredAssets([mockResult]);
 
-            expect(out.tokensByChain["eip155:1"]).toBeDefined();
-            expect(out.tokensByChain["eip155:1"]).toHaveLength(2);
-            expect(out.tokensByChain["eip155:1"]).toContain(USDC_ETH);
-            expect(out.tokensByChain["eip155:1"]).toContain(WETH_ETH);
+            expect(out.tokensByChain[1]).toBeDefined();
+            expect(out.tokensByChain[1]).toHaveLength(2);
+            expect(out.tokensByChain[1]).toContain(USDC_ETH);
+            expect(out.tokensByChain[1]).toContain(WETH_ETH);
         });
 
-        it("should populate flat tokenMetadata keyed by interop address with providers", () => {
+        it("should populate nested tokenMetadata keyed by chainId and lowercase address with providers", () => {
             const out = toDiscoveredAssets([mockResult]);
 
-            expect(out.tokenMetadata[USDC_ETH]).toEqual({
+            expect(out.tokenMetadata[1]?.[USDC_ETH.toLowerCase()]).toEqual({
                 ...usdcEth,
                 providers: ["test-provider"],
             });
-            expect(out.tokenMetadata[WETH_ETH]).toEqual({
+            expect(out.tokenMetadata[1]?.[WETH_ETH.toLowerCase()]).toEqual({
                 ...wethEth,
                 providers: ["test-provider"],
             });
         });
 
-        it("should populate tokensByChain keys with CAIP-2 format", () => {
+        it("should populate tokensByChain keys with numeric chain IDs", () => {
             const out = toDiscoveredAssets([mockResult]);
 
-            expect(Object.keys(out.tokensByChain)).toEqual(["eip155:1"]);
+            expect(Object.keys(out.tokensByChain).map(Number)).toEqual([1]);
         });
     });
 
     describe("multiple providers, overlapping chains/assets", () => {
-        it("should deduplicate assets by interop address", () => {
+        it("should deduplicate assets by address", () => {
             const out = toDiscoveredAssets([
                 result("provider-1", { chainId: 1, assets: [usdcEth] }),
                 result("provider-2", { chainId: 1, assets: [usdcEth, wethEth] }),
             ]);
 
-            expect(out.tokensByChain["eip155:1"]).toHaveLength(2);
-            expect(Object.keys(out.tokenMetadata)).toHaveLength(2);
+            expect(out.tokensByChain[1]).toHaveLength(2);
+            expect(Object.keys(out.tokenMetadata[1]!)).toHaveLength(2);
         });
 
         it("should use first-write-wins for metadata and merge providers", () => {
@@ -74,8 +74,9 @@ describe("toDiscoveredAssets", () => {
                 result("provider-2", { chainId: 1, assets: [{ ...usdcEth, symbol: "USDC-NEW" }] }),
             ]);
 
-            expect(out.tokenMetadata[USDC_ETH].symbol).toBe("USDC-OLD");
-            expect(out.tokenMetadata[USDC_ETH].providers).toEqual(["provider-1", "provider-2"]);
+            const meta = out.tokenMetadata[1]![USDC_ETH.toLowerCase()]!;
+            expect(meta.symbol).toBe("USDC-OLD");
+            expect(meta.providers).toEqual(["provider-1", "provider-2"]);
         });
 
         it("should not duplicate same provider in providers array", () => {
@@ -87,7 +88,9 @@ describe("toDiscoveredAssets", () => {
                 ),
             ]);
 
-            expect(out.tokenMetadata[USDC_ETH].providers).toEqual(["provider-1"]);
+            expect(out.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.providers).toEqual([
+                "provider-1",
+            ]);
         });
     });
 
@@ -104,10 +107,10 @@ describe("toDiscoveredAssets", () => {
                 [1],
             );
 
-            expect(Object.keys(out.tokensByChain)).toEqual(["eip155:1"]);
-            expect(out.tokensByChain["eip155:42161"]).toBeUndefined();
-            expect(out.tokenMetadata[USDC_ETH]).toBeDefined();
-            expect(out.tokenMetadata[USDC_ARB]).toBeUndefined();
+            expect(Object.keys(out.tokensByChain).map(Number)).toEqual([1]);
+            expect(out.tokensByChain[42161]).toBeUndefined();
+            expect(out.tokenMetadata[1]?.[USDC_ETH.toLowerCase()]).toBeDefined();
+            expect(out.tokenMetadata[42161]).toBeUndefined();
         });
 
         it("should return empty result when no chains match filter", () => {
@@ -137,7 +140,7 @@ describe("toDiscoveredAssets", () => {
                 ),
             ]);
 
-            expect(Object.keys(out.tokensByChain).sort()).toEqual(["eip155:1", "eip155:42161"]);
+            expect(Object.keys(out.tokensByChain).map(Number).sort()).toEqual([1, 42161]);
         });
 
         it("should maintain separate token lists per chain", () => {
@@ -149,9 +152,10 @@ describe("toDiscoveredAssets", () => {
                 ),
             ]);
 
-            expect(out.tokensByChain["eip155:1"]).toHaveLength(2);
-            expect(out.tokensByChain["eip155:42161"]).toHaveLength(2);
-            expect(Object.keys(out.tokenMetadata)).toHaveLength(4);
+            expect(out.tokensByChain[1]).toHaveLength(2);
+            expect(out.tokensByChain[42161]).toHaveLength(2);
+            expect(Object.keys(out.tokenMetadata[1]!)).toHaveLength(2);
+            expect(Object.keys(out.tokenMetadata[42161]!)).toHaveLength(2);
         });
     });
 });
@@ -167,9 +171,11 @@ describe("mergeDiscoveredAssets", () => {
 
         const merged = mergeDiscoveredAssets([sourceA, sourceB]);
 
-        expect(Object.keys(merged.tokensByChain).sort()).toEqual(["eip155:1", "eip155:42161"]);
-        expect(merged.tokenMetadata[USDC_ETH].providers).toEqual(["provider-a"]);
-        expect(merged.tokenMetadata[USDC_ARB].providers).toEqual(["provider-b"]);
+        expect(Object.keys(merged.tokensByChain).map(Number).sort()).toEqual([1, 42161]);
+        expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.providers).toEqual(["provider-a"]);
+        expect(merged.tokenMetadata[42161]![USDC_ARB.toLowerCase()]!.providers).toEqual([
+            "provider-b",
+        ]);
     });
 
     it("should merge providers for the same token", () => {
@@ -182,8 +188,11 @@ describe("mergeDiscoveredAssets", () => {
 
         const merged = mergeDiscoveredAssets([sourceA, sourceB]);
 
-        expect(merged.tokensByChain["eip155:1"]).toHaveLength(1);
-        expect(merged.tokenMetadata[USDC_ETH].providers).toEqual(["provider-a", "provider-b"]);
+        expect(merged.tokensByChain[1]).toHaveLength(1);
+        expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.providers).toEqual([
+            "provider-a",
+            "provider-b",
+        ]);
     });
 
     it("should use first-write-wins for metadata fields", () => {
@@ -199,8 +208,8 @@ describe("mergeDiscoveredAssets", () => {
 
         const merged = mergeDiscoveredAssets([sourceA, sourceB]);
 
-        expect(merged.tokenMetadata[USDC_ETH].symbol).toBe("USDC-FIRST");
-        expect(merged.tokenMetadata[USDC_ETH].decimals).toBe(6);
+        expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.symbol).toBe("USDC-FIRST");
+        expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.decimals).toBe(6);
     });
 
     it("should not duplicate providers when same provider appears in multiple sources", () => {
@@ -213,7 +222,7 @@ describe("mergeDiscoveredAssets", () => {
 
         const merged = mergeDiscoveredAssets([sourceA, sourceB]);
 
-        expect(merged.tokenMetadata[USDC_ETH].providers).toEqual(["provider-a"]);
+        expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.providers).toEqual(["provider-a"]);
     });
 
     it("should handle empty sources array", () => {


### PR DESCRIPTION
## Summary

- Replace EIP-7930 interop addresses and CAIP-350 chain identifiers with plain `0x` addresses and numeric chain IDs throughout asset discovery
- Nest `tokenMetadata` by `chainId → lowercase address` to prevent cross-chain address collisions
- Expand `RouteQuery` to 4 fields (`originChainId`, `originAsset`, `destinationChainId`, `destinationAsset`)
- Relax `isAddress` checksum validation across all schemas to accept lowercase addresses
- Simplify example app by removing `transformToUiAssets` decoding layer

Fixes EFI-836

## Test plan

- [x] All 385 unit tests pass
- [x] Build passes (including example app)
- [x] Lint and format clean
- [ ] Verify example app works end-to-end after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)