### PR TITLE
fix(ci): unbreak version-packages workflow

### DIFF
--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -44,3 +44,4 @@ jobs:
                   version: pnpm version-packages
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  HUSKY: "0"

--- a/apps/addresses-landing-page/package.json
+++ b/apps/addresses-landing-page/package.json
@@ -40,7 +40,7 @@
         "@radix-ui/react-toggle-group": "1.1.1",
         "@radix-ui/react-tooltip": "1.1.6",
         "@vercel/analytics": "1.3.1",
-        "@wonderland/interop-addresses": "0.3.0",
+        "@wonderland/interop-addresses": "workspace:*",
         "autoprefixer": "10.4.20",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,8 +155,8 @@ importers:
                 specifier: 1.3.1
                 version: 1.3.1(next@16.0.10(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
             "@wonderland/interop-addresses":
-                specifier: 0.3.0
-                version: 0.3.0(bufferutil@4.0.9)(typescript@5.6.2)(utf-8-validate@5.0.10)
+                specifier: workspace:*
+                version: link:../../packages/addresses
             autoprefixer:
                 specifier: 10.4.20
                 version: 10.4.20(postcss@8.5.6)
@@ -7099,12 +7099,6 @@ packages:
         resolution:
             {
                 integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==,
-            }
-
-    "@wonderland/interop-addresses@0.3.0":
-        resolution:
-            {
-                integrity: sha512-IfX8mdaK9dyy578yJ22V7J8Hd0wArLf1JHyA5xK4+RFDUMj3JeBUBccEWoGjZaA0ZU1GgTw1YcqBZFisQyxb6g==,
             }
 
     "@wonderland/walletless@1.2.0":
@@ -24577,18 +24571,6 @@ snapshots:
             "@webassemblyjs/ast": 1.14.1
             "@xtuc/long": 4.2.2
 
-    "@wonderland/interop-addresses@0.3.0(bufferutil@4.0.9)(typescript@5.6.2)(utf-8-validate@5.0.10)":
-        dependencies:
-            axios: 1.13.2
-            bs58: 6.0.0
-            viem: 2.28.0(bufferutil@4.0.9)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.3)
-            zod: 3.24.3
-        transitivePeerDependencies:
-            - bufferutil
-            - debug
-            - typescript
-            - utf-8-validate
-
     "@wonderland/walletless@1.2.0(viem@2.37.0(bufferutil@4.0.9)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.14.11(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.62.16(react@19.1.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.6.2)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))":
         dependencies:
             viem: 2.37.0(bufferutil@4.0.9)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -24606,11 +24588,6 @@ snapshots:
     abitype@1.0.8(typescript@5.5.4)(zod@3.24.3):
         optionalDependencies:
             typescript: 5.5.4
-            zod: 3.24.3
-
-    abitype@1.0.8(typescript@5.6.2)(zod@3.24.3):
-        optionalDependencies:
-            typescript: 5.6.2
             zod: 3.24.3
 
     abitype@1.0.8(typescript@5.6.2)(zod@3.25.76):
@@ -29134,20 +29111,6 @@ snapshots:
         transitivePeerDependencies:
             - zod
 
-    ox@0.6.9(typescript@5.6.2)(zod@3.24.3):
-        dependencies:
-            "@adraffy/ens-normalize": 1.11.0
-            "@noble/curves": 1.8.2
-            "@noble/hashes": 1.7.2
-            "@scure/bip32": 1.6.2
-            "@scure/bip39": 1.5.4
-            abitype: 1.0.8(typescript@5.6.2)(zod@3.24.3)
-            eventemitter3: 5.0.1
-        optionalDependencies:
-            typescript: 5.6.2
-        transitivePeerDependencies:
-            - zod
-
     ox@0.9.3(typescript@5.6.2)(zod@3.25.76):
         dependencies:
             "@adraffy/ens-normalize": 1.11.0
@@ -31553,23 +31516,6 @@ snapshots:
             ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
         optionalDependencies:
             typescript: 5.5.4
-        transitivePeerDependencies:
-            - bufferutil
-            - utf-8-validate
-            - zod
-
-    viem@2.28.0(bufferutil@4.0.9)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.3):
-        dependencies:
-            "@noble/curves": 1.8.2
-            "@noble/hashes": 1.7.2
-            "@scure/bip32": 1.6.2
-            "@scure/bip39": 1.5.4
-            abitype: 1.0.8(typescript@5.6.2)(zod@3.24.3)
-            isows: 1.0.6(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-            ox: 0.6.9(typescript@5.6.2)(zod@3.24.3)
-            ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-        optionalDependencies:
-            typescript: 5.6.2
         transitivePeerDependencies:
             - bufferutil
             - utf-8-validate


### PR DESCRIPTION
## Summary
- Skip husky pre-commit hooks in the version-packages CI workflow. The changesets commit was failing because `check-types` ran without built packages. The code already passed all checks in the PR workflow, so running hooks on a version bump commit is unnecessary.
- Fix `addresses-landing-page` to use `workspace:*` instead of a pinned `0.3.0` for `@wonderland/interop-addresses`, matching every other internal dependency in the monorepo.