### PR TITLE
docs: update on.eth registry references and add resource links

### DIFF
--- a/apps/addresses-landing-page/components/faq-section.tsx
+++ b/apps/addresses-landing-page/components/faq-section.tsx
@@ -100,27 +100,37 @@ export function FaqSection() {
                         What is the status of the onchain chain registry?
                     </h3>
                     <p className="font-mono text-sm lg:text-[0.9375rem] text-muted-foreground leading-relaxed">
-                        The onchain chain registry is currently under development in the{" "}
+                        <code>on.eth</code> is a canonical, ENS-native registry for chains and their
+                        associated metadata, covering networks such as Base, Arbitrum, or Ethereum.
+                        The ENS DAO has approved usage of the domain for this purpose, and the
+                        registry is being initialized with chains using the{" "}
                         <a
-                            href="https://github.com/unruggable-labs/chain-resolver"
+                            href="https://github.com/unruggable-labs/chain-resolver/"
                             target="_blank"
                             rel="noopener noreferrer"
                             className="underline hover:no-underline"
                         >
-                            chain-resolver
-                        </a>{" "}
-                        project and is approaching final testing. It will be powered by a custom ENS
-                        resolver under the dedicated ENS name <code>on.eth</code>. Until this is
-                        live, the SDK uses data from{" "}
-                        <a
-                            href="https://github.com/ethereum-lists/chains/"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="underline hover:no-underline"
-                        >
-                            ethereum-lists/chains
+                            custom chain resolver
                         </a>
-                        , using <code>shortName</code> values as identifiers.
+                        . Learn more about the registry in the{" "}
+                        <a
+                            href="https://ens.domains/blog/post/on-eth-chain-registry"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline hover:no-underline"
+                        >
+                            ENS blog post
+                        </a>
+                        . The registry is available as an{" "}
+                        <a
+                            href="https://docs.interop.wonderland.xyz/addresses/getting-started#experimental-onchain-chain-registry"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline hover:no-underline"
+                        >
+                            experimental feature
+                        </a>{" "}
+                        in the <code>interop-addresses</code> package.
                     </p>
                 </div>
 

--- a/apps/addresses-landing-page/components/how-it-works-section.tsx
+++ b/apps/addresses-landing-page/components/how-it-works-section.tsx
@@ -10,7 +10,7 @@ export function HowItWorksSection() {
                 smart contracts and other machine-readable contexts.
                 <br />
                 <strong>ERC-7828</strong>: an Interoperable Name format for end-users, optionally
-                using ENS and an on-chain chain registry for maximum readability.
+                using ENS and an onchain chain registry for maximum readability.
                 <br />
                 <br />
                 These standards work together to support interoperability use-cases across Ethereum.

--- a/apps/addresses-landing-page/components/specs-section.tsx
+++ b/apps/addresses-landing-page/components/specs-section.tsx
@@ -58,7 +58,7 @@ export function SpecsSection() {
                     <p className="font-mono text-sm md:text-[0.9375rem] lg:text-base text-muted-foreground leading-relaxed mb-5 lg:mb-6">
                         Defines a standard
                         {" <address>@<chain>"} text representation, supporting optional resolution
-                        of ENS names and readable chain identifiers based on an on-chain registry.
+                        of ENS names and readable chain identifiers based on an onchain registry.
                     </p>
                     <a
                         href="https://eips.ethereum.org/EIPS/eip-7828"

--- a/apps/docs/docs/addresses/getting-started.md
+++ b/apps/docs/docs/addresses/getting-started.md
@@ -225,14 +225,14 @@ The package resolves chain identifiers using off-chain registries:
 
 ### Experimental: Onchain Chain Registry
 
-ENS-based chain resolution is available as an experimental feature. When enabled, the SDK queries an onchain ENS registry (like `cid.eth`) to resolve chain labels:
+ENS-based chain resolution is available as an experimental feature. When enabled, the SDK queries an onchain ENS registry (like `on.eth`) to resolve chain labels:
 
 ```typescript
 import { parseName } from "@wonderland/interop-addresses";
 
-// Use cid.eth (Unruggable's chain registry on mainnet)
+// Use on.eth (ENS chain registry on mainnet)
 const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
-    useExperimentalChainRegistry: "cid.eth",
+    useExperimentalChainRegistry: "on.eth",
 });
 // result.interoperableAddress.chainType === "eip155"
 // result.interoperableAddress.chainReference === "1"
@@ -245,7 +245,7 @@ const result2 = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@arb1
 
 **How it works:**
 
-1. Constructs the full ENS domain as `{label}.{registryDomain}` (e.g., `eth.cid.eth`)
+1. Constructs the full ENS domain as `{label}.{registryDomain}` (e.g., `ethereum.on.eth`)
 2. Queries the ENS registry to find the resolver for that domain
 3. Calls the resolver's `data()` method with key `"interoperable-address"` (per ENSIP-24)
 4. Decodes the returned ERC-7930 binary format to get chainType and chainReference


### PR DESCRIPTION
## Summary
- Update `cid.eth` references to `on.eth` across docs and landing page
- Add links to [chain-resolver](https://github.com/unruggable-labs/chain-resolver/) repo, [ENS blog post](https://ens.domains/blog/post/on-eth-chain-registry), and [experimental feature docs](https://docs.interop.wonderland.xyz/addresses/getting-started#experimental-onchain-chain-registry) in the FAQ
- Normalize "on-chain" to "onchain" for terminology consistency

## Test plan
- [ ] Verify landing page renders correctly with updated FAQ links
- [ ] Verify docs site renders the updated getting-started page

🤖 Generated with [Claude Code](https://claude.com/claude-code)