### PR TITLE
refactor(addresses): accept string chain references in chainIdentifier utils

### DIFF
--- a/.changeset/chain-identifier-string-refs.md
+++ b/.changeset/chain-identifier-string-refs.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-addresses": minor
+---
+
+Widen `toChainIdentifier` and `fromChainIdentifier` to accept string chain references, enabling non-EVM chains like bip122 and starknet.

--- a/packages/addresses/src/address/chainIdentifier.ts
+++ b/packages/addresses/src/address/chainIdentifier.ts
@@ -2,16 +2,16 @@ import type { ChainIdentifier, ChainIdentifierParts } from "../internal.js";
 import { ChainTypeName, InvalidChainIdentifier } from "../internal.js";
 
 /**
- * Converts a numeric chain reference to a CAIP-350 chain identifier (e.g. `"eip155:1"`).
+ * Converts a chain reference to a CAIP-350 chain identifier (e.g. `"eip155:1"`, `"bip122:000000000019d6689c085ae165831e93"`).
  *
  * @see https://standards.chainagnostic.org/CAIPs/caip-350#chain-identifier-text-representation
  *
- * @param chainReference - Numeric chain reference (e.g. 1, 42161)
+ * @param chainReference - Chain reference (e.g. 1, "42161", "000000000019d6689c085ae165831e93")
  * @param chainType - Chain type namespace (default: "eip155" for EVM chains)
  * @returns CAIP-350 chain identifier (e.g. "eip155:1")
  */
 export function toChainIdentifier(
-    chainReference: number,
+    chainReference: string | number,
     chainType: ChainTypeName = ChainTypeName.EIP155,
 ): ChainIdentifier {
     return `${chainType}:${chainReference}`;
@@ -24,10 +24,10 @@ export function toChainIdentifier(
  *
  * @see https://standards.chainagnostic.org/CAIPs/caip-350#chain-identifier-text-representation
  *
- * @param chainIdentifier - CAIP-350 chain identifier (e.g. "eip155:1", "eip155:42161")
- * @returns An object containing the `chainReference` (number) and `chainType` ({@link ChainTypeName})
- * @throws {InvalidChainIdentifier} If the identifier is not in valid `namespace:reference` format,
- *   the namespace is not a known {@link ChainTypeName}, or the reference is not a valid non-negative integer
+ * @param chainIdentifier - CAIP-350 chain identifier (e.g. "eip155:1", "bip122:000000000019d6689c085ae165831e93")
+ * @returns An object containing the `chainReference` (string) and `chainType` ({@link ChainTypeName})
+ * @throws {InvalidChainIdentifier} If the identifier is not in valid `namespace:reference` format
+ *   or the namespace is not a known {@link ChainTypeName}
  */
 export function fromChainIdentifier(chainIdentifier: string): ChainIdentifierParts {
     const sepIndex = chainIdentifier.indexOf(":");
@@ -40,12 +40,7 @@ export function fromChainIdentifier(chainIdentifier: string): ChainIdentifierPar
         throw new InvalidChainIdentifier(chainIdentifier);
     }
 
-    const reference = chainIdentifier.slice(sepIndex + 1);
-    const chainReference = Number(reference);
-
-    if (!Number.isInteger(chainReference) || chainReference < 0) {
-        throw new InvalidChainIdentifier(chainIdentifier);
-    }
+    const chainReference = chainIdentifier.slice(sepIndex + 1);
 
     return { chainReference, chainType: namespace as ChainTypeName };
 }

--- a/packages/addresses/src/types/interopAddress.ts
+++ b/packages/addresses/src/types/interopAddress.ts
@@ -89,7 +89,7 @@ export type InteroperableName = `${string}@${string}:${string}#${Checksum}`;
  *
  * @see https://standards.chainagnostic.org/CAIPs/caip-350#chain-identifier-text-representation
  */
-export type ChainIdentifier = `${ChainTypeName}:${number}`;
+export type ChainIdentifier = `${ChainTypeName}:${string}`;
 
 /**
  * Parsed components of a CAIP-350 chain identifier.
@@ -97,8 +97,8 @@ export type ChainIdentifier = `${ChainTypeName}:${number}`;
  * @see https://standards.chainagnostic.org/CAIPs/caip-350#chain-identifier-text-representation
  */
 export interface ChainIdentifierParts {
-    /** Numeric chain reference (e.g. 1, 42161) */
-    chainReference: number;
+    /** Chain reference (e.g. "1", "42161", "000000000019d6689c085ae165831e93") */
+    chainReference: string;
     /** Chain type namespace (e.g. "eip155", "solana") */
     chainType: ChainTypeName;
 }

--- a/packages/addresses/test/address/toChainIdentifier.spec.ts
+++ b/packages/addresses/test/address/toChainIdentifier.spec.ts
@@ -12,6 +12,10 @@ describe("toChainIdentifier", () => {
         expect(toChainIdentifier(11155111)).toBe("eip155:11155111");
     });
 
+    it("should accept string chain references", () => {
+        expect(toChainIdentifier("42161")).toBe("eip155:42161");
+    });
+
     it("should use custom chain type when provided", () => {
         expect(toChainIdentifier(1, ChainTypeName.SOLANA)).toBe("solana:1");
     });
@@ -19,41 +23,65 @@ describe("toChainIdentifier", () => {
     it("should use eip155 as default chain type", () => {
         expect(toChainIdentifier(137)).toBe(toChainIdentifier(137, ChainTypeName.EIP155));
     });
+
+    it("should handle bip122 genesis hash references", () => {
+        expect(toChainIdentifier("000000000019d6689c085ae165831e93", ChainTypeName.BIP122)).toBe(
+            "bip122:000000000019d6689c085ae165831e93",
+        );
+    });
+
+    it("should handle starknet references", () => {
+        expect(toChainIdentifier("SN_MAIN", ChainTypeName.STARKNET)).toBe("starknet:SN_MAIN");
+    });
 });
 
 describe("fromChainIdentifier", () => {
     it("should parse eip155 Ethereum mainnet identifier", () => {
         expect(fromChainIdentifier("eip155:1")).toEqual({
-            chainReference: 1,
+            chainReference: "1",
             chainType: ChainTypeName.EIP155,
         });
     });
 
     it("should parse eip155 Arbitrum identifier", () => {
         expect(fromChainIdentifier("eip155:42161")).toEqual({
-            chainReference: 42161,
+            chainReference: "42161",
             chainType: ChainTypeName.EIP155,
         });
     });
 
     it("should parse Sepolia identifier", () => {
         expect(fromChainIdentifier("eip155:11155111")).toEqual({
-            chainReference: 11155111,
+            chainReference: "11155111",
             chainType: ChainTypeName.EIP155,
         });
     });
 
     it("should parse solana identifier", () => {
         expect(fromChainIdentifier("solana:101")).toEqual({
-            chainReference: 101,
+            chainReference: "101",
             chainType: ChainTypeName.SOLANA,
+        });
+    });
+
+    it("should parse bip122 identifier with genesis hash", () => {
+        expect(fromChainIdentifier("bip122:000000000019d6689c085ae165831e93")).toEqual({
+            chainReference: "000000000019d6689c085ae165831e93",
+            chainType: ChainTypeName.BIP122,
+        });
+    });
+
+    it("should parse starknet identifier", () => {
+        expect(fromChainIdentifier("starknet:SN_MAIN")).toEqual({
+            chainReference: "SN_MAIN",
+            chainType: ChainTypeName.STARKNET,
         });
     });
 
     it("should be the inverse of toChainIdentifier", () => {
         for (const chainId of [1, 137, 42161, 11155111]) {
             const { chainReference, chainType } = fromChainIdentifier(toChainIdentifier(chainId));
-            expect(chainReference).toBe(chainId);
+            expect(chainReference).toBe(String(chainId));
             expect(chainType).toBe(ChainTypeName.EIP155);
         }
     });
@@ -62,8 +90,17 @@ describe("fromChainIdentifier", () => {
         const { chainReference, chainType } = fromChainIdentifier(
             toChainIdentifier(101, ChainTypeName.SOLANA),
         );
-        expect(chainReference).toBe(101);
+        expect(chainReference).toBe("101");
         expect(chainType).toBe(ChainTypeName.SOLANA);
+    });
+
+    it("should round-trip with toChainIdentifier for bip122", () => {
+        const ref = "000000000019d6689c085ae165831e93";
+        const { chainReference, chainType } = fromChainIdentifier(
+            toChainIdentifier(ref, ChainTypeName.BIP122),
+        );
+        expect(chainReference).toBe(ref);
+        expect(chainType).toBe(ChainTypeName.BIP122);
     });
 
     it("should throw InvalidChainIdentifier for unknown namespace", () => {
@@ -80,17 +117,5 @@ describe("fromChainIdentifier", () => {
 
     it("should throw InvalidChainIdentifier for empty reference", () => {
         expect(() => fromChainIdentifier("eip155:")).toThrow(InvalidChainIdentifier);
-    });
-
-    it("should throw InvalidChainIdentifier for non-numeric reference", () => {
-        expect(() => fromChainIdentifier("eip155:abc")).toThrow(InvalidChainIdentifier);
-    });
-
-    it("should throw InvalidChainIdentifier for negative reference", () => {
-        expect(() => fromChainIdentifier("eip155:-1")).toThrow(InvalidChainIdentifier);
-    });
-
-    it("should throw InvalidChainIdentifier for floating-point reference", () => {
-        expect(() => fromChainIdentifier("eip155:1.5")).toThrow(InvalidChainIdentifier);
     });
 });


### PR DESCRIPTION
ChainIdentifier types and utilities only accepted numeric chain references (eip155). This widens them to accept strings so non-EVM chains like bip122 (Bitcoin genesis hash refs) and starknet (SN_MAIN) work.

- `toChainIdentifier` accepts `string | number` for chainReference
- `fromChainIdentifier` returns `chainReference` as string, stops rejecting non-numeric references
- `ChainIdentifier` type widened from `${ChainTypeName}:${number}` to `${ChainTypeName}:${string}`
- `ChainIdentifierParts.chainReference` changed from `number` to `string`

Backwards compatible for inputs. Consumers reading `chainReference` as `number` need to update to `string`.

Pairs with #211 which changes `getRegisteredChains` to return CAIP-2 strings.

## Test plan

Full addresses test suite (242 tests) passing. Added bip122 and starknet round-trip tests.