### PR TITLE
fix(ui): disable mode toggle during transaction execution

### DIFF
--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -218,6 +218,7 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
         <div className='flex border border-border/50 rounded-xl'>
           <button
             type='button'
+            disabled={isDisabled}
             onClick={() => {
               setMode('getQuotes');
               onInputChange?.();
@@ -226,12 +227,13 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
               mode === 'getQuotes'
                 ? 'bg-accent text-white'
                 : 'bg-background/50 text-text-secondary hover:text-text-primary'
-            }`}
+            } ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
           >
             Get Quotes
           </button>
           <button
             type='button'
+            disabled={isDisabled}
             onClick={() => {
               setMode('buildQuote');
               onInputChange?.();
@@ -240,7 +242,7 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
               mode === 'buildQuote'
                 ? 'bg-accent text-white'
                 : 'bg-background/50 text-text-secondary hover:text-text-primary'
-            }`}
+            } ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
           >
             Build Quote
           </button>


### PR DESCRIPTION
The Get Quotes / Build Quote toggle buttons in SwapForm weren't disabled during transaction execution. Clicking them mid-tx reset the form state but left all inputs disabled, breaking the UI.

Adds `disabled={isDisabled}` to both buttons, matching every other input in the form.