### PR TITLE
feat(cross-chain): validate asset support in buildQuote()

### DIFF
--- a/.changeset/validate-asset-support-buildquote.md
+++ b/.changeset/validate-asset-support-buildquote.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Add asset-support validation to `buildQuote()` — rejects unsupported token routes before calling the provider

--- a/packages/cross-chain/src/core/errors/UnsupportedAsset.exception.ts
+++ b/packages/cross-chain/src/core/errors/UnsupportedAsset.exception.ts
@@ -1,0 +1,15 @@
+/** Thrown when a provider does not support the requested asset route. */
+export class UnsupportedAsset extends Error {
+    constructor(
+        providerId: string,
+        input: { assetAddress: string; chainId: number },
+        output: { assetAddress: string; chainId: number },
+    ) {
+        super(
+            `Provider "${providerId}" does not support the route ` +
+                `${input.assetAddress} (chain ${input.chainId}) -> ` +
+                `${output.assetAddress} (chain ${output.chainId})`,
+        );
+        this.name = "UnsupportedAsset";
+    }
+}

--- a/packages/cross-chain/src/core/errors/index.ts
+++ b/packages/cross-chain/src/core/errors/index.ts
@@ -17,3 +17,4 @@ export * from "./APIRequestFailure.exception.js";
 export * from "./ZeroAmount.exception.js";
 export * from "./InsufficientFee.exception.js";
 export * from "./InvalidDeadline.exception.js";
+export * from "./UnsupportedAsset.exception.js";

--- a/packages/cross-chain/src/core/services/aggregator.ts
+++ b/packages/cross-chain/src/core/services/aggregator.ts
@@ -22,7 +22,10 @@ import { CrossChainProvider } from "../interfaces/crossChainProvider.interface.j
 import { SortingStrategy } from "../interfaces/sortingStrategy.interface.js";
 import { BestOutputStrategy } from "../sorting_strategies/bestOutput.strategy.js";
 import { mergeDiscoveredAssets } from "../utils/toDiscoveredAssets.js";
-import { validateBuildQuoteParams } from "../validators/buildQuoteValidator.js";
+import {
+    validateAssetSupport,
+    validateBuildQuoteParams,
+} from "../validators/buildQuoteValidator.js";
 import { OrderTracker } from "./OrderTracker.js";
 
 interface AggregatorConfig {
@@ -242,6 +245,9 @@ class Aggregator {
 
         const discovered = await this.discoverAssets();
         validateBuildQuoteParams(params, discovered.tokenMetadata);
+
+        const isSupported = await this.supportsRequestedAssets(provider, params);
+        validateAssetSupport(params, providerId, isSupported);
 
         const quote = await provider.buildQuote(params);
         return { ...quote, _providerId: providerId };

--- a/packages/cross-chain/src/core/validators/buildQuoteValidator.ts
+++ b/packages/cross-chain/src/core/validators/buildQuoteValidator.ts
@@ -5,6 +5,7 @@ import type { BuildQuoteRequest } from "../schemas/quoteRequest.js";
 import { InsufficientFee } from "../errors/InsufficientFee.exception.js";
 import { InvalidDeadline } from "../errors/InvalidDeadline.exception.js";
 import { UnsupportedAddress } from "../errors/UnsupportedAddress.exception.js";
+import { UnsupportedAsset } from "../errors/UnsupportedAsset.exception.js";
 import { ZeroAmount } from "../errors/ZeroAmount.exception.js";
 
 /** Minimum seconds between now and fillDeadline. */
@@ -83,6 +84,28 @@ function isSameAsset(
     const outputSymbol = tokenMetadata[outputChainId]?.[outputAddress.toLowerCase()]?.symbol;
 
     return inputSymbol !== undefined && inputSymbol === outputSymbol;
+}
+
+/**
+ * Validates that the provider supports the requested assets.
+ *
+ * Skipped when `allowDangerousParameters` is set on the request.
+ *
+ * @param params - The build quote request to validate
+ * @param providerId - The provider being targeted
+ * @param isSupported - Pre-resolved result from the discovery cache
+ * @throws UnsupportedAsset if the provider does not support the requested asset
+ */
+export function validateAssetSupport(
+    params: BuildQuoteRequest,
+    providerId: string,
+    isSupported: boolean,
+): void {
+    if (params.allowDangerousParameters) return;
+
+    if (!isSupported) {
+        throw new UnsupportedAsset(providerId, params.input, params.output);
+    }
 }
 
 function validateDeadline(fillDeadline: number, nowSeconds: number): void {

--- a/packages/cross-chain/test/services/aggregator.buildQuote.spec.ts
+++ b/packages/cross-chain/test/services/aggregator.buildQuote.spec.ts
@@ -1,0 +1,251 @@
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Quote } from "../../src/core/schemas/quote.js";
+import type { BuildQuoteRequest } from "../../src/core/schemas/quoteRequest.js";
+import { Aggregator, createAggregator } from "../../src/external.js";
+import {
+    AssetDiscoveryFailure,
+    CrossChainProvider,
+    InsufficientFee,
+    InvalidDeadline,
+    ProviderNotFound,
+    UnsupportedAsset,
+    ZeroAmount,
+} from "../../src/internal.js";
+
+const USDC_ETH = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as Address;
+const USDC_OPT = "0x7F5c764cBc14f9669B88837ca1490cCa17c31607" as Address;
+
+const MOCK_QUOTE: Quote = {
+    order: {
+        steps: [
+            {
+                kind: "transaction" as const,
+                chainId: 1,
+                transaction: {
+                    to: "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5",
+                    data: "0xabcdef",
+                },
+            },
+        ],
+    },
+    preview: {
+        inputs: [
+            {
+                chainId: 1,
+                accountAddress: "0x1234567890abcdef1234567890abcdef12345678",
+                assetAddress: USDC_ETH,
+                amount: "1000000",
+            },
+        ],
+        outputs: [
+            {
+                chainId: 10,
+                accountAddress: "0x1234567890abcdef1234567890abcdef12345678",
+                assetAddress: USDC_OPT,
+                amount: "990000",
+            },
+        ],
+    },
+    provider: "test-provider",
+};
+
+function createMockProvider(
+    providerId: string,
+    discoveryConfig: ReturnType<CrossChainProvider["getDiscoveryConfig"]> = null,
+    buildQuoteResult: Quote = MOCK_QUOTE,
+): CrossChainProvider {
+    return {
+        protocolName: providerId,
+        providerId,
+        getProviderId: vi.fn(() => providerId),
+        getProtocolName: vi.fn(() => providerId),
+        getQuotes: vi.fn(() => Promise.resolve([])),
+        buildQuote: vi.fn(() => Promise.resolve(buildQuoteResult)),
+        submitOrder: vi.fn(),
+        submitSignedOrder: vi.fn(),
+        getTrackingConfig: vi.fn(),
+        getDiscoveryConfig: vi.fn(() => discoveryConfig),
+    } as unknown as CrossChainProvider;
+}
+
+function buildParams(overrides?: Partial<BuildQuoteRequest>): BuildQuoteRequest {
+    return {
+        user: "0x1234567890abcdef1234567890abcdef12345678",
+        input: { chainId: 1, assetAddress: USDC_ETH, amount: "1000000" },
+        output: { chainId: 10, assetAddress: USDC_OPT, amount: "990000" },
+        escrowContractAddress: "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5",
+        fillDeadline: Math.floor(Date.now() / 1000) + 3600,
+        ...overrides,
+    };
+}
+
+/** Static discovery config listing both USDC_ETH and USDC_OPT as supported. */
+const FULL_DISCOVERY_CONFIG = {
+    type: "static" as const,
+    config: {
+        networks: [
+            { chainId: 1, assets: [{ address: USDC_ETH, symbol: "USDC", decimals: 6 }] },
+            { chainId: 10, assets: [{ address: USDC_OPT, symbol: "USDC", decimals: 6 }] },
+        ],
+    },
+};
+
+describe("Aggregator - buildQuote", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("returns quote with _providerId appended", async () => {
+        const provider = createMockProvider("across", FULL_DISCOVERY_CONFIG);
+        const aggregator = createAggregator({ providers: [provider] });
+        const params = buildParams();
+
+        const result = await aggregator.buildQuote("across", params);
+
+        expect(result._providerId).toBe("across");
+        expect(result.order).toEqual(MOCK_QUOTE.order);
+        expect(result.preview).toEqual(MOCK_QUOTE.preview);
+        expect(provider.buildQuote).toHaveBeenCalledWith(params);
+    });
+
+    it("throws ProviderNotFound for unknown provider", async () => {
+        const provider = createMockProvider("across", FULL_DISCOVERY_CONFIG);
+        const aggregator = createAggregator({ providers: [provider] });
+
+        await expect(aggregator.buildQuote("unknown", buildParams())).rejects.toThrow(
+            ProviderNotFound,
+        );
+    });
+
+    it("throws UnsupportedAsset when input token not in discovery", async () => {
+        const provider = createMockProvider("across", {
+            type: "static",
+            config: {
+                networks: [
+                    // Only output chain listed, input chain missing
+                    { chainId: 10, assets: [{ address: USDC_OPT, symbol: "USDC", decimals: 6 }] },
+                ],
+            },
+        });
+        const aggregator = createAggregator({ providers: [provider] });
+
+        await expect(aggregator.buildQuote("across", buildParams())).rejects.toThrow(
+            UnsupportedAsset,
+        );
+        expect(provider.buildQuote).not.toHaveBeenCalled();
+    });
+
+    it("throws UnsupportedAsset when output token not in discovery", async () => {
+        const provider = createMockProvider("across", {
+            type: "static",
+            config: {
+                networks: [
+                    // Only input chain listed, output chain missing
+                    { chainId: 1, assets: [{ address: USDC_ETH, symbol: "USDC", decimals: 6 }] },
+                ],
+            },
+        });
+        const aggregator = createAggregator({ providers: [provider] });
+
+        await expect(aggregator.buildQuote("across", buildParams())).rejects.toThrow(
+            UnsupportedAsset,
+        );
+        expect(provider.buildQuote).not.toHaveBeenCalled();
+    });
+
+    it("passes validation when no discoveryFactory provided", async () => {
+        const provider = createMockProvider("across");
+        const aggregator = new Aggregator({ providers: [provider] });
+        const params = buildParams();
+
+        const result = await aggregator.buildQuote("across", params);
+
+        expect(result._providerId).toBe("across");
+        expect(provider.buildQuote).toHaveBeenCalledWith(params);
+    });
+
+    it("passes gracefully when discovery throws AssetDiscoveryFailure", async () => {
+        const provider = createMockProvider("across", FULL_DISCOVERY_CONFIG);
+        const aggregator = createAggregator({ providers: [provider] });
+
+        // Sabotage the discovery cache to throw
+        const cache = (
+            aggregator as unknown as {
+                discoveryCache: Map<
+                    string,
+                    { isAssetSupported: (...args: unknown[]) => Promise<unknown> }
+                >;
+            }
+        ).discoveryCache;
+        const service = cache.get("across")!;
+        vi.spyOn(service, "isAssetSupported").mockRejectedValue(
+            new AssetDiscoveryFailure("boom", "discovery failed"),
+        );
+
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const params = buildParams();
+
+        const result = await aggregator.buildQuote("across", params);
+
+        expect(result._providerId).toBe("across");
+        expect(provider.buildQuote).toHaveBeenCalledWith(params);
+        expect(warnSpy).toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+    });
+
+    it("propagates ZeroAmount from validation", async () => {
+        const provider = createMockProvider("across", FULL_DISCOVERY_CONFIG);
+        const aggregator = createAggregator({ providers: [provider] });
+        const params = buildParams({
+            input: { chainId: 1, assetAddress: USDC_ETH, amount: "0" },
+        });
+
+        await expect(aggregator.buildQuote("across", params)).rejects.toThrow(ZeroAmount);
+        expect(provider.buildQuote).not.toHaveBeenCalled();
+    });
+
+    it("propagates InvalidDeadline for past deadline", async () => {
+        const provider = createMockProvider("across", FULL_DISCOVERY_CONFIG);
+        const aggregator = createAggregator({ providers: [provider] });
+        const params = buildParams({ fillDeadline: Math.floor(Date.now() / 1000) - 100 });
+
+        await expect(aggregator.buildQuote("across", params)).rejects.toThrow(InvalidDeadline);
+        expect(provider.buildQuote).not.toHaveBeenCalled();
+    });
+
+    it("propagates InsufficientFee for same-token output >= input", async () => {
+        const provider = createMockProvider("across", FULL_DISCOVERY_CONFIG);
+        const aggregator = createAggregator({ providers: [provider] });
+        const params = buildParams({
+            input: { chainId: 1, assetAddress: USDC_ETH, amount: "1000000" },
+            output: { chainId: 1, assetAddress: USDC_ETH, amount: "1000000" },
+        });
+
+        await expect(aggregator.buildQuote("across", params)).rejects.toThrow(InsufficientFee);
+        expect(provider.buildQuote).not.toHaveBeenCalled();
+    });
+
+    it("allowDangerousParameters bypasses all validation", async () => {
+        const provider = createMockProvider("across", {
+            type: "static",
+            config: {
+                networks: [], // No assets supported
+            },
+        });
+        const aggregator = createAggregator({ providers: [provider] });
+        const params = buildParams({
+            input: { chainId: 1, assetAddress: USDC_ETH, amount: "0" },
+            output: { chainId: 1, assetAddress: USDC_ETH, amount: "0" },
+            fillDeadline: Math.floor(Date.now() / 1000) - 100,
+            allowDangerousParameters: true,
+        });
+
+        const result = await aggregator.buildQuote("across", params);
+
+        expect(result._providerId).toBe("across");
+        expect(provider.buildQuote).toHaveBeenCalledWith(params);
+    });
+});

--- a/packages/cross-chain/test/validators/buildQuoteValidator.spec.ts
+++ b/packages/cross-chain/test/validators/buildQuoteValidator.spec.ts
@@ -5,9 +5,11 @@ import { describe, expect, it } from "vitest";
 import type { BuildQuoteRequest } from "../../src/core/schemas/quoteRequest.js";
 import { InsufficientFee } from "../../src/core/errors/InsufficientFee.exception.js";
 import { InvalidDeadline } from "../../src/core/errors/InvalidDeadline.exception.js";
+import { UnsupportedAsset } from "../../src/core/errors/UnsupportedAsset.exception.js";
 import { ZeroAmount } from "../../src/core/errors/ZeroAmount.exception.js";
 import {
     MIN_DEADLINE_BUFFER_SECONDS,
+    validateAssetSupport,
     validateBuildQuoteParams,
 } from "../../src/core/validators/buildQuoteValidator.js";
 
@@ -150,6 +152,23 @@ describe("validateBuildQuoteParams", () => {
 
         it("accepts far future deadline", () => {
             expect(() => validate(buildParams({ fillDeadline: NOW + 86400 }))).not.toThrow();
+        });
+    });
+
+    describe("asset support", () => {
+        it("rejects token the provider does not support", () => {
+            const params = buildParams();
+            expect(() => validateAssetSupport(params, "across", false)).toThrow(UnsupportedAsset);
+        });
+
+        it("accepts token the provider supports", () => {
+            const params = buildParams();
+            expect(() => validateAssetSupport(params, "across", true)).not.toThrow();
+        });
+
+        it("skips validation when allowDangerousParameters is set", () => {
+            const params = buildParams({ allowDangerousParameters: true });
+            expect(() => validateAssetSupport(params, "across", false)).not.toThrow();
         });
     });
 


### PR DESCRIPTION
## Summary
- Adds `UnsupportedAsset` error and `validateAssetSupport()` to reject unsupported token routes in `buildQuote()` before calling the provider
- Includes 10 integration tests for the full `buildQuote()` pipeline and 3 unit tests for the validator

## Test plan
- [x] All 686 existing tests pass
- [x] ESLint, Prettier, and `tsc --noEmit` pass

Closes EFI-852