### PR TITLE
feat(ui): improve build quote UX - fee display, error mapping, timeout notice

### DIFF
--- a/examples/ui/app/cross-chain/components/OrderTracking/ErrorView.tsx
+++ b/examples/ui/app/cross-chain/components/OrderTracking/ErrorView.tsx
@@ -15,12 +15,27 @@ function getMessage(state: ErrorViewProps['state']): string {
   return state.message;
 }
 
+function getTimeoutNotice(state: ErrorViewProps['state'], chainName: string | undefined): string | null {
+  if (state.step !== STEP.TIMEOUT) return null;
+  const lastStatus = state.update?.status;
+  const chain = chainName ?? 'the origin chain';
+
+  // If the order was already settled/executed, it likely completed - just tracking lost it
+  if (lastStatus === 'settled' || lastStatus === 'executed' || lastStatus === 'settling') {
+    return 'The order may have completed after tracking stopped. Check the origin transaction for details.';
+  }
+
+  // If still pending/created, it probably expired unfilled
+  return `If the order expired unfilled, your tokens will be refunded automatically to your wallet on ${chain}. This usually takes 1-3 hours.`;
+}
+
 export function ErrorView({ state, onReset }: ErrorViewProps) {
   const chainConfig = useChainConfig();
   const originChainId = 'originChainId' in state ? state.originChainId : undefined;
   const originChain = chainConfig.getChain(originChainId);
   const originTxUrl = chainConfig.getExplorerTxUrl(originChainId, state.txHash);
   const isTimeout = state.step === STEP.TIMEOUT;
+  const timeoutNotice = getTimeoutNotice(state, originChain?.name);
   const borderColor = isTimeout ? 'border-warning/30' : 'border-error/30';
   const bgColor = isTimeout ? 'bg-warning/5' : 'bg-error/5';
   const iconBg = isTimeout ? 'bg-warning' : 'bg-error';
@@ -44,6 +59,13 @@ export function ErrorView({ state, onReset }: ErrorViewProps) {
           <p className='text-sm text-text-secondary'>{formatMessageWithDate(getMessage(state))}</p>
         </div>
       </div>
+
+      {/* Context notice for timeouts */}
+      {timeoutNotice && (
+        <div className='p-3 rounded-lg bg-warning/10 border border-warning/20 mb-4'>
+          <p className='text-sm text-warning'>{timeoutNotice}</p>
+        </div>
+      )}
 
       {/* Transaction link if available */}
       {state.txHash && originTxUrl && (

--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -8,7 +8,7 @@ import { MINT_AMOUNT, useMintToken } from '../hooks/useMintToken';
 import { useChainConfig, useTokenConfig } from '../hooks/useNetworkConfig';
 import { useRouteSelection } from '../hooks/useRouteSelection';
 import { useBalanceStore, type TokenBalance } from '../stores/balanceStore';
-import { isValidAmount, sanitizeAmountInput } from '../utils/amountValidation';
+import { formatFee, isValidAmount, sanitizeAmountInput } from '../utils/amountValidation';
 import { TokenSelect } from './TokenSelect';
 import { WalletConnect } from './WalletConnect';
 
@@ -95,6 +95,15 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
   }, [inputAmount, inputTokenInfo?.decimals, amountIsValid]);
 
   const hasInsufficientBalance = Boolean(tokenBalance && inputAmount && parsedInputAmount > tokenBalance.raw);
+
+  const outputTokenInfo = outputTokenAddress ? tokenConfig.TOKEN_INFO[outputChainId]?.[outputTokenAddress] : null;
+  const isSameToken = Boolean(inputTokenInfo && outputTokenInfo && inputTokenInfo.symbol === outputTokenInfo.symbol);
+
+  const feeDisplay = useMemo(() => {
+    if (mode !== 'buildQuote' || !isSameToken) return null;
+    if (!isValidAmount(inputAmount) || !isValidAmount(outputAmount)) return null;
+    return formatFee(inputAmount, outputAmount);
+  }, [mode, inputAmount, outputAmount, isSameToken]);
 
   const handleMaxClick = () => {
     if (!tokenBalance) return;
@@ -383,7 +392,15 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
                 disabled={isDisabled}
                 className={`w-full px-4 py-3 bg-background/50 border border-border/50 rounded-xl font-mono text-sm focus:border-accent focus:ring-2 focus:ring-accent/20 ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
               />
-              <p className='text-xs text-text-tertiary mt-1'>Difference is the relayer fee</p>
+              {feeDisplay ? (
+                <p data-testid='fee-display' className='text-xs text-accent mt-1'>
+                  {feeDisplay}
+                </p>
+              ) : (
+                <p data-testid='fee-hint' className='text-xs text-text-tertiary mt-1'>
+                  Difference is the fee
+                </p>
+              )}
             </div>
           )}
         </div>

--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -8,7 +8,7 @@ import { MINT_AMOUNT, useMintToken } from '../hooks/useMintToken';
 import { useChainConfig, useTokenConfig } from '../hooks/useNetworkConfig';
 import { useRouteSelection } from '../hooks/useRouteSelection';
 import { useBalanceStore, type TokenBalance } from '../stores/balanceStore';
-import { formatFee, isValidAmount, sanitizeAmountInput } from '../utils/amountValidation';
+import { formatFee, isValidAmount, normalizeAmount, sanitizeAmountInput } from '../utils/amountValidation';
 import { TokenSelect } from './TokenSelect';
 import { WalletConnect } from './WalletConnect';
 
@@ -103,6 +103,12 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
     if (mode !== 'buildQuote' || !isSameToken) return null;
     if (!isValidAmount(inputAmount) || !isValidAmount(outputAmount)) return null;
     return formatFee(inputAmount, outputAmount);
+  }, [mode, inputAmount, outputAmount, isSameToken]);
+
+  const noFeeWarning = useMemo(() => {
+    if (mode !== 'buildQuote' || !isSameToken) return false;
+    if (!isValidAmount(inputAmount) || !isValidAmount(outputAmount)) return false;
+    return parseFloat(normalizeAmount(outputAmount)) >= parseFloat(normalizeAmount(inputAmount));
   }, [mode, inputAmount, outputAmount, isSameToken]);
 
   const handleMaxClick = () => {
@@ -392,11 +398,17 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
                 disabled={isDisabled}
                 className={`w-full px-4 py-3 bg-background/50 border border-border/50 rounded-xl font-mono text-sm focus:border-accent focus:ring-2 focus:ring-accent/20 ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
               />
-              {feeDisplay ? (
+              {noFeeWarning && (
+                <p data-testid='fee-warning' className='text-xs text-error mt-1'>
+                  Output must be less than input to cover the solver fee
+                </p>
+              )}
+              {!noFeeWarning && feeDisplay && (
                 <p data-testid='fee-display' className='text-xs text-accent mt-1'>
                   {feeDisplay}
                 </p>
-              ) : (
+              )}
+              {!noFeeWarning && !feeDisplay && (
                 <p data-testid='fee-hint' className='text-xs text-text-tertiary mt-1'>
                   Difference is the fee
                 </p>

--- a/examples/ui/app/cross-chain/utils/amountValidation.spec.ts
+++ b/examples/ui/app/cross-chain/utils/amountValidation.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isValidAmount, sanitizeAmountInput } from './amountValidation';
+import { isValidAmount, sanitizeAmountInput, formatFee } from './amountValidation';
 
 describe('sanitizeAmountInput', () => {
   it('allows digits and dot', () => {
@@ -35,5 +35,30 @@ describe('isValidAmount', () => {
     expect(isValidAmount('abc')).toBe(false);
     expect(isValidAmount('-10')).toBe(false);
     expect(isValidAmount('1e10')).toBe(false);
+  });
+});
+
+describe('formatFee', () => {
+  it('returns fee string when output < input', () => {
+    expect(formatFee('0.5', '0.4')).toBe('Fee: 0.1000 (20.00%)');
+    expect(formatFee('100', '99')).toBe('Fee: 1.0000 (1.00%)');
+    expect(formatFee('1', '0.999')).toBe('Fee: 0.0010 (0.10%)');
+  });
+
+  it('returns null when output equals input', () => {
+    expect(formatFee('0.5', '0.5')).toBeNull();
+  });
+
+  it('returns null when output exceeds input', () => {
+    expect(formatFee('0.5', '0.6')).toBeNull();
+  });
+
+  it('returns null for zero input', () => {
+    expect(formatFee('0', '0')).toBeNull();
+  });
+
+  it('returns null for invalid values', () => {
+    expect(formatFee('abc', '0.5')).toBeNull();
+    expect(formatFee('0.5', 'xyz')).toBeNull();
   });
 });

--- a/examples/ui/app/cross-chain/utils/amountValidation.ts
+++ b/examples/ui/app/cross-chain/utils/amountValidation.ts
@@ -26,3 +26,12 @@ export function isValidAmount(value: string): boolean {
   if (!/^\d+\.?\d*$/.test(normalized)) return false;
   return !isNaN(parseFloat(normalized));
 }
+
+/** Formats the fee between two same-token amounts, e.g. "Fee: 0.0030 (0.60%)". Returns null if not applicable. */
+export function formatFee(inputAmount: string, outputAmount: string): string | null {
+  const input = parseFloat(normalizeAmount(inputAmount));
+  const output = parseFloat(normalizeAmount(outputAmount));
+  if (!input || isNaN(output) || output >= input) return null;
+  const fee = input - output;
+  return `Fee: ${fee.toFixed(4)} (${((fee / input) * 100).toFixed(2)}%)`;
+}

--- a/examples/ui/app/cross-chain/utils/errorMessages.spec.ts
+++ b/examples/ui/app/cross-chain/utils/errorMessages.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { parseError } from './errorMessages';
+
+describe('parseError - SDK validation errors', () => {
+  it('maps InsufficientFee to user-friendly message', () => {
+    const err = {
+      name: 'InsufficientFee',
+      message: 'output.amount (1000000) must be less than input.amount (1000000)',
+    };
+    const result = parseError(err);
+    expect(result.title).toBe('No Fee Margin');
+    expect(result.message).toContain('less than input');
+  });
+
+  it('maps ZeroAmount to user-friendly message', () => {
+    const err = { name: 'ZeroAmount', message: 'input.amount must be greater than zero' };
+    const result = parseError(err);
+    expect(result.title).toBe('Invalid Amount');
+    expect(result.message).toContain('zero');
+  });
+
+  it('maps InvalidDeadline (past) to user-friendly message', () => {
+    const err = { name: 'InvalidDeadline', message: 'fillDeadline (1700000000) is in the past (now: 1700000100)' };
+    const result = parseError(err);
+    expect(result.title).toBe('Invalid Deadline');
+  });
+
+  it('maps InvalidDeadline (too soon) to user-friendly message', () => {
+    const err = { name: 'InvalidDeadline', message: 'fillDeadline is too soon: 30s from now, minimum is 60s' };
+    const result = parseError(err);
+    expect(result.title).toBe('Invalid Deadline');
+  });
+});

--- a/examples/ui/app/cross-chain/utils/errorMessages.ts
+++ b/examples/ui/app/cross-chain/utils/errorMessages.ts
@@ -110,13 +110,7 @@ const ERROR_PATTERNS: Array<{ pattern: RegExp; result: ParsedError }> = [
       message: 'Token allowance is insufficient for this transfer.',
     },
   },
-  {
-    pattern: /execution reverted/i,
-    result: {
-      title: 'Transaction Failed',
-      message: 'The transaction would fail. Check your inputs.',
-    },
-  },
+  // SDK validation errors - must come before generic "execution reverted" to avoid shadowing
   {
     pattern: /InsufficientFee|output\.amount.*must be less than input/i,
     result: {
@@ -136,6 +130,13 @@ const ERROR_PATTERNS: Array<{ pattern: RegExp; result: ParsedError }> = [
     result: {
       title: 'Invalid Deadline',
       message: 'Fill deadline must be at least 60 seconds in the future.',
+    },
+  },
+  {
+    pattern: /execution reverted/i,
+    result: {
+      title: 'Transaction Failed',
+      message: 'The transaction would fail. Check your inputs.',
     },
   },
   {
@@ -167,13 +168,23 @@ export function parseError(error: unknown): ParsedError {
   }
 
   // Extract error details
-  const err = error as { code?: number; message?: string; shortMessage?: string };
+  const err = error as { code?: number; name?: string; message?: string; shortMessage?: string };
   const code = err.code;
   const message = err.shortMessage || err.message || String(error);
 
   // Check for known error codes
   if (code && WALLET_ERROR_CODES[code]) {
     return WALLET_ERROR_CODES[code];
+  }
+
+  // Check err.name first so SDK error classes (e.g. InsufficientFee) match
+  // even when the message text doesn't contain the pattern keywords
+  if (err.name) {
+    for (const { pattern, result } of ERROR_PATTERNS) {
+      if (pattern.test(err.name)) {
+        return result;
+      }
+    }
   }
 
   // Check for known patterns in error message

--- a/examples/ui/app/cross-chain/utils/errorMessages.ts
+++ b/examples/ui/app/cross-chain/utils/errorMessages.ts
@@ -118,6 +118,27 @@ const ERROR_PATTERNS: Array<{ pattern: RegExp; result: ParsedError }> = [
     },
   },
   {
+    pattern: /InsufficientFee|output\.amount.*must be less than input/i,
+    result: {
+      title: 'No Fee Margin',
+      message: 'Output amount must be less than input for the solver to earn a fee.',
+    },
+  },
+  {
+    pattern: /ZeroAmount|amount must be greater than zero/i,
+    result: {
+      title: 'Invalid Amount',
+      message: 'Amount cannot be zero.',
+    },
+  },
+  {
+    pattern: /InvalidDeadline|fillDeadline.*in the past|fillDeadline is too soon/i,
+    result: {
+      title: 'Invalid Deadline',
+      message: 'Fill deadline must be at least 60 seconds in the future.',
+    },
+  },
+  {
     pattern: /network.*error|fetch.*failed|connection/i,
     result: {
       title: 'Network Error',

--- a/examples/ui/app/cross-chain/utils/orderTrackingHelpers.ts
+++ b/examples/ui/app/cross-chain/utils/orderTrackingHelpers.ts
@@ -26,7 +26,38 @@ export function isSubmitPhase(state: BridgeState): boolean {
 }
 
 /**
- * Get display label for current state - uses SDK OrderStatus directly when tracking
+ * Map SDK OrderStatus to a human-readable label.
+ * Statuses from oif-specs OrderStatus enum:
+ *   created → pending → executing → executed → settling → settled → finalized
+ *   With failure paths: pending/executing → failed, settled → refunded
+ */
+function humanizeOrderStatus(status: OrderStatus): string {
+  switch (status) {
+    case OrderStatus.Created:
+      return 'Order created';
+    case OrderStatus.Pending:
+      return 'Awaiting solver';
+    case OrderStatus.Executing:
+      return 'Solver executing';
+    case OrderStatus.Executed:
+      return 'Executed';
+    case OrderStatus.Settling:
+      return 'Settling';
+    case OrderStatus.Settled:
+      return 'Settled';
+    case OrderStatus.Finalized:
+      return 'Complete';
+    case OrderStatus.Failed:
+      return 'Failed';
+    case OrderStatus.Refunded:
+      return 'Refunded';
+    default:
+      return formatOrderStatus(status);
+  }
+}
+
+/**
+ * Get display label for current state
  */
 export function getStateLabel(state: BridgeState): string {
   switch (state.step) {
@@ -46,12 +77,11 @@ export function getStateLabel(state: BridgeState): string {
           return 'Confirming';
       }
     case STEP.TRACKING:
-      // Display SDK OrderStatus directly
-      return formatOrderStatus(state.update.status);
+      return humanizeOrderStatus(state.update.status);
     case STEP.DONE:
-      return formatOrderStatus(OrderStatus.Finalized);
+      return 'Complete';
     case STEP.TIMEOUT:
-      return 'Timeout';
+      return 'Timed out';
     case STEP.ERROR:
       return 'Error';
     default:
@@ -83,10 +113,39 @@ export function getProgressMessage(state: BridgeState): string | undefined {
   }
 
   if (state.step === STEP.TRACKING) {
-    return state.update.message;
+    return humanizeTrackingMessage(state.update.status, state.update.message);
   }
 
   return undefined;
+}
+
+/**
+ * Provide a human-readable progress message for each tracking status.
+ * Falls back to the SDK message for unknown states.
+ */
+function humanizeTrackingMessage(status: OrderStatus, sdkMessage?: string): string {
+  switch (status) {
+    case OrderStatus.Created:
+      return 'Order recorded, waiting for validation...';
+    case OrderStatus.Pending:
+      return 'Waiting for a solver to pick up your order...';
+    case OrderStatus.Executing:
+      return 'Solver is submitting transactions...';
+    case OrderStatus.Executed:
+      return 'Transactions submitted, waiting for settlement...';
+    case OrderStatus.Settling:
+      return 'Settlement in progress...';
+    case OrderStatus.Settled:
+      return 'Assets settled, finalizing...';
+    case OrderStatus.Finalized:
+      return 'Order complete.';
+    case OrderStatus.Failed:
+      return sdkMessage ?? 'Order failed.';
+    case OrderStatus.Refunded:
+      return 'Order refunded. Tokens returned to your wallet on the origin chain.';
+    default:
+      return sdkMessage ?? '';
+  }
 }
 
 /**

--- a/examples/ui/tests/cross-chain.spec.ts
+++ b/examples/ui/tests/cross-chain.spec.ts
@@ -236,6 +236,46 @@ test.describe('Address menu', () => {
   });
 });
 
+test.describe('Build quote fee display', () => {
+  test('shows fee percentage for same-token with output < input', async ({ page }) => {
+    await page.getByRole('button', { name: 'Build Quote' }).click();
+
+    await page.getByTestId('input-token-select').click();
+    await page.getByTestId('input-token-select-listbox').getByText('USDC').click();
+    await page.getByTestId('output-token-select').click();
+    await page.getByTestId('output-token-select-listbox').getByText('USDC').click();
+
+    await page.getByLabel('You send').fill('1');
+    await page.getByLabel('You receive').fill('0.99');
+
+    await expect(page.getByTestId('fee-display')).toBeVisible();
+    await expect(page.getByTestId('fee-hint')).not.toBeVisible();
+  });
+
+  test('shows default hint when output equals input', async ({ page }) => {
+    await page.getByRole('button', { name: 'Build Quote' }).click();
+
+    await page.getByTestId('input-token-select').click();
+    await page.getByTestId('input-token-select-listbox').getByText('USDC').click();
+    await page.getByTestId('output-token-select').click();
+    await page.getByTestId('output-token-select-listbox').getByText('USDC').click();
+
+    await page.getByLabel('You send').fill('1');
+    await page.getByLabel('You receive').fill('1');
+
+    await expect(page.getByTestId('fee-hint')).toBeVisible();
+    await expect(page.getByTestId('fee-display')).not.toBeVisible();
+  });
+
+  test('shows default hint before output is filled', async ({ page }) => {
+    await page.getByRole('button', { name: 'Build Quote' }).click();
+
+    await page.getByLabel('You send').fill('1');
+
+    await expect(page.getByTestId('fee-hint')).toBeVisible();
+  });
+});
+
 test.describe('Negative test', () => {
   test.beforeEach(async ({ page }) => {
     await page.evaluate(() => {

--- a/examples/ui/tests/cross-chain.spec.ts
+++ b/examples/ui/tests/cross-chain.spec.ts
@@ -252,7 +252,7 @@ test.describe('Build quote fee display', () => {
     await expect(page.getByTestId('fee-hint')).not.toBeVisible();
   });
 
-  test('shows default hint when output equals input', async ({ page }) => {
+  test('shows warning when output equals input for same token', async ({ page }) => {
     await page.getByRole('button', { name: 'Build Quote' }).click();
 
     await page.getByTestId('input-token-select').click();
@@ -263,7 +263,7 @@ test.describe('Build quote fee display', () => {
     await page.getByLabel('You send').fill('1');
     await page.getByLabel('You receive').fill('1');
 
-    await expect(page.getByTestId('fee-hint')).toBeVisible();
+    await expect(page.getByTestId('fee-warning')).toBeVisible();
     await expect(page.getByTestId('fee-display')).not.toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

Closes EFI-850

- Show fee percentage for same-token build quotes (e.g. "Fee: 0.1000 (20.00%)")
- Map SDK validation errors (`InsufficientFee`, `ZeroAmount`, `InvalidDeadline`) to user-friendly messages in the UI
- Add context notice on tracking timeouts based on last known order status (may have completed vs likely refunded)
- Humanize order tracking status labels (e.g. "Awaiting solver" instead of "Pending")

## Test plan

- [x] 33 unit tests pass (formatFee, errorMessages, routeSelection)
- [x] 16 e2e tests pass (3 new build quote fee display tests)
- [x] Type-check and lint clean