### PR TITLE
fix(docs): correct method names, add starknet chainType, update examples

### DIFF
--- a/apps/docs/docs/addresses/api.md
+++ b/apps/docs/docs/addresses/api.md
@@ -495,7 +495,7 @@ type InteroperableAddress =
       }
     | {
           version: number;
-          chainType: "eip155" | "bip122" | "solana"; // Text variant
+          chainType: "eip155" | "bip122" | "solana" | "starknet"; // Text variant
           chainReference?: string;
           address?: string;
       };

--- a/apps/docs/docs/addresses/concepts.md
+++ b/apps/docs/docs/addresses/concepts.md
@@ -87,7 +87,7 @@ graph TD
 
 ## Chain resolution
 
-When a name uses a chain shortname (e.g., `@eth` instead of `@eip155:1`), the SDK resolves it using a two-tier strategy:
+When a name uses a chain shortname (e.g., `@ethereum` instead of `@eip155:1`), the SDK resolves it using a two-tier strategy:
 
 1. **Onchain**: Queries the `on.eth` ENS registry on Ethereum mainnet. The registry maps labels like `ethereum` to their ERC-7930 binary representation.
 2. **Offchain fallback**: Uses the chainid.network registry to map shortnames to chain IDs.
@@ -98,13 +98,13 @@ You can customize resolution behavior per call:
 
 ```typescript
 // Disable onchain, use offchain only
-await parseName("0x...@eth", { onchainRegistry: false });
+await parseName("0x...@ethereum", { onchainRegistry: false });
 
 // Custom registry domain
-await parseName("0x...@eth", { onchainRegistry: "custom.eth" });
+await parseName("0x...@ethereum", { onchainRegistry: "custom.eth" });
 
 // Custom RPC URL for onchain resolution
-await parseName("0x...@eth", { rpcUrl: "https://my-rpc.example.com" });
+await parseName("0x...@ethereum", { rpcUrl: "https://my-rpc.example.com" });
 ```
 
 ## Checksums

--- a/apps/docs/docs/addresses/concepts.md
+++ b/apps/docs/docs/addresses/concepts.md
@@ -97,8 +97,8 @@ Both are enabled by default. Fully-qualified CAIP-2 identifiers (e.g., `eip155:1
 You can customize resolution behavior per call:
 
 ```typescript
-// Disable onchain, use offchain only
-await parseName("0x...@ethereum", { onchainRegistry: false });
+// Disable onchain, use offchain only (chainid.network uses "eth" shortname)
+await parseName("0x...@eth", { onchainRegistry: false });
 
 // Custom registry domain
 await parseName("0x...@ethereum", { onchainRegistry: "custom.eth" });

--- a/apps/docs/docs/cross-chain/concepts.md
+++ b/apps/docs/docs/cross-chain/concepts.md
@@ -47,7 +47,7 @@ sequenceDiagram
     rpc-->>-dev: Transaction Hash
 
     Note over dev,tracker: 3. Track
-    dev->>+tracker: watch(txHash, chains)
+    dev->>+tracker: watchOrder(txHash, chains)
     loop Until Finalized / Failed / Refunded
         tracker->>tracker: Check status
         tracker-->>dev: Status Update

--- a/apps/docs/docs/cross-chain/oif-provider.md
+++ b/apps/docs/docs/cross-chain/oif-provider.md
@@ -112,6 +112,7 @@ const quotes = await oifProvider.getQuotes({
 
 const quote = quotes[0];
 const step = getTransactionSteps(quote.order)[0];
+// walletClient: a viem WalletClient connected to the user's wallet
 await walletClient.sendTransaction({
     to: step.transaction.to,
     data: step.transaction.data,


### PR DESCRIPTION
## Summary

- Fix `watch()` -> `watchOrder()` in cross-chain concepts sequence diagram
- Add `walletClient` comment in OIF provider example snippet
- Add missing `starknet` to `chainType` union in addresses API docs
- Update `@eth` -> `@ethereum` in chain resolution examples (legacy alias)