### PR TITLE
feat(addresses): enable onchain registry (on.eth) by default

### DIFF
--- a/.changeset/onchain-registry-default.md
+++ b/.changeset/onchain-registry-default.md
@@ -1,0 +1,11 @@
+---
+"@wonderland/interop-addresses": minor
+---
+
+feat: enable onchain chain registry (on.eth) by default
+
+-   Replace `useExperimentalChainRegistry` with `onchainRegistry`, `offchainRegistryFallback`, and `rpcUrl` options
+-   Onchain resolution via `on.eth` is now the default when parsing chain labels
+-   Add default public RPC endpoint so onchain resolution works without configuration
+-   Offchain chainid.network registry used as automatic fallback
+-   Fully-qualified CAIP-2 identifiers (e.g., `eip155:10`) always work regardless of registry settings

--- a/apps/docs/docs/addresses/getting-started.md
+++ b/apps/docs/docs/addresses/getting-started.md
@@ -218,39 +218,55 @@ const checksum = calculateChecksum(textAddr);
 
 ## Chain Resolution
 
-The package resolves chain identifiers using off-chain registries:
+The package resolves chain labels using a two-tier strategy:
 
--   **Primary**: Uses `shortnameToChainId` with built-in chain shortname mappings
--   **Fallback**: Uses viem's chain definitions and chainid.network
+-   **Primary (default)**: Queries the `on.eth` onchain ENS registry on mainnet
+-   **Fallback**: Uses `shortnameToChainId` with chainid.network mappings
 
-### Experimental: Onchain Chain Registry
-
-ENS-based chain resolution is available as an experimental feature. When enabled, the SDK queries an onchain ENS registry (like `on.eth`) to resolve chain labels:
+Both are enabled by default. Fully-qualified CAIP-2 identifiers (e.g., `eip155:10`) always work without any registry.
 
 ```typescript
 import { parseName } from "@wonderland/interop-addresses";
 
-// Use on.eth (ENS chain registry on mainnet)
-const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
-    useExperimentalChainRegistry: "on.eth",
-});
+// Default behavior: onchain (on.eth) + offchain fallback
+const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth");
 // result.interoperableAddress.chainType === "eip155"
 // result.interoperableAddress.chainReference === "1"
-
-// Or use on.eth when deployed
-const result2 = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@arb1", {
-    useExperimentalChainRegistry: "on.eth",
-});
 ```
 
 **How it works:**
 
 1. Constructs the full ENS domain as `{label}.{registryDomain}` (e.g., `ethereum.on.eth`)
 2. Queries the ENS registry to find the resolver for that domain
-3. Calls the resolver's `data()` method with key `"interoperable-address"` (per ENSIP-24)
+3. Calls the resolver's `interoperableAddress(label)` method on the ChainResolver contract
 4. Decodes the returned ERC-7930 binary format to get chainType and chainReference
 
 If onchain resolution fails (domain not found, resolver error, etc.), it automatically falls back to the offchain chainid.network registry.
+
+### Customizing Resolution
+
+```typescript
+// Disable onchain, use offchain only
+const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
+    onchainRegistry: false,
+});
+
+// Disable both registries (only fully-qualified CAIP-2 works)
+const result2 = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1", {
+    onchainRegistry: false,
+    offchainRegistryFallback: false,
+});
+
+// Custom registry domain
+const result3 = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
+    onchainRegistry: "custom.eth",
+});
+
+// Custom RPC URL
+const result4 = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
+    rpcUrl: "https://my-rpc.example.com",
+});
+```
 
 ## References
 

--- a/examples/ui/app/actions/parse-name.ts
+++ b/examples/ui/app/actions/parse-name.ts
@@ -6,24 +6,14 @@ type ParseNameResult =
   | { success: true; parsed: ParsedInteroperableNameResult; binary: string }
   | { success: false; error: string };
 
-export interface ParseNameActionOptions {
-  /** Experimental: ENS-based chain registry domain (e.g., "cid.eth") */
-  useExperimentalChainRegistry?: string;
-}
-
 /**
  * Server action to parse an interoperable name.
  * We run this server-side because ENS resolution requires an
  * RPC URL with an API key that shouldn't be exposed to the client.
  */
-export async function parseNameAction(
-  interoperableName: string,
-  options?: ParseNameActionOptions,
-): Promise<ParseNameResult> {
+export async function parseNameAction(interoperableName: string): Promise<ParseNameResult> {
   try {
-    const parsed = await parseName(interoperableName, {
-      useExperimentalChainRegistry: options?.useExperimentalChainRegistry,
-    });
+    const parsed = await parseName(interoperableName);
     const binary = encodeAddress(parsed.interoperableAddress, { format: 'hex' });
 
     return { success: true, parsed, binary };

--- a/examples/ui/app/components/InputSection.tsx
+++ b/examples/ui/app/components/InputSection.tsx
@@ -15,8 +15,6 @@ interface InputSectionProps {
   setAddress: (value: string) => void;
   chainReference: string;
   setChainReference: (value: string) => void;
-  useOnchainRegistry: boolean;
-  setUseOnchainRegistry: (value: boolean) => void;
   onConvert: () => void;
   onExampleClick: (example: string) => void;
   isLoading?: boolean;
@@ -32,8 +30,6 @@ export function InputSection({
   setAddress,
   chainReference,
   setChainReference,
-  useOnchainRegistry,
-  setUseOnchainRegistry,
   onConvert,
   onExampleClick,
   isLoading = false,
@@ -132,31 +128,6 @@ export function InputSection({
             </div>
           </div>
         )}
-
-        <div className='flex items-center gap-2'>
-          <input
-            id='onchain-registry-toggle'
-            type='checkbox'
-            checked={useOnchainRegistry}
-            onChange={(e) => setUseOnchainRegistry(e.target.checked)}
-            className='w-4 h-4 rounded border-border/50 bg-background/50 text-accent focus:ring-accent/20 focus:ring-2 cursor-pointer'
-          />
-          <label htmlFor='onchain-registry-toggle' className='text-sm text-text-secondary cursor-pointer select-none'>
-            Use onchain registry{' '}
-            <span className='text-xs text-text-tertiary'>
-              (experimental, via{' '}
-              <a
-                href='https://cid.eth.limo'
-                target='_blank'
-                rel='noopener noreferrer'
-                className='text-accent hover:underline'
-              >
-                cid.eth
-              </a>
-              )
-            </span>
-          </label>
-        </div>
 
         <div className='flex flex-col-reverse sm:flex-row gap-3 sm:justify-between'>
           <ExampleButtons examples={isReadableMode ? readableModeExamples : buildModeExamples} />

--- a/examples/ui/app/components/InteractivePlayground.tsx
+++ b/examples/ui/app/components/InteractivePlayground.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { InputMode, type InteroperableNamePart, type BinaryPart, type AddressResult } from '../types';
-import { convertFromReadable, type ConversionOptions } from '../utils/address-conversion';
+import { convertFromReadable } from '../utils/address-conversion';
 import { InputSection } from './InputSection';
 import { ResultDisplays } from './ResultDisplays';
 import type { Chain } from '../lib/getChains';
@@ -16,7 +16,6 @@ export function InteractivePlayground({ chains }: InteractivePlaygroundProps) {
   const [readableName, setReadableName] = useState('');
   const [address, setAddress] = useState('');
   const [chainReference, setChainReference] = useState('');
-  const [useOnchainRegistry, setUseOnchainRegistry] = useState(false);
   const [hoveredName, setHoveredName] = useState<InteroperableNamePart>(null);
   const [hoveredBinary, setHoveredBinary] = useState<BinaryPart>(null);
   const [copied, setCopied] = useState(false);
@@ -33,12 +32,7 @@ export function InteractivePlayground({ chains }: InteractivePlaygroundProps) {
   const [lastReadableInput, setLastReadableInput] = useState('');
   const [lastBuildAddress, setLastBuildAddress] = useState('');
   const [lastBuildChainReference, setLastBuildChainReference] = useState('');
-  const [lastUseOnchainRegistry, setLastUseOnchainRegistry] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-
-  const conversionOptions: ConversionOptions | undefined = useOnchainRegistry
-    ? { useExperimentalChainRegistry: 'cid.eth' }
-    : undefined;
 
   const updateReadableResult = (conversionResult: Awaited<ReturnType<typeof convertFromReadable>>) => {
     setReadableResult({
@@ -49,7 +43,6 @@ export function InteractivePlayground({ chains }: InteractivePlaygroundProps) {
     });
     setReadableParsedResult(conversionResult.parsedResult);
     setLastReadableInput(readableName.trim());
-    setLastUseOnchainRegistry(useOnchainRegistry);
   };
 
   const updateBuildResult = (conversionResult: Awaited<ReturnType<typeof convertFromReadable>>) => {
@@ -62,14 +55,13 @@ export function InteractivePlayground({ chains }: InteractivePlaygroundProps) {
     setBuildParsedResult(conversionResult.parsedResult);
     setLastBuildAddress(address.trim());
     setLastBuildChainReference(chainReference.trim());
-    setLastUseOnchainRegistry(useOnchainRegistry);
   };
 
   const convertReadable = async () => {
     try {
       setReadableError('');
       if (!readableName.trim()) return setReadableResult(null);
-      const result = await convertFromReadable(readableName, conversionOptions);
+      const result = await convertFromReadable(readableName);
       updateReadableResult(result);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to process';
@@ -83,7 +75,7 @@ export function InteractivePlayground({ chains }: InteractivePlaygroundProps) {
       setBuildError('');
       if (!address.trim() || !chainReference.trim()) return setBuildResult(null);
       const _readableName = `${address}@${chainReference}`;
-      const result = await convertFromReadable(_readableName, conversionOptions);
+      const result = await convertFromReadable(_readableName);
       updateBuildResult(result);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to process';
@@ -121,13 +113,11 @@ export function InteractivePlayground({ chains }: InteractivePlaygroundProps) {
   const activeResult = mode === InputMode.READABLE ? readableResult : buildResult;
   const activeError = mode === InputMode.READABLE ? readableError : buildError;
   const activeParsedResult = mode === InputMode.READABLE ? readableParsedResult : buildParsedResult;
-  const registryChanged = lastUseOnchainRegistry !== useOnchainRegistry;
-  const isReadableStale =
-    !!readableResult && Boolean(lastReadableInput) && (lastReadableInput !== readableName.trim() || registryChanged);
+  const isReadableStale = !!readableResult && Boolean(lastReadableInput) && lastReadableInput !== readableName.trim();
   const isBuildStale =
     !!buildResult &&
     Boolean(lastBuildAddress || lastBuildChainReference) &&
-    (lastBuildAddress !== address.trim() || lastBuildChainReference !== chainReference.trim() || registryChanged);
+    (lastBuildAddress !== address.trim() || lastBuildChainReference !== chainReference.trim());
   const isStale = mode === InputMode.READABLE ? isReadableStale : isBuildStale;
 
   return (
@@ -142,8 +132,6 @@ export function InteractivePlayground({ chains }: InteractivePlaygroundProps) {
         setAddress={setAddress}
         chainReference={chainReference}
         setChainReference={setChainReference}
-        useOnchainRegistry={useOnchainRegistry}
-        setUseOnchainRegistry={setUseOnchainRegistry}
         onConvert={handleConvert}
         onExampleClick={handleExampleClick}
         isLoading={isLoading}

--- a/examples/ui/app/utils/address-conversion.ts
+++ b/examples/ui/app/utils/address-conversion.ts
@@ -1,5 +1,5 @@
 import { type ParsedInteroperableNameResult } from '@wonderland/interop-addresses';
-import { parseNameAction, type ParseNameActionOptions } from '../actions/parse-name';
+import { parseNameAction } from '../actions/parse-name';
 import { parseInteroperableAddressForDisplay } from './demo-helpers';
 import type { ParsedBinary, ParsedInteroperableName } from './demo-helpers';
 
@@ -13,22 +13,11 @@ export interface ConversionResult {
   parsedResult: ParsedInteroperableNameResult;
 }
 
-export interface ConversionOptions {
-  /** Experimental: ENS-based chain registry domain (e.g., "cid.eth") */
-  useExperimentalChainRegistry?: string;
-}
-
-export async function convertFromReadable(
-  interoperableName: string,
-  options?: ConversionOptions,
-): Promise<ConversionResult> {
+export async function convertFromReadable(interoperableName: string): Promise<ConversionResult> {
   let result;
-  const parseOptions: ParseNameActionOptions | undefined = options?.useExperimentalChainRegistry
-    ? { useExperimentalChainRegistry: options.useExperimentalChainRegistry }
-    : undefined;
 
   try {
-    result = await parseNameAction(interoperableName, parseOptions);
+    result = await parseNameAction(interoperableName);
   } catch {
     throw new Error(NETWORK_ERROR_MESSAGE);
   }

--- a/packages/addresses/README.md
+++ b/packages/addresses/README.md
@@ -357,27 +357,28 @@ This package implements:
 -   ✅ ENS name resolution for addresses (e.g., `alice.eth@eip155:1`)
 -   ✅ Validation: ENS names MUST include chain reference
 -   ✅ Context-aware error handling for ENS vs raw addresses
--   ✅ **Experimental**: ENS chain label resolution via onchain registries (e.g., `cid.eth`)
+-   ✅ ENS chain label resolution via onchain registry (`on.eth`, enabled by default)
 
-### Experimental: Onchain Chain Registry
+### Onchain Chain Registry
 
-ENS-based chain resolution is available as an experimental feature using the `useExperimentalChainRegistry` option:
+Chain labels are resolved via the `on.eth` onchain ENS registry by default. If onchain resolution fails, it falls back to chainid.network.
 
 ```typescript
 import { parseName } from "@wonderland/interop-addresses";
 
-// Use cid.eth (Unruggable's chain registry on mainnet)
-const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
-    useExperimentalChainRegistry: "cid.eth",
+// Default: uses on.eth onchain registry + offchain fallback
+const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth");
+
+// Disable onchain, use offchain only
+const result2 = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
+    onchainRegistry: false,
 });
 
-// Or use on.eth when deployed
-const result2 = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
-    useExperimentalChainRegistry: "on.eth",
+// Custom RPC URL
+const result3 = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
+    rpcUrl: "https://my-rpc.example.com",
 });
 ```
-
-This queries the specified ENS-based chain registry on mainnet. If onchain resolution fails, it falls back to chainid.network.
 
 ### Not Yet Implemented
 

--- a/packages/addresses/src/name/index.ts
+++ b/packages/addresses/src/name/index.ts
@@ -66,6 +66,10 @@ export interface ParseNameOptions {
     offchainRegistryFallback?: boolean;
     /** Custom mainnet RPC URL for onchain registry lookups. */
     rpcUrl?: string;
+    /**
+     * @deprecated Use `onchainRegistry` instead. Maps to `onchainRegistry` when set.
+     */
+    useExperimentalChainRegistry?: string;
 }
 
 export function parseName(
@@ -95,11 +99,14 @@ export async function parseName(
     // Track metadata flags
     const isChainLabel = !parsed.chainType;
 
+    // Support deprecated alias: useExperimentalChainRegistry → onchainRegistry
+    const onchainRegistry = opts?.onchainRegistry ?? opts?.useExperimentalChainRegistry;
+
     // Step 1: Resolve and validate chain identifier
     const resolvedChain = await resolveChain({
         chainType: parsed.chainType,
         chainReference: parsed.chainReference,
-        onchainRegistry: opts?.onchainRegistry,
+        onchainRegistry,
         offchainRegistryFallback: opts?.offchainRegistryFallback,
         rpcUrl: opts?.rpcUrl,
     });

--- a/packages/addresses/src/name/index.ts
+++ b/packages/addresses/src/name/index.ts
@@ -60,8 +60,12 @@ export interface ParsedInteroperableNameResult<
  */
 export interface ParseNameOptions {
     representation?: "binary" | "text";
-    /** Experimental: ENS-based chain registry domain (e.g., "cid.eth", "on.eth") */
-    useExperimentalChainRegistry?: string;
+    /** Onchain ENS-based chain registry domain. Default: "on.eth". true = use "on.eth", false = skip onchain, string = custom domain. */
+    onchainRegistry?: string | boolean;
+    /** Whether to fall back to offchain chainid.network registry. Default: true. */
+    offchainRegistryFallback?: boolean;
+    /** Custom mainnet RPC URL for onchain registry lookups. */
+    rpcUrl?: string;
 }
 
 export function parseName(
@@ -95,7 +99,9 @@ export async function parseName(
     const resolvedChain = await resolveChain({
         chainType: parsed.chainType,
         chainReference: parsed.chainReference,
-        useExperimentalChainRegistry: opts?.useExperimentalChainRegistry,
+        onchainRegistry: opts?.onchainRegistry,
+        offchainRegistryFallback: opts?.offchainRegistryFallback,
+        rpcUrl: opts?.rpcUrl,
     });
     const resolvedChainType = resolvedChain.chainType;
     const resolvedChainRef = resolvedChain.chainReference;

--- a/packages/addresses/src/name/resolveChain.ts
+++ b/packages/addresses/src/name/resolveChain.ts
@@ -1,14 +1,18 @@
 import { ChainTypeName, ChainTypeName as ChainTypeNameEnum } from "../constants/interopAddress.js";
 import { InvalidChainIdentifier, InvalidChainType } from "../internal.js";
 import { isValidChain, isValidChainType } from "./isValidChain.js";
-import { resolveChainFromRegistry } from "./resolveChainFromRegistry.js";
+import { DEFAULT_REGISTRY_DOMAIN, resolveChainFromRegistry } from "./resolveChainFromRegistry.js";
 import { shortnameToChainId } from "./shortnameToChainId.js";
 
 export interface ResolveChainInput {
     chainType?: string;
     chainReference?: string;
-    /** Experimental: ENS-based chain registry domain (e.g., "cid.eth", "on.eth") */
-    useExperimentalChainRegistry?: string;
+    /** Onchain ENS-based chain registry domain. Default: "on.eth". Set false to disable. */
+    onchainRegistry?: string | boolean;
+    /** Whether to fall back to offchain chainid.network registry. Default: true. */
+    offchainRegistryFallback?: boolean;
+    /** Custom mainnet RPC URL for onchain registry lookups. */
+    rpcUrl?: string;
 }
 
 export interface ResolvedChain {
@@ -30,7 +34,7 @@ export interface ResolvedChain {
  * @throws {InvalidChainIdentifier} If chainReference can't be resolved or chain combination is invalid
  */
 export const resolveChain = async (input: ResolveChainInput): Promise<ResolvedChain> => {
-    const { chainType, chainReference, useExperimentalChainRegistry } = input;
+    const { chainType, chainReference, onchainRegistry, offchainRegistryFallback, rpcUrl } = input;
 
     // Case 1: Both chainType and chainReference provided
     if (chainType && chainReference) {
@@ -67,11 +71,22 @@ export const resolveChain = async (input: ResolveChainInput): Promise<ResolvedCh
 
     // Case 3: Only chainReference provided - resolve it
     if (chainReference) {
-        // Try onchain registry first if registry domain is provided
-        if (useExperimentalChainRegistry) {
+        // Determine effective registry domain (default: "on.eth")
+        const registryDomain =
+            onchainRegistry === false
+                ? null
+                : typeof onchainRegistry === "string" && onchainRegistry
+                  ? onchainRegistry
+                  : DEFAULT_REGISTRY_DOMAIN;
+
+        const useOffchain = offchainRegistryFallback !== false;
+
+        // Try onchain registry first (enabled by default)
+        if (registryDomain) {
             const registryResult = await resolveChainFromRegistry(
                 chainReference,
-                useExperimentalChainRegistry,
+                registryDomain,
+                rpcUrl,
             );
             if (registryResult) {
                 return registryResult;
@@ -79,13 +94,15 @@ export const resolveChain = async (input: ResolveChainInput): Promise<ResolvedCh
             // Fall through to offchain resolution if onchain fails
         }
 
-        // Offchain resolution via chainid.network
-        const resolvedChainId = await shortnameToChainId(chainReference);
-        if (resolvedChainId) {
-            return {
-                chainType: ChainTypeNameEnum.EIP155,
-                chainReference: resolvedChainId.toString(),
-            };
+        // Offchain fallback via chainid.network
+        if (useOffchain) {
+            const resolvedChainId = await shortnameToChainId(chainReference);
+            if (resolvedChainId) {
+                return {
+                    chainType: ChainTypeNameEnum.EIP155,
+                    chainReference: resolvedChainId.toString(),
+                };
+            }
         }
 
         throw new InvalidChainIdentifier(

--- a/packages/addresses/src/name/resolveChainFromRegistry.ts
+++ b/packages/addresses/src/name/resolveChainFromRegistry.ts
@@ -4,6 +4,12 @@ import * as chains from "viem/chains";
 import { decodeAddress } from "../address/index.js";
 import { ChainTypeName } from "../constants/interopAddress.js";
 
+/** Default onchain ENS registry domain for chain resolution. */
+export const DEFAULT_REGISTRY_DOMAIN = "on.eth";
+
+// Default public Ethereum mainnet RPC endpoint
+const DEFAULT_MAINNET_RPC_URL = "https://cloudflare-eth.com";
+
 // Standard ENS registry address (same on all networks)
 const ENS_REGISTRY_ADDRESS: Address = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
 
@@ -32,10 +38,17 @@ export function clearRegistryCache(): void {
     resolutionCache.clear();
 }
 
-async function getResolverAddress(registryDomain: string): Promise<Address | null> {
+function getRpcUrl(rpcUrl?: string): string {
+    return rpcUrl ?? process.env.MAINNET_RPC_URL ?? DEFAULT_MAINNET_RPC_URL;
+}
+
+async function getResolverAddress(
+    registryDomain: string,
+    rpcUrl?: string,
+): Promise<Address | null> {
     const client = createPublicClient({
         chain: chains.mainnet,
-        transport: http(process.env.MAINNET_RPC_URL),
+        transport: http(getRpcUrl(rpcUrl)),
     });
 
     const registryNode = namehash(registryDomain);
@@ -56,15 +69,16 @@ async function getResolverAddress(registryDomain: string): Promise<Address | nul
 async function resolveLabel(
     label: string,
     registryDomain: string,
+    rpcUrl?: string,
 ): Promise<ResolvedChainFromRegistry | null> {
-    const resolverAddr = await getCachedResolver(registryDomain);
+    const resolverAddr = await getCachedResolver(registryDomain, rpcUrl);
     if (!resolverAddr) {
         return null;
     }
 
     const client = createPublicClient({
         chain: chains.mainnet,
-        transport: http(process.env.MAINNET_RPC_URL),
+        transport: http(getRpcUrl(rpcUrl)),
     });
 
     const interopAddrBytes = await client.readContract({
@@ -88,16 +102,17 @@ async function resolveLabel(
     };
 }
 
-function getCachedResolver(registryDomain: string): Promise<Address | null> {
-    const existing = resolverCache.get(registryDomain);
+function getCachedResolver(registryDomain: string, rpcUrl?: string): Promise<Address | null> {
+    const cacheKey = `${registryDomain}:${rpcUrl ?? ""}`;
+    const existing = resolverCache.get(cacheKey);
     if (existing) return existing;
 
-    const promise = getResolverAddress(registryDomain).catch((error) => {
+    const promise = getResolverAddress(registryDomain, rpcUrl).catch((error) => {
         // Evict on error so the next call retries
-        resolverCache.delete(registryDomain);
+        resolverCache.delete(cacheKey);
         throw error;
     });
-    resolverCache.set(registryDomain, promise);
+    resolverCache.set(cacheKey, promise);
     return promise;
 }
 
@@ -105,7 +120,7 @@ function getCachedResolver(registryDomain: string): Promise<Address | null> {
  * Resolves a chain label to chainType and chainReference using an onchain ENS-based registry.
  *
  * This implements forward resolution via the ChainResolver contract:
- * 1. Gets the resolver for the registry domain (e.g., cid.eth) from ENS registry
+ * 1. Gets the resolver for the registry domain (e.g., on.eth) from ENS registry
  * 2. Calls interoperableAddress(label) on the resolver with the label string
  * 3. Decodes the returned ERC-7930 binary format
  *
@@ -113,25 +128,27 @@ function getCachedResolver(registryDomain: string): Promise<Address | null> {
  * in-flight request. Transient errors are not cached and will be retried on the next call.
  *
  * @param label - The chain label to resolve (e.g., "optimism", "arbitrum", "base")
- * @param registryDomain - The ENS registry domain (e.g., "cid.eth", "on.eth")
+ * @param registryDomain - The ENS registry domain (e.g., "on.eth")
+ * @param rpcUrl - Optional custom mainnet RPC URL. Falls back to MAINNET_RPC_URL env var, then a default public endpoint.
  * @returns The resolved chainType and chainReference, or null if resolution fails
  *
  * @example
  * ```ts
- * // Resolve "optimism" using cid.eth registry
- * const result = await resolveChainFromRegistry("optimism", "cid.eth");
+ * // Resolve "optimism" using on.eth registry
+ * const result = await resolveChainFromRegistry("optimism", "on.eth");
  * // result: { chainType: "eip155", chainReference: "10" }
  * ```
  */
 export function resolveChainFromRegistry(
     label: string,
     registryDomain: string,
+    rpcUrl?: string,
 ): Promise<ResolvedChainFromRegistry | null> {
-    const cacheKey = `${label}:${registryDomain}`;
+    const cacheKey = `${label}:${registryDomain}:${rpcUrl ?? ""}`;
     const existing = resolutionCache.get(cacheKey);
     if (existing) return existing;
 
-    const promise = resolveLabel(label, registryDomain).catch(() => {
+    const promise = resolveLabel(label, registryDomain, rpcUrl).catch(() => {
         // Evict on error so the next call retries
         resolutionCache.delete(cacheKey);
         return null;

--- a/packages/addresses/src/name/resolveChainFromRegistry.ts
+++ b/packages/addresses/src/name/resolveChainFromRegistry.ts
@@ -39,7 +39,7 @@ export function clearRegistryCache(): void {
 }
 
 function getRpcUrl(rpcUrl?: string): string {
-    return rpcUrl ?? process.env.MAINNET_RPC_URL ?? DEFAULT_MAINNET_RPC_URL;
+    return rpcUrl?.trim() || process.env.MAINNET_RPC_URL?.trim() || DEFAULT_MAINNET_RPC_URL;
 }
 
 async function getResolverAddress(
@@ -103,16 +103,15 @@ async function resolveLabel(
 }
 
 function getCachedResolver(registryDomain: string, rpcUrl?: string): Promise<Address | null> {
-    const cacheKey = `${registryDomain}:${rpcUrl ?? ""}`;
-    const existing = resolverCache.get(cacheKey);
+    const existing = resolverCache.get(registryDomain);
     if (existing) return existing;
 
     const promise = getResolverAddress(registryDomain, rpcUrl).catch((error) => {
         // Evict on error so the next call retries
-        resolverCache.delete(cacheKey);
+        resolverCache.delete(registryDomain);
         throw error;
     });
-    resolverCache.set(cacheKey, promise);
+    resolverCache.set(registryDomain, promise);
     return promise;
 }
 
@@ -144,7 +143,7 @@ export function resolveChainFromRegistry(
     registryDomain: string,
     rpcUrl?: string,
 ): Promise<ResolvedChainFromRegistry | null> {
-    const cacheKey = `${label}:${registryDomain}:${rpcUrl ?? ""}`;
+    const cacheKey = `${label}:${registryDomain}`;
     const existing = resolutionCache.get(cacheKey);
     if (existing) return existing;
 

--- a/packages/addresses/test/name/parseNameWithRegistry.spec.ts
+++ b/packages/addresses/test/name/parseNameWithRegistry.spec.ts
@@ -8,9 +8,14 @@ const { mockResolveChainFromRegistry } = vi.hoisted(() => {
     return { mockResolveChainFromRegistry };
 });
 
-vi.mock("../../src/name/resolveChainFromRegistry.js", () => ({
-    resolveChainFromRegistry: mockResolveChainFromRegistry,
-}));
+vi.mock("../../src/name/resolveChainFromRegistry.js", async (importOriginal) => {
+    const actual =
+        await importOriginal<typeof import("../../src/name/resolveChainFromRegistry.js")>();
+    return {
+        ...actual,
+        resolveChainFromRegistry: mockResolveChainFromRegistry,
+    };
+});
 
 const { mockShortnameToChainId } = vi.hoisted(() => {
     const mockShortnameToChainId = vi.fn();
@@ -32,25 +37,23 @@ vi.mock("viem", async () => {
     };
 });
 
-describe("parseName with useExperimentalChainRegistry", () => {
+describe("parseName with onchain registry", () => {
     beforeEach(() => {
         mockResolveChainFromRegistry.mockReset();
         mockShortnameToChainId.mockReset();
         mockGetEnsAddress.mockReset();
     });
 
-    describe("when useExperimentalChainRegistry is provided", () => {
-        it("uses onchain registry for chain resolution", async () => {
+    describe("default behavior (onchain registry enabled)", () => {
+        it("uses onchain registry by default with on.eth", async () => {
             mockResolveChainFromRegistry.mockResolvedValue({
                 chainType: "eip155",
                 chainReference: "1",
             });
 
-            const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
-                useExperimentalChainRegistry: "cid.eth",
-            });
+            const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth");
 
-            expect(mockResolveChainFromRegistry).toHaveBeenCalledWith("eth", "cid.eth");
+            expect(mockResolveChainFromRegistry).toHaveBeenCalledWith("eth", "on.eth", undefined);
             expect(mockShortnameToChainId).not.toHaveBeenCalled();
             expect(isTextAddress(result.interoperableAddress)).toBe(true);
             if (isTextAddress(result.interoperableAddress)) {
@@ -64,11 +67,9 @@ describe("parseName with useExperimentalChainRegistry", () => {
             mockResolveChainFromRegistry.mockResolvedValue(null);
             mockShortnameToChainId.mockResolvedValue(1);
 
-            const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
-                useExperimentalChainRegistry: "cid.eth",
-            });
+            const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth");
 
-            expect(mockResolveChainFromRegistry).toHaveBeenCalledWith("eth", "cid.eth");
+            expect(mockResolveChainFromRegistry).toHaveBeenCalledWith("eth", "on.eth", undefined);
             expect(mockShortnameToChainId).toHaveBeenCalledWith("eth");
             expect(isTextAddress(result.interoperableAddress)).toBe(true);
             if (isTextAddress(result.interoperableAddress)) {
@@ -76,43 +77,50 @@ describe("parseName with useExperimentalChainRegistry", () => {
                 expect(result.interoperableAddress.chainReference).toBe("1");
             }
         });
+    });
 
-        it("works with different registry domains", async () => {
+    describe("custom onchainRegistry domain", () => {
+        it("uses the specified registry domain", async () => {
             mockResolveChainFromRegistry.mockResolvedValue({
                 chainType: "eip155",
                 chainReference: "42161",
             });
 
             const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@arb1", {
-                useExperimentalChainRegistry: "on.eth",
+                onchainRegistry: "custom.eth",
             });
 
-            expect(mockResolveChainFromRegistry).toHaveBeenCalledWith("arb1", "on.eth");
+            expect(mockResolveChainFromRegistry).toHaveBeenCalledWith(
+                "arb1",
+                "custom.eth",
+                undefined,
+            );
             if (isTextAddress(result.interoperableAddress)) {
                 expect(result.interoperableAddress.chainReference).toBe("42161");
             }
         });
 
-        it("preserves other options like representation", async () => {
+        it("uses on.eth when onchainRegistry is true", async () => {
             mockResolveChainFromRegistry.mockResolvedValue({
                 chainType: "eip155",
                 chainReference: "1",
             });
 
-            const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
-                useExperimentalChainRegistry: "cid.eth",
-                representation: "binary",
+            await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
+                onchainRegistry: true,
             });
 
-            expect(result.interoperableAddress.chainType instanceof Uint8Array).toBe(true);
+            expect(mockResolveChainFromRegistry).toHaveBeenCalledWith("eth", "on.eth", undefined);
         });
     });
 
-    describe("when useExperimentalChainRegistry is NOT provided", () => {
-        it("uses offchain resolution only", async () => {
+    describe("onchainRegistry disabled", () => {
+        it("skips onchain when onchainRegistry is false", async () => {
             mockShortnameToChainId.mockResolvedValue(1);
 
-            const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth");
+            const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
+                onchainRegistry: false,
+            });
 
             expect(mockResolveChainFromRegistry).not.toHaveBeenCalled();
             expect(mockShortnameToChainId).toHaveBeenCalledWith("eth");
@@ -123,11 +131,71 @@ describe("parseName with useExperimentalChainRegistry", () => {
         });
     });
 
+    describe("offchainRegistryFallback disabled", () => {
+        it("does not fall back to offchain when disabled", async () => {
+            mockResolveChainFromRegistry.mockResolvedValue(null);
+
+            await expect(
+                parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
+                    offchainRegistryFallback: false,
+                }),
+            ).rejects.toThrow();
+
+            expect(mockResolveChainFromRegistry).toHaveBeenCalledWith("eth", "on.eth", undefined);
+            expect(mockShortnameToChainId).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("both registries disabled", () => {
+        it("throws when shortname is used with both registries off", async () => {
+            await expect(
+                parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
+                    onchainRegistry: false,
+                    offchainRegistryFallback: false,
+                }),
+            ).rejects.toThrow();
+
+            expect(mockResolveChainFromRegistry).not.toHaveBeenCalled();
+            expect(mockShortnameToChainId).not.toHaveBeenCalled();
+        });
+
+        it("works with fully-qualified CAIP-2 even with both registries off", async () => {
+            const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:10", {
+                onchainRegistry: false,
+                offchainRegistryFallback: false,
+            });
+
+            expect(mockResolveChainFromRegistry).not.toHaveBeenCalled();
+            expect(mockShortnameToChainId).not.toHaveBeenCalled();
+            if (isTextAddress(result.interoperableAddress)) {
+                expect(result.interoperableAddress.chainType).toBe("eip155");
+                expect(result.interoperableAddress.chainReference).toBe("10");
+            }
+        });
+    });
+
+    describe("rpcUrl option", () => {
+        it("passes rpcUrl to resolveChainFromRegistry", async () => {
+            mockResolveChainFromRegistry.mockResolvedValue({
+                chainType: "eip155",
+                chainReference: "1",
+            });
+
+            await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
+                rpcUrl: "https://custom-rpc.com",
+            });
+
+            expect(mockResolveChainFromRegistry).toHaveBeenCalledWith(
+                "eth",
+                "on.eth",
+                "https://custom-rpc.com",
+            );
+        });
+    });
+
     describe("when chainType is explicitly provided", () => {
         it("does not use registry (explicit chain takes precedence)", async () => {
-            const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1", {
-                useExperimentalChainRegistry: "cid.eth",
-            });
+            const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1");
 
             // When both chainType and chainReference are provided, no resolution is needed
             expect(mockResolveChainFromRegistry).not.toHaveBeenCalled();
@@ -148,11 +216,9 @@ describe("parseName with useExperimentalChainRegistry", () => {
             });
             mockGetEnsAddress.mockResolvedValue("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
 
-            const result = await parseName("vitalik.eth@eth", {
-                useExperimentalChainRegistry: "cid.eth",
-            });
+            const result = await parseName("vitalik.eth@eth");
 
-            expect(mockResolveChainFromRegistry).toHaveBeenCalledWith("eth", "cid.eth");
+            expect(mockResolveChainFromRegistry).toHaveBeenCalledWith("eth", "on.eth", undefined);
             expect(result.meta.isENS).toBe(true);
             expect(result.meta.isChainLabel).toBe(true);
             if (isTextAddress(result.interoperableAddress)) {
@@ -168,14 +234,25 @@ describe("parseName with useExperimentalChainRegistry", () => {
                 chainReference: "1",
             });
 
-            const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
-                useExperimentalChainRegistry: "cid.eth",
-            });
+            const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth");
 
             // Checksum should be calculated based on resolved chain
             expect(result.meta.checksum).toBeDefined();
             expect(typeof result.meta.checksum).toBe("string");
             expect(result.meta.checksum?.length).toBe(8);
+        });
+
+        it("preserves other options like representation", async () => {
+            mockResolveChainFromRegistry.mockResolvedValue({
+                chainType: "eip155",
+                chainReference: "1",
+            });
+
+            const result = await parseName("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eth", {
+                representation: "binary",
+            });
+
+            expect(result.interoperableAddress.chainType instanceof Uint8Array).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## Summary

- Enable onchain chain resolution via `on.eth` ENS registry by default — no opt-in required
- Replace `useExperimentalChainRegistry` with three new `ParseNameOptions`: `onchainRegistry`, `offchainRegistryFallback`, and `rpcUrl`
- Add default public RPC endpoint (`cloudflare-eth.com`) so it works out of the box, with env var (`MAINNET_RPC_URL`) and per-call `rpcUrl` overrides
- Remove the experimental toggle from the `examples/ui` demo app
- Update docs and README to reflect the new defaults

Fixes EFI-837

## Test plan

- [x] All 423 Vitest tests pass (0 regressions)
- [x] TypeScript type-check passes across all packages
- [x] Lint-staged hooks pass
- [x] Verify onchain resolution works against live `on.eth` registry in staging
- [x] Smoke test `examples/ui` to confirm toggle removal and default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)