### PR TITLE
feat(cross-chain): replace onBeforeTracking with PreTracker interface

### DIFF
--- a/.changeset/relay-pre-tracker.md
+++ b/.changeset/relay-pre-tracker.md
@@ -1,0 +1,10 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+feat: replace onBeforeTracking hook with PreTracker interface
+
+-   Add PreTracker interface and APIPreTracker implementation
+-   Add PreTrackerFactory for config-driven pre-tracker creation
+-   Add WatchOrderByOrderId.openTxHash field for order-id tracking path
+-   Remove OnBeforeTracking callback type

--- a/apps/docs/docs/cross-chain/intent-tracking.md
+++ b/apps/docs/docs/cross-chain/intent-tracking.md
@@ -118,7 +118,7 @@ if (status.fillEvent) {
 
 -   Relay uses **API-based tracking** for both mainnet and testnet. Both opened intent parsing and fill watching use the `/intents/status/v3` endpoint.
 -   **No RPC URLs required** — all tracking is done through the Relay API.
--   Transaction notification is **automatic** — when tracking starts, the `onBeforeTracking` hook calls `POST /transactions/index` to accelerate solver indexing. No manual step required.
+-   Transaction notification is **automatic** — when tracking starts, the pre-tracker calls `POST /transactions/index` to accelerate solver indexing. No manual step required.
 
 ```typescript
 const originChainId = 11155111;
@@ -126,7 +126,7 @@ const destinationChainId = 84532;
 
 const hash = await walletClient.sendTransaction({ ... });
 
-// Start tracking — Relay is automatically notified via onBeforeTracking
+// Start tracking — Relay is automatically notified via the pre-tracker
 const tracker = aggregator.track({
     txHash: hash,
     providerId: quote.provider,

--- a/apps/docs/docs/cross-chain/relay-provider.md
+++ b/apps/docs/docs/cross-chain/relay-provider.md
@@ -88,7 +88,7 @@ console.log("Transaction sent:", hash);
 -   Transaction simulation
 -   Order tracking support
 -   API-based intent tracking
--   Automatic transaction notification for faster solver indexing via `onBeforeTracking`
+-   Automatic transaction notification for faster solver indexing via the pre-tracker
 
 ## Tracking
 
@@ -101,7 +101,7 @@ Unlike Across, Relay does not require RPC URLs for tracking since all tracking i
 
 ## Transaction Notification
 
-Transaction notification is automatic — when tracking starts, the `onBeforeTracking` hook calls Relay's [transaction indexing](https://docs.relay.link/references/api/api_guides/transaction-indexing) via `POST /transactions/index`, accelerating the indexing process before transaction validation completes. No manual step is required.
+Transaction notification is automatic — when tracking starts, the pre-tracker calls Relay's [transaction indexing](https://docs.relay.link/references/api/api_guides/transaction-indexing) via `POST /transactions/index`, accelerating the indexing process before transaction validation completes. No manual step is required.
 
 ## Next Step
 

--- a/packages/cross-chain/README.md
+++ b/packages/cross-chain/README.md
@@ -125,7 +125,7 @@ if (selectedQuote) {
 -   Relay tracking is fully **API-based** for both mainnet and testnet.
 -   Both opened intent parsing and fill watching use the `/intents/status/v3` endpoint.
 -   No RPC URLs are required for Relay tracking.
--   Relay automatically notifies the solver of new deposits via `onBeforeTracking` for faster indexing.
+-   Relay automatically notifies the solver of new deposits via the pre-tracker for faster indexing.
 
 ### Aggregator
 

--- a/packages/cross-chain/src/core/interfaces/crossChainProvider.interface.ts
+++ b/packages/cross-chain/src/core/interfaces/crossChainProvider.interface.ts
@@ -2,10 +2,10 @@ import type { Hex } from "viem";
 
 import type { Quote, SubmitOrderResponse } from "../schemas/quote.js";
 import type { QuoteRequest } from "../schemas/quoteRequest.js";
-import type { OnBeforeTracking } from "../types/tracking.js";
 import type { AssetDiscoveryConfig } from "./assetDiscovery.interface.js";
 import type { FillWatcherConfig } from "./fillWatcher.interface.js";
 import type { OpenedIntentParserConfig } from "./openedIntentParser.interface.js";
+import type { PreTrackerConfig } from "./preTracker.interface.js";
 import { ProviderExecuteNotImplemented } from "../errors/ProviderExecuteNotImplemented.exception.js";
 
 export abstract class CrossChainProvider {
@@ -69,15 +69,15 @@ export abstract class CrossChainProvider {
      * @returns Configuration object containing:
      *   - openedIntentParserConfig: Config for parsing opened intent from origin chain
      *   - fillWatcherConfig: Config for watching fill events on destination chain
-     *   - onBeforeTracking: Optional hook called before tracking begins (e.g. notify solver of deposit)
+     *   - preTrackerConfig: Optional config for the pre-tracker that runs before tracking begins
      */
     abstract getTrackingConfig(): {
         /** Configuration for parsing opened intent data */
         openedIntentParserConfig: OpenedIntentParserConfig;
         /** Configuration for watching fill events */
         fillWatcherConfig: FillWatcherConfig;
-        /** Optional hook executed before tracking begins (e.g. notify solver of deposit) */
-        onBeforeTracking?: OnBeforeTracking;
+        /** Optional config for the pre-tracker that runs before tracking begins */
+        preTrackerConfig?: PreTrackerConfig;
     };
 
     /**

--- a/packages/cross-chain/src/core/interfaces/index.ts
+++ b/packages/cross-chain/src/core/interfaces/index.ts
@@ -7,3 +7,4 @@ export * from "./quotes.interface.js";
 export * from "./sortingStrategy.interface.js";
 export * from "./intentValidator.interface.js";
 export * from "./assetDiscovery.interface.js";
+export * from "./preTracker.interface.js";

--- a/packages/cross-chain/src/core/interfaces/orderTrackerFactory.interface.ts
+++ b/packages/cross-chain/src/core/interfaces/orderTrackerFactory.interface.ts
@@ -2,6 +2,7 @@ import type { PublicClient } from "viem";
 
 import type { FillWatcher } from "./fillWatcher.interface.js";
 import type { OpenedIntentParser } from "./openedIntentParser.interface.js";
+import type { PreTracker } from "./preTracker.interface.js";
 
 /**
  * Configuration for OrderTrackerFactory
@@ -17,4 +18,5 @@ export interface OrderTrackerFactoryConfig {
 export interface OrderTrackerConfig extends OrderTrackerFactoryConfig {
     openedIntentParser?: OpenedIntentParser;
     fillWatcher?: FillWatcher;
+    preTracker?: PreTracker;
 }

--- a/packages/cross-chain/src/core/interfaces/preTracker.interface.ts
+++ b/packages/cross-chain/src/core/interfaces/preTracker.interface.ts
@@ -1,0 +1,36 @@
+import type { Hex } from "viem";
+
+import type { APIPreTrackerConfig } from "../services/APIPreTracker.js";
+
+/**
+ * Parameters passed to a pre-tracker before order watching begins.
+ */
+export interface PreTrackerParams {
+    /** Origin transaction hash */
+    txHash: Hex;
+    /** Chain ID where the origin transaction was submitted */
+    originChainId: number;
+    /** Optional order or request identifier, when already known */
+    orderId?: Hex;
+}
+
+/**
+ * Executes a protocol-specific step before order tracking begins.
+ *
+ * Implementations are best-effort: callers catch and log errors
+ * without blocking the tracking flow.
+ */
+export interface PreTracker {
+    /** Run the pre-tracking step with the given parameters. */
+    execute(params: PreTrackerParams): Promise<void>;
+}
+
+/**
+ * Discriminated union of pre-tracker configurations.
+ * Returned by {@link CrossChainProvider.getTrackingConfig} to declare which
+ * pre-tracking strategy a provider requires.
+ */
+export type PreTrackerConfig = APIPreTrackerConfig;
+
+// Re-export for convenience
+export type { APIPreTrackerConfig };

--- a/packages/cross-chain/src/core/services/APIPreTracker.ts
+++ b/packages/cross-chain/src/core/services/APIPreTracker.ts
@@ -17,6 +17,8 @@ export interface APIPreTrackerConfig {
     buildBody: (params: PreTrackerParams) => Record<string, unknown>;
     /** Optional custom headers */
     headers?: Record<string, string>;
+    /** Optional request timeout in milliseconds (defaults to 5000) */
+    timeoutMs?: number;
 }
 
 /**
@@ -33,6 +35,7 @@ export class APIPreTracker implements PreTracker {
         try {
             await axios.post(url, body, {
                 headers: this.config.headers,
+                timeout: this.config.timeoutMs ?? 5000,
             });
         } catch (error) {
             if (axios.isAxiosError(error)) {

--- a/packages/cross-chain/src/core/services/APIPreTracker.ts
+++ b/packages/cross-chain/src/core/services/APIPreTracker.ts
@@ -1,0 +1,49 @@
+import axios from "axios";
+
+import type { PreTracker, PreTrackerParams } from "../interfaces/preTracker.interface.js";
+import { APIRequestFailure } from "../errors/APIRequestFailure.exception.js";
+
+/**
+ * Configuration for an API-based pre-tracker.
+ */
+export interface APIPreTrackerConfig {
+    /** Discriminator for the pre-tracker config union */
+    type: "api";
+    /** Protocol name used in error messages */
+    protocolName: string;
+    /** Build the target URL for the POST request */
+    buildUrl: () => string;
+    /** Build the JSON body from the pre-tracker parameters */
+    buildBody: (params: PreTrackerParams) => Record<string, unknown>;
+    /** Optional custom headers */
+    headers?: Record<string, string>;
+}
+
+/**
+ * Pre-tracker that notifies a protocol via an HTTP POST request.
+ */
+export class APIPreTracker implements PreTracker {
+    constructor(private readonly config: APIPreTrackerConfig) {}
+
+    /** {@inheritDoc PreTracker.execute} */
+    async execute(params: PreTrackerParams): Promise<void> {
+        const url = this.config.buildUrl();
+        const body = this.config.buildBody(params);
+
+        try {
+            await axios.post(url, body, {
+                headers: this.config.headers,
+            });
+        } catch (error) {
+            if (axios.isAxiosError(error)) {
+                const status = error.response?.status ?? 0;
+                const text =
+                    typeof error.response?.data === "string"
+                        ? error.response.data
+                        : JSON.stringify(error.response?.data ?? error.message);
+                throw new APIRequestFailure(this.config.protocolName, status, text);
+            }
+            throw error;
+        }
+    }
+}

--- a/packages/cross-chain/src/core/services/APIPreTracker.ts
+++ b/packages/cross-chain/src/core/services/APIPreTracker.ts
@@ -17,7 +17,7 @@ export interface APIPreTrackerConfig {
     buildBody: (params: PreTrackerParams) => Record<string, unknown>;
     /** Optional custom headers */
     headers?: Record<string, string>;
-    /** Optional request timeout in milliseconds (defaults to 5000) */
+    /** Optional request timeout in milliseconds (defaults to 15000) */
     timeoutMs?: number;
 }
 
@@ -35,7 +35,7 @@ export class APIPreTracker implements PreTracker {
         try {
             await axios.post(url, body, {
                 headers: this.config.headers,
-                timeout: this.config.timeoutMs ?? 5000,
+                timeout: this.config.timeoutMs ?? 15000,
             });
         } catch (error) {
             if (axios.isAxiosError(error)) {

--- a/packages/cross-chain/src/core/services/OrderTracker.ts
+++ b/packages/cross-chain/src/core/services/OrderTracker.ts
@@ -4,6 +4,7 @@ import { Address, Hex } from "viem";
 import type { FillWatcher } from "../interfaces/fillWatcher.interface.js";
 import type { OpenedIntentParser } from "../interfaces/openedIntentParser.interface.js";
 import type { OrderTrackerEvents } from "../interfaces/orderTracker.interface.js";
+import type { PreTracker } from "../interfaces/preTracker.interface.js";
 import type {
     OpenedIntent,
     OrderTrackerYield,
@@ -13,7 +14,6 @@ import type {
     WatchOrderByTxHash,
     WatchOrderParams,
 } from "../types/orderTracking.js";
-import type { OnBeforeTracking } from "../types/tracking.js";
 import { OpenedIntentNotFoundError } from "../errors/OpenedIntentNotFound.exception.js";
 import { OrderTrackerEvent } from "../interfaces/orderTracker.interface.js";
 import { OrderFailureReason, OrderStatus, OrderTrackerYieldType } from "../types/orderTracking.js";
@@ -63,7 +63,7 @@ export class OrderTracker extends EventEmitter {
         private readonly openedIntentParser: OpenedIntentParser,
         private readonly fillWatcher: FillWatcher,
         private readonly clientManager?: PublicClientManager,
-        private readonly onBeforeTracking?: OnBeforeTracking,
+        private readonly preTracker?: PreTracker,
     ) {
         super();
     }
@@ -165,6 +165,8 @@ export class OrderTracker extends EventEmitter {
             throw new Error(`Timeout must be positive, got ${timeout}ms`);
         }
 
+        await this.invokePreTracker(params);
+
         if ("txHash" in params && params.txHash) {
             yield* this.watchOrderByTxHash({ ...params, timeout });
         } else {
@@ -178,14 +180,6 @@ export class OrderTracker extends EventEmitter {
     ): AsyncGenerator<OrderTrackerYield> {
         const { txHash, originChainId, timeout } = params;
         const startTime = Date.now();
-
-        if (this.onBeforeTracking) {
-            try {
-                await this.onBeforeTracking({ txHash, originChainId });
-            } catch (error) {
-                console.warn("[OrderTracker] onBeforeTracking failed:", error);
-            }
-        }
 
         let lastUpdate: OrderTrackingUpdate = this.createUpdate({
             status: OrderStatus.Pending,
@@ -524,6 +518,30 @@ export class OrderTracker extends EventEmitter {
             if (terminalStatuses.has(item.update.status)) {
                 return;
             }
+        }
+    }
+
+    /**
+     * Invoke the pre-tracker once before dispatching to a specific watch path.
+     * Extracts txHash/orderId from whichever WatchOrderParams variant was provided.
+     * Best-effort: logs a warning on failure but never blocks tracking.
+     */
+    private async invokePreTracker(params: WatchOrderParams): Promise<void> {
+        if (!this.preTracker) return;
+
+        const txHash = "txHash" in params ? params.txHash : params.openTxHash;
+        if (!txHash) return;
+
+        const orderId = "orderId" in params ? params.orderId : undefined;
+
+        try {
+            await this.preTracker.execute({
+                txHash,
+                originChainId: params.originChainId,
+                orderId,
+            });
+        } catch (error) {
+            console.warn("[OrderTracker] pre-tracker failed:", error);
         }
     }
 

--- a/packages/cross-chain/src/core/services/OrderTracker.ts
+++ b/packages/cross-chain/src/core/services/OrderTracker.ts
@@ -529,7 +529,9 @@ export class OrderTracker extends EventEmitter {
     private async invokePreTracker(params: WatchOrderParams): Promise<void> {
         if (!this.preTracker) return;
 
-        const txHash = "txHash" in params ? params.txHash : params.openTxHash;
+        const txHash =
+            ("txHash" in params ? params.txHash : undefined) ??
+            ("openTxHash" in params ? params.openTxHash : undefined);
         if (!txHash) return;
 
         const orderId = "orderId" in params ? params.orderId : undefined;
@@ -541,7 +543,10 @@ export class OrderTracker extends EventEmitter {
                 orderId,
             });
         } catch (error) {
-            console.warn("[OrderTracker] pre-tracker failed:", error);
+            console.warn(
+                "[OrderTracker] pre-tracker failed:",
+                error instanceof Error ? error.message : String(error),
+            );
         }
     }
 

--- a/packages/cross-chain/src/core/services/index.ts
+++ b/packages/cross-chain/src/core/services/index.ts
@@ -8,3 +8,4 @@ export * from "./intentValidationsAggregator.js";
 export * from "./BaseAssetDiscoveryService.js";
 export * from "./StaticAssetDiscoveryService.js";
 export * from "./CustomApiAssetDiscoveryService.js";
+export * from "./APIPreTracker.js";

--- a/packages/cross-chain/src/core/types/index.ts
+++ b/packages/cross-chain/src/core/types/index.ts
@@ -1,3 +1,2 @@
 export * from "./orderTracking.js";
 export * from "./assetDiscovery.js";
-export * from "./tracking.js";

--- a/packages/cross-chain/src/core/types/orderTracking.ts
+++ b/packages/cross-chain/src/core/types/orderTracking.ts
@@ -198,13 +198,15 @@ export interface WatchOrderByTxHash extends WatchOrderBase {
     destinationChainId?: number;
 }
 
-/** Watch by orderId (escrow orders) */
+/** Watch by order identifier instead of transaction hash */
 export interface WatchOrderByOrderId extends WatchOrderBase {
     txHash?: never;
-    /** Order ID from submitSignedOrder() */
+    /** Order or request identifier returned by the protocol */
     orderId: Hex;
-    /** Required - no order to parse */
+    /** Required when no origin transaction is available to parse */
     destinationChainId: number;
+    /** Origin transaction hash, passed to the pre-tracker when provided */
+    openTxHash?: Hex;
 }
 
 /** Pass txHash for user-open orders, orderId for escrow orders */

--- a/packages/cross-chain/src/core/types/tracking.ts
+++ b/packages/cross-chain/src/core/types/tracking.ts
@@ -1,8 +1,0 @@
-import type { Hex } from "viem";
-
-export type OnBeforeTrackingParams = {
-    txHash: Hex;
-    originChainId: number;
-};
-
-export type OnBeforeTracking = (params: OnBeforeTrackingParams) => Promise<void>;

--- a/packages/cross-chain/src/external.ts
+++ b/packages/cross-chain/src/external.ts
@@ -27,6 +27,8 @@ export {
     OIFOpenedIntentParser,
     APIOpenedIntentParser,
     CustomEventOpenedIntentParser,
+    APIPreTracker,
+    PreTrackerFactory,
     // Sorting
     SortingStrategyFactory,
     // Asset Discovery

--- a/packages/cross-chain/src/factories/index.ts
+++ b/packages/cross-chain/src/factories/index.ts
@@ -5,3 +5,4 @@ export * from "./assetDiscoveryFactory.js";
 export * from "./sortingStrategyFactory.js";
 export * from "./orderTrackerFactory.js";
 export * from "./intentValidatorFactory.js";
+export * from "./preTrackerFactory.js";

--- a/packages/cross-chain/src/factories/orderTrackerFactory.ts
+++ b/packages/cross-chain/src/factories/orderTrackerFactory.ts
@@ -52,9 +52,11 @@ export class OrderTrackerFactory {
             config?.fillWatcher ??
             this.createFillWatcher(trackingConfig.fillWatcherConfig as FillWatcherConfig);
 
-        const preTracker = trackingConfig.preTrackerConfig
-            ? (config?.preTracker ?? this.preTrackerFactory.create(trackingConfig.preTrackerConfig))
-            : undefined;
+        const preTracker =
+            config?.preTracker ??
+            (trackingConfig.preTrackerConfig
+                ? this.preTrackerFactory.create(trackingConfig.preTrackerConfig)
+                : undefined);
 
         return new OrderTracker(openedIntentParser, fillWatcher, this.clientManager, preTracker);
     }

--- a/packages/cross-chain/src/factories/orderTrackerFactory.ts
+++ b/packages/cross-chain/src/factories/orderTrackerFactory.ts
@@ -11,8 +11,10 @@ import {
     OrderTracker,
     OrderTrackerConfig,
     OrderTrackerFactoryConfig,
+    PreTracker,
     PublicClientManager,
 } from "../internal.js";
+import { PreTrackerFactory } from "./preTrackerFactory.js";
 
 /**
  * Factory class for creating OrderTracker instances
@@ -36,6 +38,7 @@ export class OrderTrackerFactory {
         config?: {
             openedIntentParser?: OpenedIntentParser;
             fillWatcher?: FillWatcher;
+            preTracker?: PreTracker;
         },
     ): OrderTracker {
         const trackingConfig = provider.getTrackingConfig();
@@ -48,12 +51,12 @@ export class OrderTrackerFactory {
             config?.fillWatcher ??
             this.createFillWatcher(trackingConfig.fillWatcherConfig as FillWatcherConfig);
 
-        return new OrderTracker(
-            openedIntentParser,
-            fillWatcher,
-            this.clientManager,
-            trackingConfig.onBeforeTracking,
-        );
+        const preTrackerFactory = new PreTrackerFactory();
+        const preTracker = trackingConfig.preTrackerConfig
+            ? (config?.preTracker ?? preTrackerFactory.create(trackingConfig.preTrackerConfig))
+            : undefined;
+
+        return new OrderTracker(openedIntentParser, fillWatcher, this.clientManager, preTracker);
     }
 
     /**
@@ -136,6 +139,7 @@ export function createOrderTracker(
         publicClient,
         openedIntentParser: customParser,
         fillWatcher: customFillWatcher,
+        preTracker: customPreTracker,
         rpcUrls,
     } = config || {};
 
@@ -143,5 +147,6 @@ export function createOrderTracker(
     return factory.createTracker(provider, {
         openedIntentParser: customParser,
         fillWatcher: customFillWatcher,
+        preTracker: customPreTracker,
     });
 }

--- a/packages/cross-chain/src/factories/orderTrackerFactory.ts
+++ b/packages/cross-chain/src/factories/orderTrackerFactory.ts
@@ -22,6 +22,7 @@ import { PreTrackerFactory } from "./preTrackerFactory.js";
  */
 export class OrderTrackerFactory {
     private readonly clientManager: PublicClientManager;
+    private readonly preTrackerFactory = new PreTrackerFactory();
 
     constructor(config?: OrderTrackerFactoryConfig) {
         this.clientManager = new PublicClientManager(config?.publicClient, config?.rpcUrls);
@@ -51,9 +52,8 @@ export class OrderTrackerFactory {
             config?.fillWatcher ??
             this.createFillWatcher(trackingConfig.fillWatcherConfig as FillWatcherConfig);
 
-        const preTrackerFactory = new PreTrackerFactory();
         const preTracker = trackingConfig.preTrackerConfig
-            ? (config?.preTracker ?? preTrackerFactory.create(trackingConfig.preTrackerConfig))
+            ? (config?.preTracker ?? this.preTrackerFactory.create(trackingConfig.preTrackerConfig))
             : undefined;
 
         return new OrderTracker(openedIntentParser, fillWatcher, this.clientManager, preTracker);

--- a/packages/cross-chain/src/factories/preTrackerFactory.ts
+++ b/packages/cross-chain/src/factories/preTrackerFactory.ts
@@ -15,6 +15,10 @@ export class PreTrackerFactory {
         switch (config.type) {
             case "api":
                 return new APIPreTracker(config);
+            default:
+                throw new Error(
+                    `Unsupported preTracker type: ${(config as { type?: string }).type ?? "unknown"}`,
+                );
         }
     }
 }

--- a/packages/cross-chain/src/factories/preTrackerFactory.ts
+++ b/packages/cross-chain/src/factories/preTrackerFactory.ts
@@ -1,0 +1,20 @@
+import type { PreTracker, PreTrackerConfig } from "../internal.js";
+import { APIPreTracker } from "../internal.js";
+
+/**
+ * Factory for creating {@link PreTracker} instances from provider config.
+ */
+export class PreTrackerFactory {
+    /**
+     * Create a PreTracker based on the config type.
+     *
+     * @param config - Discriminated union returned by {@link CrossChainProvider.getTrackingConfig}
+     * @returns A configured PreTracker instance
+     */
+    create(config: PreTrackerConfig): PreTracker {
+        switch (config.type) {
+            case "api":
+                return new APIPreTracker(config);
+        }
+    }
+}

--- a/packages/cross-chain/src/protocols/relay/provider.ts
+++ b/packages/cross-chain/src/protocols/relay/provider.ts
@@ -6,8 +6,9 @@ import { ZodError } from "zod";
 import type {
     AssetDiscoveryConfig,
     FillWatcherConfig,
-    OnBeforeTracking,
     OpenedIntentParserConfig,
+    PreTrackerConfig,
+    PreTrackerParams,
     Quote,
     QuoteRequest,
 } from "../../internal.js";
@@ -106,7 +107,7 @@ export class RelayProvider extends CrossChainProvider {
     getTrackingConfig(): {
         openedIntentParserConfig: OpenedIntentParserConfig;
         fillWatcherConfig: FillWatcherConfig;
-        onBeforeTracking: OnBeforeTracking;
+        preTrackerConfig: PreTrackerConfig;
     } {
         return {
             openedIntentParserConfig: {
@@ -131,11 +132,16 @@ export class RelayProvider extends CrossChainProvider {
                 buildEndpoint: (params): string => `/intents/status/v3?requestId=${params.orderId}`,
                 extractFillEvent,
             } as FillWatcherConfig,
-            onBeforeTracking: async ({ txHash, originChainId }): Promise<void> => {
-                await this.apiService.indexTransaction({
-                    chainId: String(originChainId),
-                    txHash,
-                });
+            preTrackerConfig: {
+                type: "api" as const,
+                protocolName: RelayProvider.PROTOCOL_NAME,
+                buildUrl: (): string => `${this.baseUrl}/transactions/index`,
+                buildBody: (params: PreTrackerParams): Record<string, unknown> => ({
+                    chainId: String(params.originChainId),
+                    txHash: params.txHash,
+                    ...(params.orderId && { requestId: params.orderId }),
+                }),
+                headers: Object.keys(this.apiHeaders).length > 0 ? this.apiHeaders : undefined,
             },
         };
     }

--- a/packages/cross-chain/src/protocols/relay/services/RelayApiService.ts
+++ b/packages/cross-chain/src/protocols/relay/services/RelayApiService.ts
@@ -37,7 +37,7 @@ export class RelayApiService {
         }
     }
 
-    /** POST /transactions/index — notify Relay of a deposit transaction for faster solver indexing. */
+    /** POST /transactions/index — tell Relay about a deposit transaction for faster solver indexing. */
     async indexTransaction(
         params: RelayIndexTransactionRequest,
     ): Promise<RelayIndexTransactionResponse> {

--- a/packages/cross-chain/test/protocols/relay/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/provider.spec.ts
@@ -27,7 +27,6 @@ const HTTP_STATUS_BAD_REQUEST = 400;
 const RELAY_ERROR_AMOUNT_TOO_LOW = "AMOUNT_TOO_LOW";
 const RELAY_ERROR_ROUTE_NOT_FOUND = "ROUTE_NOT_FOUND";
 const TX_HASH = "0xdeposithash";
-const INDEX_ENDPOINT = "/transactions/index";
 const RELAY_BASE_URL = "https://api.relay.link";
 
 // ── Mock & Helpers ───────────────────────────────────────
@@ -269,38 +268,40 @@ describe("RelayProvider", () => {
             expect(config.openedIntentParserConfig.type).toBe("api");
         });
 
-        it("includes onBeforeTracking hook", () => {
+        it("includes preTrackerConfig", () => {
             const config = provider.getTrackingConfig();
-            expect(config.onBeforeTracking).toBeDefined();
-            expect(typeof config.onBeforeTracking).toBe("function");
+            expect(config.preTrackerConfig).toBeDefined();
+            expect(config.preTrackerConfig.type).toBe("api");
         });
 
-        it("onBeforeTracking calls /transactions/index with stringified chainId", async () => {
-            mockPost.mockResolvedValue({ data: { message: "Transaction indexed" } });
+        it("preTrackerConfig builds correct URL and body", () => {
             const config = provider.getTrackingConfig();
-            await config.onBeforeTracking!({
+            const preTrackerConfig = config.preTrackerConfig;
+            expect(preTrackerConfig.buildUrl()).toContain("/transactions/index");
+            const body = preTrackerConfig.buildBody({
                 txHash: TX_HASH,
                 originChainId: ORIGIN_CHAIN_ID,
             });
-            expect(mockPost).toHaveBeenCalledWith(INDEX_ENDPOINT, {
+            expect(body).toEqual({
                 chainId: String(ORIGIN_CHAIN_ID),
                 txHash: TX_HASH,
             });
         });
 
-        it("onBeforeTracking propagates errors from the API", async () => {
-            mockPost.mockRejectedValue(
-                makeAxiosError(
-                    { message: "Not found" },
-                    HTTP_STATUS_BAD_REQUEST,
-                    "Request failed",
-                    "ERR_BAD_REQUEST",
-                ),
-            );
+        it("preTrackerConfig includes requestId when orderId provided", () => {
             const config = provider.getTrackingConfig();
-            await expect(
-                config.onBeforeTracking!({ txHash: TX_HASH, originChainId: ORIGIN_CHAIN_ID }),
-            ).rejects.toThrow();
+            const preTrackerConfig = config.preTrackerConfig;
+            const orderId = "0xorder123" as `0x${string}`;
+            const body = preTrackerConfig.buildBody({
+                txHash: TX_HASH,
+                originChainId: ORIGIN_CHAIN_ID,
+                orderId,
+            });
+            expect(body).toEqual({
+                chainId: String(ORIGIN_CHAIN_ID),
+                txHash: TX_HASH,
+                requestId: orderId,
+            });
         });
     });
 

--- a/packages/cross-chain/test/services/APIPreTracker.spec.ts
+++ b/packages/cross-chain/test/services/APIPreTracker.spec.ts
@@ -74,7 +74,7 @@ describe("APIPreTracker", () => {
             expect(axios.post).toHaveBeenCalledWith(
                 `${BASE_URL}${INDEX_ENDPOINT}`,
                 { chainId: String(ORIGIN_CHAIN_ID), txHash: TX_HASH },
-                { headers: undefined },
+                { headers: undefined, timeout: 15000 },
             );
         });
 
@@ -86,7 +86,7 @@ describe("APIPreTracker", () => {
             expect(axios.post).toHaveBeenCalledWith(
                 `${BASE_URL}${INDEX_ENDPOINT}`,
                 { chainId: String(ORIGIN_CHAIN_ID), txHash: TX_HASH, requestId: ORDER_ID },
-                { headers: undefined },
+                { headers: undefined, timeout: 15000 },
             );
         });
 
@@ -99,6 +99,19 @@ describe("APIPreTracker", () => {
 
             expect(axios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), {
                 headers,
+                timeout: 15000,
+            });
+        });
+
+        it("uses custom timeoutMs when configured", async () => {
+            preTracker = new APIPreTracker(makeConfig({ timeoutMs: 3000 }));
+            vi.mocked(axios.post).mockResolvedValueOnce({ status: 200, data: {} });
+
+            await preTracker.execute(makeParams());
+
+            expect(axios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), {
+                headers: undefined,
+                timeout: 3000,
             });
         });
 

--- a/packages/cross-chain/test/services/APIPreTracker.spec.ts
+++ b/packages/cross-chain/test/services/APIPreTracker.spec.ts
@@ -1,0 +1,143 @@
+import type { Hex } from "viem";
+import axios, { AxiosError } from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PreTrackerParams } from "../../src/core/interfaces/preTracker.interface.js";
+import type { APIPreTrackerConfig } from "../../src/core/services/APIPreTracker.js";
+import { APIPreTracker, APIRequestFailure } from "../../src/internal.js";
+
+vi.mock("axios");
+
+// ── Constants ────────────────────────────────────────────
+
+const BASE_URL = "https://api.relay.link";
+const INDEX_ENDPOINT = "/transactions/index";
+const PROTOCOL_NAME = "relay";
+const TX_HASH = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" as Hex;
+const ORIGIN_CHAIN_ID = 1;
+const ORDER_ID = "0xorder456" as Hex;
+
+// ── Helpers ──────────────────────────────────────────────
+
+function makeAxiosError(status: number, data: unknown): AxiosError {
+    const error = new AxiosError("Request failed");
+    error.response = {
+        status,
+        data,
+        statusText: "",
+        headers: {},
+        config: {} as never,
+    };
+    return error;
+}
+
+function makeConfig(overrides?: Partial<APIPreTrackerConfig>): APIPreTrackerConfig {
+    return {
+        type: "api",
+        protocolName: PROTOCOL_NAME,
+        buildUrl: () => `${BASE_URL}${INDEX_ENDPOINT}`,
+        buildBody: (params: PreTrackerParams) => ({
+            chainId: String(params.originChainId),
+            txHash: params.txHash,
+            ...(params.orderId && { requestId: params.orderId }),
+        }),
+        ...overrides,
+    };
+}
+
+function makeParams(overrides?: Partial<PreTrackerParams>): PreTrackerParams {
+    return {
+        txHash: TX_HASH,
+        originChainId: ORIGIN_CHAIN_ID,
+        ...overrides,
+    };
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+describe("APIPreTracker", () => {
+    let preTracker: APIPreTracker;
+    let config: APIPreTrackerConfig;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        config = makeConfig();
+        preTracker = new APIPreTracker(config);
+    });
+
+    describe("execute()", () => {
+        it("sends POST request to the configured URL with body", async () => {
+            vi.mocked(axios.post).mockResolvedValueOnce({ status: 200, data: {} });
+
+            await preTracker.execute(makeParams());
+
+            expect(axios.post).toHaveBeenCalledWith(
+                `${BASE_URL}${INDEX_ENDPOINT}`,
+                { chainId: String(ORIGIN_CHAIN_ID), txHash: TX_HASH },
+                { headers: undefined },
+            );
+        });
+
+        it("includes orderId as requestId when provided", async () => {
+            vi.mocked(axios.post).mockResolvedValueOnce({ status: 200, data: {} });
+
+            await preTracker.execute(makeParams({ orderId: ORDER_ID }));
+
+            expect(axios.post).toHaveBeenCalledWith(
+                `${BASE_URL}${INDEX_ENDPOINT}`,
+                { chainId: String(ORIGIN_CHAIN_ID), txHash: TX_HASH, requestId: ORDER_ID },
+                { headers: undefined },
+            );
+        });
+
+        it("passes custom headers when configured", async () => {
+            const headers = { "x-api-key": "test-key" };
+            preTracker = new APIPreTracker(makeConfig({ headers }));
+            vi.mocked(axios.post).mockResolvedValueOnce({ status: 200, data: {} });
+
+            await preTracker.execute(makeParams());
+
+            expect(axios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), {
+                headers,
+            });
+        });
+
+        it("wraps AxiosError into APIRequestFailure with status and body", async () => {
+            const axiosError = makeAxiosError(500, "Internal Server Error");
+            vi.mocked(axios.post).mockRejectedValueOnce(axiosError);
+            vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+            const error = await preTracker.execute(makeParams()).catch((e: APIRequestFailure) => e);
+
+            expect(error).toBeInstanceOf(APIRequestFailure);
+            expect(error.status).toBe(500);
+            expect(error.body).toBe("Internal Server Error");
+        });
+
+        it("wraps AxiosError with JSON response data into APIRequestFailure", async () => {
+            const axiosError = makeAxiosError(400, { message: "Invalid txHash" });
+            vi.mocked(axios.post).mockRejectedValueOnce(axiosError);
+            vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+            const error = await preTracker.execute(makeParams()).catch((e: APIRequestFailure) => e);
+
+            expect(error).toBeInstanceOf(APIRequestFailure);
+            expect(error.status).toBe(400);
+            expect(error.body).toBe(JSON.stringify({ message: "Invalid txHash" }));
+        });
+
+        it("re-throws non-Axios errors as-is", async () => {
+            const networkError = new Error("DNS resolution failed");
+            vi.mocked(axios.post).mockRejectedValueOnce(networkError);
+            vi.mocked(axios.isAxiosError).mockReturnValue(false);
+
+            await expect(preTracker.execute(makeParams())).rejects.toThrow("DNS resolution failed");
+        });
+
+        it("resolves without error on success", async () => {
+            vi.mocked(axios.post).mockResolvedValueOnce({ status: 200, data: { message: "ok" } });
+
+            await expect(preTracker.execute(makeParams())).resolves.toBeUndefined();
+        });
+    });
+});

--- a/packages/cross-chain/test/services/OrderTracker.spec.ts
+++ b/packages/cross-chain/test/services/OrderTracker.spec.ts
@@ -691,7 +691,7 @@ describe("OrderTracker", () => {
             expect(items.length).toBeGreaterThan(0);
             expect(warnSpy).toHaveBeenCalledWith(
                 "[OrderTracker] pre-tracker failed:",
-                expect.any(Error),
+                "network failure",
             );
             warnSpy.mockRestore();
         });

--- a/packages/cross-chain/test/services/OrderTracker.spec.ts
+++ b/packages/cross-chain/test/services/OrderTracker.spec.ts
@@ -13,6 +13,7 @@ import {
     OrderTrackerYield,
     OrderTrackerYieldType,
     OrderTrackingUpdate,
+    PreTracker,
     WatchOrderParams,
 } from "../../src/internal.js";
 import { createMockFillEvent, createMockOpenedIntent } from "../mocks/orderTracking.js";
@@ -563,14 +564,16 @@ describe("OrderTracker", () => {
         });
     });
 
-    describe("onBeforeTracking hook", () => {
-        it("executes hook before tracking starts via watchOrder", async () => {
-            const onBeforeTracking = vi.fn().mockResolvedValue(undefined);
-            const trackerWithHook = new OrderTracker(
+    describe("preTracker", () => {
+        it("invokes pre-tracker before tracking starts via watchOrder (txHash path)", async () => {
+            const mockPreTracker: PreTracker = {
+                execute: vi.fn().mockResolvedValue(undefined),
+            };
+            const trackerWithPreTracker = new OrderTracker(
                 mockOpenedIntentParser,
                 mockFillWatcher,
                 undefined,
-                onBeforeTracking,
+                mockPreTracker,
             );
 
             const mockOpenedIntent = createMockOpenedIntent({
@@ -589,7 +592,7 @@ describe("OrderTracker", () => {
             vi.mocked(mockFillWatcher.waitForFill).mockResolvedValue(mockFillEventData);
 
             const items: OrderTrackerYield[] = [];
-            for await (const item of trackerWithHook.watchOrder({
+            for await (const item of trackerWithPreTracker.watchOrder({
                 txHash: mockTxHash,
                 originChainId: mockOriginChainId,
                 destinationChainId: mockDestinationChainId,
@@ -598,21 +601,65 @@ describe("OrderTracker", () => {
                 items.push(item);
             }
 
-            expect(onBeforeTracking).toHaveBeenCalledWith({
+            expect(mockPreTracker.execute).toHaveBeenCalledWith({
                 txHash: mockTxHash,
                 originChainId: mockOriginChainId,
+                orderId: undefined,
             });
             expect(items.length).toBeGreaterThan(0);
         });
 
-        it("continues tracking and warns if hook fails", async () => {
-            const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-            const onBeforeTracking = vi.fn().mockRejectedValue(new Error("network failure"));
-            const trackerWithHook = new OrderTracker(
+        it("invokes pre-tracker with orderId on the orderId path", async () => {
+            const mockPreTracker: PreTracker = {
+                execute: vi.fn().mockResolvedValue(undefined),
+            };
+            const trackerWithPreTracker = new OrderTracker(
                 mockOpenedIntentParser,
                 mockFillWatcher,
                 undefined,
-                onBeforeTracking,
+                mockPreTracker,
+            );
+
+            const mockOrderId =
+                "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" as Hex;
+            const mockOpenTxHash =
+                "0xaaaa567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" as Hex;
+            const mockFillEventData = createMockFillEvent();
+
+            vi.mocked(mockFillWatcher.getFill).mockResolvedValue({
+                fillEvent: mockFillEventData,
+                status: OrderStatus.Finalized,
+            });
+
+            const items: OrderTrackerYield[] = [];
+            for await (const item of trackerWithPreTracker.watchOrder({
+                orderId: mockOrderId,
+                originChainId: mockOriginChainId,
+                destinationChainId: mockDestinationChainId,
+                openTxHash: mockOpenTxHash,
+                timeout: 10000,
+            })) {
+                items.push(item);
+            }
+
+            expect(mockPreTracker.execute).toHaveBeenCalledWith({
+                txHash: mockOpenTxHash,
+                originChainId: mockOriginChainId,
+                orderId: mockOrderId,
+            });
+            expect(items.length).toBeGreaterThan(0);
+        });
+
+        it("continues tracking and warns if pre-tracker fails", async () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+            const mockPreTracker: PreTracker = {
+                execute: vi.fn().mockRejectedValue(new Error("network failure")),
+            };
+            const trackerWithPreTracker = new OrderTracker(
+                mockOpenedIntentParser,
+                mockFillWatcher,
+                undefined,
+                mockPreTracker,
             );
 
             const mockOpenedIntent = createMockOpenedIntent({
@@ -631,7 +678,7 @@ describe("OrderTracker", () => {
             vi.mocked(mockFillWatcher.waitForFill).mockResolvedValue(mockFillEventData);
 
             const items: OrderTrackerYield[] = [];
-            for await (const item of trackerWithHook.watchOrder({
+            for await (const item of trackerWithPreTracker.watchOrder({
                 txHash: mockTxHash,
                 originChainId: mockOriginChainId,
                 destinationChainId: mockDestinationChainId,
@@ -640,10 +687,10 @@ describe("OrderTracker", () => {
                 items.push(item);
             }
 
-            expect(onBeforeTracking).toHaveBeenCalled();
+            expect(mockPreTracker.execute).toHaveBeenCalled();
             expect(items.length).toBeGreaterThan(0);
             expect(warnSpy).toHaveBeenCalledWith(
-                "[OrderTracker] onBeforeTracking failed:",
+                "[OrderTracker] pre-tracker failed:",
                 expect.any(Error),
             );
             warnSpy.mockRestore();

--- a/packages/cross-chain/test/services/orderTrackerFactory.spec.ts
+++ b/packages/cross-chain/test/services/orderTrackerFactory.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AcrossProvider, OrderTracker, OrderTrackerFactory } from "../../src/external.js";
-import { FillWatcher, OpenedIntentParser } from "../../src/internal.js";
+import { FillWatcher, OpenedIntentParser, PreTracker } from "../../src/internal.js";
 
 const MOCK_API_URL = "https://mocked.across.url/api";
 const MOCK_PROVIDER_ID = "across";
@@ -77,6 +77,18 @@ describe("OrderTrackerFactory", () => {
 
             const tracker = factory.createTracker(provider, {
                 fillWatcher: mockFillWatcher,
+            });
+
+            expect(tracker).toBeInstanceOf(OrderTracker);
+        });
+
+        it("accepts custom preTracker", () => {
+            const mockPreTracker: PreTracker = {
+                execute: vi.fn(),
+            };
+
+            const tracker = factory.createTracker(provider, {
+                preTracker: mockPreTracker,
             });
 
             expect(tracker).toBeInstanceOf(OrderTracker);


### PR DESCRIPTION
## Summary

Replace the `onBeforeTracking` callback with a `PreTracker` interface and factory pattern, so providers declare pre-tracking behavior via config instead of passing closures.

### Class diagram

```mermaid
classDiagram
    class PreTracker {
        <<interface>>
        +execute(params: PreTrackerParams) Promise~void~
    }

    class APIPreTracker {
        -config: APIPreTrackerConfig
        +execute(params: PreTrackerParams) Promise~void~
    }

    class PreTrackerFactory {
        +create(config: PreTrackerConfig) PreTracker
    }

    class OrderTrackerFactory {
        -preTrackerFactory: PreTrackerFactory
        +createTracker(provider, config?) OrderTracker
    }

    class OrderTracker {
        -preTracker?: PreTracker
        +watchOrder(params) AsyncGenerator
        -invokePreTracker(params) Promise~void~
    }

    class CrossChainProvider {
        <<abstract>>
        +getTrackingConfig()
    }

    PreTracker <|.. APIPreTracker : implements
    PreTrackerFactory --> APIPreTracker : creates
    OrderTrackerFactory --> PreTrackerFactory : uses
    OrderTrackerFactory --> OrderTracker : creates
    OrderTracker --> PreTracker : invokes
    CrossChainProvider --> OrderTrackerFactory : config
```

### Flow

```
Provider.getTrackingConfig()
    └─▶ preTrackerConfig: { type: "api", buildUrl, buildBody, ... }

OrderTrackerFactory.createTracker()
    └─▶ PreTrackerFactory.create(config)  →  APIPreTracker

OrderTracker.watchOrder(params)
    └─▶ invokePreTracker(params)  →  best-effort, warns on failure
    └─▶ watchOrderByTxHash() / watchOrderByOrderId()
```

### Other

- `WatchOrderByOrderId` gains optional `openTxHash` for the pre-tracker
- Removed `OnBeforeTracking` type and `tracking.ts`

## Tests

- `APIPreTracker` — POST, headers, error wrapping, passthrough
- `OrderTracker` — pre-tracker on both paths, continues on failure
- `OrderTrackerFactory` — custom `preTracker` override
- Relay provider — config shape, builders, `requestId` mapping