### PR TITLE
fix: remove defunct cloudflare RPC fallback & show decimal chain ref

### DIFF
--- a/.changeset/fix-cloudflare-rpc.md
+++ b/.changeset/fix-cloudflare-rpc.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-addresses": patch
+---
+
+Remove defunct cloudflare-eth.com RPC fallback in resolveChainFromRegistry, letting viem use its default public RPC endpoint instead

--- a/examples/ui/app/components/BinaryFormatDisplay.tsx
+++ b/examples/ui/app/components/BinaryFormatDisplay.tsx
@@ -33,8 +33,12 @@ const fields: FieldConfig<BinaryPartKey, AddressResult>[] = [
     key: BinaryPartKey.CHAIN_REF,
     label: 'Chain Reference',
     getValue: (r) => r.chainRefHex || null,
-    getDisplayValue: (r) => r.chainRefHex || <span className='text-text-tertiary italic'>(empty)</span>,
-    description: 'Chain ID (e.g., 0x01 = mainnet)',
+    getDisplayValue: (r) => {
+      if (!r.chainRefHex) return <span className='text-text-tertiary italic'>(empty)</span>;
+      const decimal = parseInt(r.chainRefHex, 16);
+      return Number.isNaN(decimal) ? r.chainRefHex : `${r.chainRefHex} (${decimal})`;
+    },
+    description: 'Chain ID in hex and decimal (e.g., 0x01 = 1 = mainnet)',
   },
   {
     key: BinaryPartKey.ADDRESS_LENGTH,

--- a/packages/addresses/src/name/resolveChainFromRegistry.ts
+++ b/packages/addresses/src/name/resolveChainFromRegistry.ts
@@ -7,9 +7,6 @@ import { ChainTypeName } from "../constants/interopAddress.js";
 /** Default onchain ENS registry domain for chain resolution. */
 export const DEFAULT_REGISTRY_DOMAIN = "on.eth";
 
-// Default public Ethereum mainnet RPC endpoint
-const DEFAULT_MAINNET_RPC_URL = "https://cloudflare-eth.com";
-
 // Standard ENS registry address (same on all networks)
 const ENS_REGISTRY_ADDRESS: Address = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
 
@@ -38,8 +35,8 @@ export function clearRegistryCache(): void {
     resolutionCache.clear();
 }
 
-function getRpcUrl(rpcUrl?: string): string {
-    return rpcUrl?.trim() || process.env.MAINNET_RPC_URL?.trim() || DEFAULT_MAINNET_RPC_URL;
+function getRpcUrl(rpcUrl?: string): string | undefined {
+    return rpcUrl?.trim() || process.env.MAINNET_RPC_URL?.trim() || undefined;
 }
 
 async function getResolverAddress(


### PR DESCRIPTION
## Summary
- **fix(addresses):** Remove defunct `cloudflare-eth.com` RPC fallback in `resolveChainFromRegistry`. The endpoint returns error `-32046` ("Cannot fulfill request"), causing onchain chain resolution (e.g. `vitalik.eth@ethereum`) to silently fail. Now defers to viem's default public RPC (`eth.merkle.io`), consistent with `getRegisteredChains` and `resolveENS`.
- **feat(ui):** Show decimal representation alongside hex for chain references in the binary format display (e.g. `01 (1)` instead of just `01`).

## Test plan
- [x] `resolveChainFromRegistry` tests pass (15/15)
- [ ] Verify `vitalik.eth@ethereum` resolves correctly without `MAINNET_RPC_URL` set
- [ ] Verify binary display shows decimal chain reference values