### PR TITLE
fix(ui): disable buildQuote tab until simulation issues are resolved

### DIFF
--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -63,7 +63,8 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
   const [recipient, setRecipient] = useState('');
   const hasAutoFilledRef = useRef(false);
   const [inputAmount, setInputAmount] = useState('');
-  const [mode, setMode] = useState<SwapFormMode>('getQuotes');
+  // TODO: restore setMode when buildQuote tab is re-enabled (EFI-856)
+  const [mode] = useState<SwapFormMode>('getQuotes');
   const [outputAmount, setOutputAmount] = useState('');
   const [fillDeadlineSecs, setFillDeadlineSecs] = useState(DEADLINE_OPTIONS[0].value);
 
@@ -230,6 +231,7 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
       <div className='relative flex flex-col gap-6'>
         <WalletConnect />
 
+        {/* TODO: re-enable once buildQuote simulation issues are resolved (EFI-856)
         <div className='flex border border-border/50 rounded-xl'>
           <button
             type='button'
@@ -262,6 +264,7 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
             Build Quote
           </button>
         </div>
+        */}
 
         <div>
           <label htmlFor='recipient-address' className='text-sm font-medium text-text-secondary mb-2 block'>

--- a/examples/ui/tests/cross-chain.spec.ts
+++ b/examples/ui/tests/cross-chain.spec.ts
@@ -236,7 +236,8 @@ test.describe('Address menu', () => {
   });
 });
 
-test.describe('Build quote fee display', () => {
+// TODO: re-enable when buildQuote tab is restored (EFI-856)
+test.describe.skip('Build quote fee display', () => {
   test('shows fee percentage for same-token with output < input', async ({ page }) => {
     await page.getByRole('button', { name: 'Build Quote' }).click();
 


### PR DESCRIPTION
## Summary
- Comments out the Get Quotes / Build Quote tab switcher so the UI only uses `getQuotes` for now
- buildQuote on mainnet has simulation failures, order errors, and Base RPC 523s (EFI-856)
- All buildQuote-related code stays in place, just not reachable from the UI

Tracked in EFI-856. To re-enable: uncomment the tab bar in `SwapForm.tsx` and restore `setMode`.