### PR TITLE
docs: improve docs for agent and developer clarity

### DIFF
--- a/.changeset/export-errors-and-docs.md
+++ b/.changeset/export-errors-and-docs.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-addresses": patch
+---
+
+Export error classes and missing functions (`resolveAddress`, `resolveChain`, `isValidChain`, `isValidChainType`) from the public API

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ lcov.info
 
 # ESLint cache
 .eslintcache
+
+.serie/
+.mcp.json

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Both formats are interchangeable - convert between them as needed for your use c
 import { encodeAddress, InteropAddressProvider } from "@wonderland/interop-addresses";
 
 // Convert between human-readable (interoperable name) and binary addresses
-const interoperableName = "alice.eth@eip155:1#ABCD1234";
+const interoperableName = "alice.eth@eip155:1";
 const binaryAddress = await InteropAddressProvider.nameToBinary(interoperableName);
 // Returns: "0x0001000000010114d8da6bf26964af9d7eed9e03e53415d37aa96045"
 

--- a/apps/docs/docs/addresses.md
+++ b/apps/docs/docs/addresses.md
@@ -2,33 +2,58 @@
 title: Addresses
 ---
 
-The `addresses` package handles interoperable blockchain addresses — a format that encodes a recipient, a chain, and optionally a domain name into a single string (e.g., `vitalik.eth@eip155:1#4CA88C9C`).
+Ethereum is multichain. An address like `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045` doesn't tell you _which_ chain it's on — and sending to the right address on the wrong chain can mean lost funds.
 
-It is a reference implementation of [EIP-7930](https://eips.ethereum.org/EIPS/eip-7930), [ERC-7828](https://eips.ethereum.org/EIPS/eip-7828), and [CAIP-350](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-350.md).
+Interoperable addresses fix this by encoding the **address and the chain together**, so every recipient is unambiguous.
 
-## What it does
+## What it looks like
 
--   Parse and format human-readable interoperable names (ERC-7828)
--   Encode and decode binary interoperable addresses (EIP-7930)
--   Resolve ENS names and chain shortnames automatically
--   Validate checksums and address structure
--   Convert between name, address, and binary formats
+**For people** — [ERC-7828](https://eips.ethereum.org/EIPS/eip-7828) gives you a readable name that includes the chain:
 
-## Architecture
+```
+vitalik.eth@ethereum
+0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:10#1A2B3C4D
+```
 
-The package follows a two-layer design:
+These names support ENS, chain shortnames (like `ethereum` or `base`), and checksums to catch errors.
 
-1. **Address Layer** — synchronous encoding/decoding of structured address objects (binary or text representation)
-2. **Name Layer** — async operations that involve ENS resolution or chain label resolution
+**For smart contracts** — [EIP-7930](https://eips.ethereum.org/EIPS/eip-7930) gives you a compact binary format optimized for onchain use:
 
-See [Concepts](./addresses/concepts.md) for a deeper explanation of the architecture and the standards.
+```
+0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045
+```
+
+Both formats carry the same information and convert back and forth losslessly.
+
+## Quick example
+
+```typescript
+import { getAddress, getChainId, parseName } from "@wonderland/interop-addresses";
+
+// Parse a human-readable name into its components
+const result = await parseName("vitalik.eth@eip155:1");
+// → address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+// → chain:   eip155:1 (Ethereum mainnet)
+
+// Or grab just the parts you need
+const address = await getAddress("vitalik.eth@eip155:1");
+const chainId = await getChainId("vitalik.eth@eip155:1");
+```
+
+## What the package does
+
+-   **Parse** human-readable names like `vitalik.eth@ethereum` into addresses and chain IDs
+-   **Encode/decode** compact binary addresses for smart contracts
+-   **Resolve** ENS names and chain shortnames automatically
+-   **Validate** checksums to catch typos and tampering
+-   **Convert** between human-readable, structured, and binary formats
 
 ## Where to start
 
 | I want to...                 | Go to                                                   |
 | ---------------------------- | ------------------------------------------------------- |
 | Try it out                   | [Getting Started](./addresses/getting-started.md)       |
-| Understand the design        | [Concepts](./addresses/concepts.md)                     |
+| Understand the standards     | [Concepts](./addresses/concepts.md)                     |
 | See a real-world walkthrough | [Parsing an Interoperable Name](./addresses/example.md) |
 | Learn advanced patterns      | [Advanced Usage](./addresses/advanced-usage.md)         |
 | Look up a function signature | [API Reference](./addresses/api.md)                     |

--- a/apps/docs/docs/addresses/advanced-usage.md
+++ b/apps/docs/docs/addresses/advanced-usage.md
@@ -53,12 +53,7 @@ const isValidBinary = isValidBinaryAddress(
 ## Working with Chain References
 
 ```typescript
-import {
-    isValidChain,
-    isValidChainType,
-    resolveChain,
-    shortnameToChainId,
-} from "@wonderland/interop-addresses";
+import { isValidChain, isValidChainType, resolveChain } from "@wonderland/interop-addresses";
 
 // Validate chain type
 const isValid = isValidChainType("eip155"); // true
@@ -69,10 +64,6 @@ const isValidChainRef = isValidChain("eip155", "1"); // true
 // Resolve chain (handles shortname resolution, validation, etc.)
 const resolved = await resolveChain({ chainReference: "eth" });
 // Returns: { chainType: "eip155", chainReference: "1" }
-
-// Resolve shortname to chain ID
-const chainId = await shortnameToChainId("eth");
-// Returns: 1 or undefined
 ```
 
 ## Error Handling

--- a/apps/docs/docs/addresses/advanced-usage.md
+++ b/apps/docs/docs/addresses/advanced-usage.md
@@ -18,7 +18,7 @@ const checksum = await computeChecksum("vitalik.eth@eip155:1");
 // Returns: "4CA88C9C"
 
 // Parse with checksum validation
-const result = await parseName("vitalik.eth@eip155:1#4CA88C9C");
+const result = await parseName("vitalik.eth@eip155:1");
 // result.meta.checksum - always calculated
 // result.meta.checksumMismatch - present if provided checksum didn't match
 ```
@@ -35,12 +35,12 @@ import {
 } from "@wonderland/interop-addresses";
 
 // Validate any interop address (binary or name)
-const isValid = await isValidInteropAddress("vitalik.eth@eip155:1#4CA88C9C", {
+const isValid = await isValidInteropAddress("vitalik.eth@eip155:1", {
     validateChecksumFlag: true,
 });
 
 // Validate specifically interoperable names
-const isValidName = await isValidInteroperableName("vitalik.eth@eip155:1#4CA88C9C", {
+const isValidName = await isValidInteroperableName("vitalik.eth@eip155:1", {
     validateChecksumFlag: true,
 });
 
@@ -127,7 +127,7 @@ import {
 } from "@wonderland/interop-addresses";
 
 // Start with name
-const name = "vitalik.eth@eip155:1#4CA88C9C";
+const name = "vitalik.eth@eip155:1";
 
 // Parse to get text address (default)
 const parsed = await parseName(name);

--- a/apps/docs/docs/addresses/api.md
+++ b/apps/docs/docs/addresses/api.md
@@ -26,7 +26,7 @@ nameToBinary(
 ```typescript
 import { nameToBinary } from "@wonderland/interop-addresses";
 
-const binary = await nameToBinary("vitalik.eth@eip155:1#4CA88C9C", { format: "hex" });
+const binary = await nameToBinary("vitalik.eth@eip155:1", { format: "hex" });
 ```
 
 #### `getAddress`
@@ -42,7 +42,7 @@ getAddress(address: string): Promise<string>
 ```typescript
 import { getAddress } from "@wonderland/interop-addresses";
 
-const address = await getAddress("vitalik.eth@eip155:1#4CA88C9C");
+const address = await getAddress("vitalik.eth@eip155:1");
 // Returns: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 ```
 
@@ -59,7 +59,7 @@ getChainId(address: string): Promise<string>
 ```typescript
 import { getChainId } from "@wonderland/interop-addresses";
 
-const chainId = await getChainId("vitalik.eth@eip155:1#4CA88C9C");
+const chainId = await getChainId("vitalik.eth@eip155:1");
 // Returns: "1"
 ```
 
@@ -96,7 +96,7 @@ isValidInteropAddress(
 ```typescript
 import { isValidInteropAddress } from "@wonderland/interop-addresses";
 
-const isValid = await isValidInteropAddress("vitalik.eth@eip155:1#4CA88C9C", {
+const isValid = await isValidInteropAddress("vitalik.eth@eip155:1", {
     validateChecksumFlag: true,
 });
 ```
@@ -117,7 +117,7 @@ isValidInteroperableName(
 ```typescript
 import { isValidInteroperableName } from "@wonderland/interop-addresses";
 
-const isValid = await isValidInteroperableName("vitalik.eth@eip155:1#4CA88C9C");
+const isValid = await isValidInteroperableName("vitalik.eth@eip155:1");
 ```
 
 ### Synchronous Methods
@@ -336,7 +336,7 @@ The `address` field is an `InteroperableAddress` in the requested representation
 ```typescript
 import { isTextAddress } from "@wonderland/interop-addresses";
 
-const result = await parseName("vitalik.eth@eip155:1#4CA88C9C");
+const result = await parseName("vitalik.eth@eip155:1");
 
 if (isTextAddress(result.interoperableAddress)) {
     // Access text fields directly
@@ -537,7 +537,7 @@ The text variant uses CAIP-350's text encoding rules, which are chainType-specif
 The ERC-7828-style human-readable name string:
 
 ```typescript
-type InteroperableName = string; // e.g., "vitalik.eth@eip155:1#4CA88C9C"
+type InteroperableName = string; // e.g., "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1#4CA88C9C"
 ```
 
 ### `ParsedInteropNameComponents`
@@ -591,7 +591,7 @@ The `interoperableAddress` field contains the `InteroperableAddress` type in the
 ```typescript
 import { isTextAddress } from "@wonderland/interop-addresses";
 
-const result = await parseName("vitalik.eth@eip155:1#4CA88C9C");
+const result = await parseName("vitalik.eth@eip155:1");
 
 if (isTextAddress(result.interoperableAddress)) {
     // Access text fields directly

--- a/apps/docs/docs/addresses/api.md
+++ b/apps/docs/docs/addresses/api.md
@@ -418,14 +418,6 @@ resolveChain(
 ): Promise<{ chainType: ChainTypeName; chainReference?: string }>
 ```
 
-#### `shortnameToChainId`
-
-Resolves a chain shortname to its chain ID.
-
-```typescript
-shortnameToChainId(shortName: string): Promise<number | undefined>
-```
-
 #### `getRegisteredChains`
 
 Fetches all chains registered in the on.eth ChainResolver contract. Uses multicall to call `chainCount()` and then `getChainAtIndex()` for each index, decoding the ERC-7930 interoperable address to extract the CAIP-2 chain type and reference.
@@ -471,7 +463,6 @@ import {
     parseName,
     resolveAddress,
     resolveChain,
-    shortnameToChainId,
     toBinaryRepresentation,
     toTextRepresentation,
     validateChecksum,

--- a/apps/docs/docs/addresses/concepts.md
+++ b/apps/docs/docs/addresses/concepts.md
@@ -2,74 +2,65 @@
 title: Concepts
 ---
 
-This page explains the ideas behind the `addresses` package — the standards it implements, the architecture it follows, and the design decisions that shape its API.
+This page explains the standards behind interoperable addresses and how the package implements them.
 
 ## The problem
 
-Blockchain addresses today are chain-specific. An Ethereum address like `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045` doesn't tell you _which_ chain the account lives on. In a multichain world, this ambiguity leads to lost funds, broken UIs, and manual chain selection.
+An Ethereum address like `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045` doesn't say _which chain_ the account is on. In a multichain world, this ambiguity leads to lost funds, broken UIs, and manual chain selection.
 
-Interoperable addresses solve this by encoding the chain alongside the address in a single, standardized format.
+Interoperable addresses solve this by encoding the **chain alongside the address** in a single, standardized format — in two complementary ways.
 
-## The standards
+## Human-readable: ERC-7828
 
-The package implements three complementary standards:
+[ERC-7828](https://eips.ethereum.org/EIPS/eip-7828) defines a readable name format designed for end-users, wallets, and UIs:
 
-### EIP-7930: Interoperable Addresses
+```
+vitalik.eth@ethereum
+0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:10#1A2B3C4D
+```
 
-Defines a **binary serialization format** for addresses that includes a version byte, chain type, chain reference, and the address itself. This is the canonical wire format — compact, unambiguous, and suitable for storage and transmission.
+The format is: `{address}@{chain}#{checksum}`
 
-Example (hex): `0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045`
+What makes it user-friendly:
 
-### CAIP-350: Text Encoding Rules
+-   **ENS names** work directly — `vitalik.eth` instead of a raw hex address
+-   **Chain shortnames** like `ethereum`, `base`, or `optimism` resolve automatically via an onchain registry
+-   **Checksums** (4 bytes, calculated from the binary form) catch typos and detect tampering
+-   Fully-qualified CAIP-2 identifiers (`eip155:1`) also work when precision matters
 
-Defines how the binary fields should be represented as human-readable text, with chain-type-specific rules:
+This is what users see and what apps display.
+
+## Onchain-optimized: EIP-7930
+
+[EIP-7930](https://eips.ethereum.org/EIPS/eip-7930) defines a compact binary format optimized for smart contracts, where minimal byte size directly reduces gas costs:
+
+```
+0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045
+```
+
+The binary encodes a version byte, chain type, chain reference, and the address into a single byte sequence — no ambiguity, no resolution needed. This is the format smart contracts pass around and store onchain.
+
+## How they relate
+
+Both formats carry the same information. A human-readable ERC-7828 name resolves to the same structured address that EIP-7930 serializes into bytes:
+
+```
+vitalik.eth@eip155:1  ←→  { chainType: "eip155", chainReference: "1", address: "0xd8dA..." }  ←→  0x0001...
+      (name)                              (structured address)                                    (binary)
+```
+
+A third standard, [CAIP-350](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-350.md), defines chain-type-specific rules for representing binary fields as text:
 
 -   **eip155**: Chain references as decimal strings, addresses as hex with EIP-55 checksumming
 -   **bip122**: Chain references as 32-char lowercase hex (genesis hash prefix), addresses as base58check or bech32/bech32m
 -   **solana**: Base58 encoding for both chain references and addresses
 
-### ERC-7828: Readable Interoperable Names
+## Package API design
 
-Defines a **human-readable string format** that combines an address (or ENS name), a chain identifier, and an optional checksum:
+The package API reflects the two formats:
 
-```
-vitalik.eth@eip155:1#4CA88C9C
-```
-
-Format: `{address}@{chainType}:{chainReference}#{checksum}`
-
-This format supports ENS names and chain shortnames (like `eth` or `base`) for better UX.
-
-## Two-layer architecture
-
-The package is organized into two layers, each handling a different level of abstraction:
-
-### Address Layer (sync)
-
-Handles the structured `InteroperableAddress` type — a discriminated union that can be either a **text** or **binary** representation:
-
-```typescript
-// Text variant — human-friendly strings
-{ version: 1, chainType: "eip155", chainReference: "1", address: "0xd8dA..." }
-
-// Binary variant — raw bytes
-{ version: 1, chainType: Uint8Array, chainReference: Uint8Array, address: Uint8Array }
-```
-
-All Address Layer operations are **synchronous**: encoding, decoding, checksum calculation, validation, and conversion between representations. Use `isTextAddress()` or `isBinaryAddress()` type guards to narrow the union.
-
-### Name Layer (async)
-
-Handles the human-readable `InteroperableName` string format. Operations that involve resolution (parsing names, converting names to binary) are **asynchronous** because they may need to:
-
--   Resolve ENS names to raw addresses (via ENSIP-11)
--   Resolve chain shortnames (like `eth`) to CAIP-2 identifiers (like `eip155:1`)
-
-Some Name Layer operations are synchronous — `formatName` and `binaryToName` don't require resolution and return immediately.
-
-The Name Layer builds on top of the Address Layer — parsing a name ultimately produces an `InteroperableAddress`.
-
-### How the layers connect
+-   **Functions that work with names** (`parseName`, `nameToBinary`, `getAddress`, `getChainId`) are **async** — they may need to resolve ENS names or chain shortnames over the network.
+-   **Functions that work with binary/structured addresses** (`encodeAddress`, `decodeAddress`, `formatName`, `binaryToName`) are **sync** — everything is already resolved.
 
 ```mermaid
 graph TD
@@ -84,6 +75,18 @@ graph TD
     C -->|"decodeAddress (sync)"| B
     C -->|"binaryToName (sync)"| A
 ```
+
+The structured `InteroperableAddress` in the middle is a discriminated union — it can hold either text strings or raw bytes:
+
+```typescript
+// Text variant — human-friendly strings
+{ version: 1, chainType: "eip155", chainReference: "1", address: "0xd8dA..." }
+
+// Binary variant — raw bytes
+{ version: 1, chainType: Uint8Array, chainReference: Uint8Array, address: Uint8Array }
+```
+
+Use `isTextAddress()` or `isBinaryAddress()` type guards to narrow the union.
 
 ## Chain resolution
 
@@ -112,7 +115,7 @@ await parseName("0x...@ethereum", { rpcUrl: "https://my-rpc.example.com" });
 Checksums protect against typos and address tampering. The checksum is computed from the binary serialization of the address and appended to the name after a `#`:
 
 ```
-vitalik.eth@eip155:1#4CA88C9C
+vitalik.eth@eip155:1
                      ^^^^^^^^ checksum
 ```
 

--- a/apps/docs/docs/addresses/concepts.md
+++ b/apps/docs/docs/addresses/concepts.md
@@ -115,8 +115,8 @@ await parseName("0x...@ethereum", { rpcUrl: "https://my-rpc.example.com" });
 Checksums protect against typos and address tampering. The checksum is computed from the binary serialization of the address and appended to the name after a `#`:
 
 ```
-vitalik.eth@eip155:1
-                     ^^^^^^^^ checksum
+vitalik.eth@eip155:1#4CA88C9C
+                     ^^^^^^^^^ checksum
 ```
 
 The SDK always calculates the checksum when parsing. If the input includes a checksum, the SDK compares it against the calculated value and reports any mismatch via `result.meta.checksumMismatch`.

--- a/apps/docs/docs/addresses/concepts.md
+++ b/apps/docs/docs/addresses/concepts.md
@@ -116,7 +116,7 @@ Checksums protect against typos and address tampering. The checksum is computed 
 
 ```
 vitalik.eth@eip155:1#4CA88C9C
-                     ^^^^^^^^^ checksum
+                     ^^^^^^^^ checksum
 ```
 
 The SDK always calculates the checksum when parsing. If the input includes a checksum, the SDK compares it against the calculated value and reports any mismatch via `result.meta.checksumMismatch`.

--- a/apps/docs/docs/addresses/example.md
+++ b/apps/docs/docs/addresses/example.md
@@ -60,27 +60,21 @@ console.log(result.meta.isENS); // true
 Before using the parsed address, you should validate the checksum to ensure the address hasn't been tampered with:
 
 ```typescript
-import { parseName, validateChecksum } from "@wonderland/interop-addresses";
+import { parseName } from "@wonderland/interop-addresses";
 
-const interoperableName = "vitalik.eth@base";
+// Input includes a checksum — the SDK compares it against the calculated value
+// Note: checksums are computed from the resolved address, not ENS names
+const interoperableName = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1#4CA88C9C";
 const result = await parseName(interoperableName);
 
-// Check if there was a checksum mismatch
+// If the provided checksum doesn't match, checksumMismatch is set
 if (result.meta.checksumMismatch) {
     console.warn("Checksum mismatch detected!");
     console.warn(`Provided: ${result.meta.checksumMismatch.provided}`);
     console.warn(`Calculated: ${result.meta.checksumMismatch.calculated}`);
-    // Handle the mismatch appropriately for your use case
-}
-
-// Or explicitly validate the checksum
-try {
-    validateChecksum(result.interoperableAddress, result.meta.checksum, {
-        isENSName: result.meta.isENS,
-    });
-    console.log("Checksum is valid!");
-} catch (error) {
-    console.error("Invalid checksum:", error);
+    // Handle the mismatch — the address may have been tampered with
+} else {
+    console.log("Checksum valid:", result.meta.checksum);
 }
 ```
 
@@ -133,7 +127,7 @@ console.log(addr);
 Here's a complete example showing the recommended workflow:
 
 ```typescript
-import { isTextAddress, parseName, validateChecksum } from "@wonderland/interop-addresses";
+import { isTextAddress, parseName } from "@wonderland/interop-addresses";
 
 async function processInteropAddress(interopAddress: string) {
     try {

--- a/apps/docs/docs/addresses/example.md
+++ b/apps/docs/docs/addresses/example.md
@@ -12,7 +12,7 @@ While interop addresses provide a convenient, human-readable way to represent ac
 
 ## Use Case
 
-Suppose you're a wallet developer. You want your users to be able to input an interop address (e.g., `vitalik.eth@base#4CA88C9C`) and seamlessly interact with contracts that only accept canonical addresses. The SDK makes this process straightforward.
+Suppose you're a wallet developer. You want your users to be able to input an interop address (e.g., `vitalik.eth@base`) and seamlessly interact with contracts that only accept canonical addresses. The SDK makes this process straightforward.
 
 Since you're building a wallet and want your product to be as fast and lightweight as possible, it's best to import only the individual functions you need. This approach maximizes tree shaking and minimizes your bundle size.
 
@@ -25,7 +25,7 @@ sequenceDiagram
     participant SDK
     participant SmartContract
 
-    User->>Wallet: vitalik.eth@base#4CA88C9C
+    User->>Wallet: vitalik.eth@base
     Wallet->>SDK: parseName(interopAddress)
     SDK-->>Wallet: result with address, chainType, chainReference, checksum
     Wallet->>Wallet: Validate checksum
@@ -39,7 +39,7 @@ The `parseName` method is the recommended way to extract all components from an 
 ```typescript
 import { isTextAddress, parseName } from "@wonderland/interop-addresses";
 
-const interoperableName = "vitalik.eth@base#4CA88C9C";
+const interoperableName = "vitalik.eth@base";
 const result = await parseName(interoperableName);
 
 // Use type guard to access text fields
@@ -62,7 +62,7 @@ Before using the parsed address, you should validate the checksum to ensure the 
 ```typescript
 import { parseName, validateChecksum } from "@wonderland/interop-addresses";
 
-const interoperableName = "vitalik.eth@base#4CA88C9C";
+const interoperableName = "vitalik.eth@base";
 const result = await parseName(interoperableName);
 
 // Check if there was a checksum mismatch
@@ -91,7 +91,7 @@ If you only need specific components, you can use the individual extraction func
 ```typescript
 import { getAddress, getChainId } from "@wonderland/interop-addresses";
 
-const interoperableName = "vitalik.eth@base#4CA88C9C";
+const interoperableName = "vitalik.eth@base";
 
 // Extract just the address
 const address = await getAddress(interoperableName);
@@ -166,7 +166,7 @@ async function processInteropAddress(interopAddress: string) {
 }
 
 // Usage
-await processInteropAddress("vitalik.eth@base#4CA88C9C");
+await processInteropAddress("vitalik.eth@base");
 ```
 
 ## Additional Notes

--- a/apps/docs/docs/addresses/getting-started.md
+++ b/apps/docs/docs/addresses/getting-started.md
@@ -2,7 +2,7 @@
 title: Getting Started
 ---
 
-In this tutorial, you'll parse an interoperable address and extract its components. By the end, you'll know how to go from a human-readable name like `vitalik.eth@eip155:1#4CA88C9C` to its raw address and chain ID.
+In this tutorial, you'll parse an interoperable address and extract its components. By the end, you'll know how to go from a human-readable name like `vitalik.eth@eip155:1` to its raw address and chain ID.
 
 ## Install the package
 
@@ -21,7 +21,7 @@ An interoperable name encodes an address, a chain, and a checksum in a single st
 ```typescript
 import { isTextAddress, parseName } from "@wonderland/interop-addresses";
 
-const result = await parseName("vitalik.eth@eip155:1#4CA88C9C");
+const result = await parseName("vitalik.eth@eip155:1");
 
 if (isTextAddress(result.interoperableAddress)) {
     console.log(result.interoperableAddress.address);
@@ -60,10 +60,10 @@ If you only need the address or chain ID, use the convenience functions:
 ```typescript
 import { getAddress, getChainId } from "@wonderland/interop-addresses";
 
-const address = await getAddress("vitalik.eth@eip155:1#4CA88C9C");
+const address = await getAddress("vitalik.eth@eip155:1");
 // "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 
-const chainId = await getChainId("vitalik.eth@eip155:1#4CA88C9C");
+const chainId = await getChainId("vitalik.eth@eip155:1");
 // "1"
 ```
 
@@ -105,7 +105,7 @@ graph TD
 import { binaryToName, nameToBinary } from "@wonderland/interop-addresses";
 
 // Name → Binary (async, may resolve ENS)
-const binary = await nameToBinary("vitalik.eth@eip155:1#4CA88C9C", { format: "hex" });
+const binary = await nameToBinary("vitalik.eth@eip155:1", { format: "hex" });
 
 // Binary → Name (sync)
 const name = binaryToName(binary);

--- a/apps/docs/docs/addresses/getting-started.md
+++ b/apps/docs/docs/addresses/getting-started.md
@@ -128,6 +128,22 @@ Resolution uses a two-tier strategy:
 
 Fully-qualified identifiers (e.g., `eip155:10`) always work without any registry lookup.
 
+## Which function should I use?
+
+| I have...                                    | I need...                      | Use                               |
+| -------------------------------------------- | ------------------------------ | --------------------------------- |
+| A name like `vitalik.eth@eip155:1`           | The full parsed result         | `parseName()` (async)             |
+| A name like `vitalik.eth@eip155:1`           | Just the address               | `getAddress()` (async)            |
+| A name like `vitalik.eth@eip155:1`           | Just the chain ID              | `getChainId()` (async)            |
+| A name like `vitalik.eth@eip155:1`           | The binary form for a contract | `nameToBinary()` (async)          |
+| A binary address (`0x0001...`)               | The structured fields          | `decodeAddress()` (sync)          |
+| A binary address (`0x0001...`)               | A human-readable name          | `binaryToName()` (sync)           |
+| Structured fields (chainType, address, etc.) | A binary address               | `encodeAddress()` (sync)          |
+| Structured fields (chainType, address, etc.) | A human-readable name          | `formatName()` (sync)             |
+| Any address string                           | To check if it's valid         | `isValidInteropAddress()` (async) |
+
+**Rule of thumb:** If your input contains ENS names or chain shortnames (like `ethereum` instead of `eip155:1`), use async functions — they resolve names over the network. If you already have structured data or raw binary, sync functions work.
+
 ## Next steps
 
 -   [Concepts](./concepts.md) — understand the two-layer architecture and the standards behind it

--- a/apps/docs/docs/cross-chain.md
+++ b/apps/docs/docs/cross-chain.md
@@ -8,7 +8,7 @@ It follows [EIP-7683](https://www.erc7683.org/) for cross-chain intent structure
 
 ## What it does
 
--   Fetch and compare quotes from multiple providers (Across, Relay, OIF)
+-   Fetch and compare quotes from multiple providers (Across, Relay, OIF, LiFi)
 -   Execute cross-chain transfers via signature (gasless) or transaction
 -   Track orders from initiation to completion
 -   Aggregate quotes with configurable sorting strategies

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -142,22 +142,22 @@ response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`)
 2. **Get quotes** → `provider.getQuotes(request)` or `aggregator.getQuotes(request)`
 3. **Check order type** → `isSignatureOnlyOrder(quote.order)`
     - **Signature (gasless):** `signTypedData()` → `provider.submitOrder(quote, signature)`
-    - **Transaction (user pays gas):** `sendTransaction(step.transaction)`
-4. **Track** → `aggregator.track(quote)` or use `createOrderTracker()`
+    - **Transaction (user pays gas):** `walletClient.sendTransaction({ to, data, value: BigInt(value) })`
+4. **Track** → `aggregator.track({ txHash, providerId, originChainId, destinationChainId })`
 
 ### Which function should I use?
 
-| I want to...                            | Use                                      |
-| --------------------------------------- | ---------------------------------------- |
-| Get quotes from one provider            | `provider.getQuotes(request)`            |
-| Get quotes from multiple providers      | `aggregator.getQuotes(request)`          |
-| Build a quote locally (no provider API) | `aggregator.buildQuote(request)`         |
-| Submit a signed order                   | `provider.submitOrder(quote, signature)` |
-| Check if order is gasless               | `isSignatureOnlyOrder(quote.order)`      |
-| Get signature steps from an order       | `getSignatureSteps(quote.order)`         |
-| Get transaction steps from an order     | `getTransactionSteps(quote.order)`       |
-| Track an order after submission         | `aggregator.track(quote)`                |
-| Discover supported tokens               | `aggregator.discoverAssets()`            |
+| I want to...                            | Use                                                            |
+| --------------------------------------- | -------------------------------------------------------------- |
+| Get quotes from one provider            | `provider.getQuotes(request)`                                  |
+| Get quotes from multiple providers      | `aggregator.getQuotes(request)`                                |
+| Build a quote locally (no provider API) | `aggregator.buildQuote(providerId, request)`                   |
+| Submit a signed order                   | `provider.submitOrder(quote, signature)`                       |
+| Check if order is gasless               | `isSignatureOnlyOrder(quote.order)`                            |
+| Get signature steps from an order       | `getSignatureSteps(quote.order)`                               |
+| Get transaction steps from an order     | `getTransactionSteps(quote.order)`                             |
+| Track an order after submission         | `aggregator.track({ txHash, providerId, originChainId, ... })` |
+| Discover supported tokens               | `aggregator.discoverAssets()`                                  |
 
 ## Next steps
 

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -142,7 +142,7 @@ response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`)
 2. **Get quotes** → `provider.getQuotes(request)` or `aggregator.getQuotes(request)`
 3. **Check order type** → `isSignatureOnlyOrder(quote.order)`
     - **Signature (gasless):** `signTypedData()` → `provider.submitOrder(quote, signature)`
-    - **Transaction (user pays gas):** `walletClient.sendTransaction(step.transaction)`
+    - **Transaction (user pays gas):** `walletClient.sendTransaction(...)` (see [example above](#execute-the-transaction) — convert string `value` to `BigInt`)
 4. **Track** → `aggregator.track({ txHash, providerId, originChainId, destinationChainId })`
 
 ### Which function should I use?

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -143,21 +143,22 @@ response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`)
 3. **Check order type** → `isSignatureOnlyOrder(quote.order)`
     - **Signature (gasless):** `signTypedData()` → `provider.submitOrder(quote, signature)`
     - **Transaction (user pays gas):** `walletClient.sendTransaction(...)` (see [example above](#execute-the-transaction) — convert string `value` to `BigInt`)
-4. **Track** → `aggregator.track({ txHash, providerId, originChainId, destinationChainId })`
+4. **Track** → `createOrderTracker(provider)` for single-provider or `aggregator.track({ txHash, providerId, originChainId, destinationChainId })` for aggregator
 
 ### Which function should I use?
 
-| I want to...                            | Use                                                            |
-| --------------------------------------- | -------------------------------------------------------------- |
-| Get quotes from one provider            | `provider.getQuotes(request)`                                  |
-| Get quotes from multiple providers      | `aggregator.getQuotes(request)`                                |
-| Build a quote locally (no provider API) | `aggregator.buildQuote(providerId, request)`                   |
-| Submit a signed order                   | `provider.submitOrder(quote, signature)`                       |
-| Check if order is gasless               | `isSignatureOnlyOrder(quote.order)`                            |
-| Get signature steps from an order       | `getSignatureSteps(quote.order)`                               |
-| Get transaction steps from an order     | `getTransactionSteps(quote.order)`                             |
-| Track an order after submission         | `aggregator.track({ txHash, providerId, originChainId, ... })` |
-| Discover supported tokens               | `aggregator.discoverAssets()`                                  |
+| I want to...                            | Use                                                                    |
+| --------------------------------------- | ---------------------------------------------------------------------- |
+| Get quotes from one provider            | `provider.getQuotes(request)`                                          |
+| Get quotes from multiple providers      | `aggregator.getQuotes(request)`                                        |
+| Build a quote locally (no provider API) | `aggregator.buildQuote(providerId, request)`                           |
+| Submit a signed order                   | `provider.submitOrder(quote, signature)`                               |
+| Check if order is gasless               | `isSignatureOnlyOrder(quote.order)`                                    |
+| Get signature steps from an order       | `getSignatureSteps(quote.order)`                                       |
+| Get transaction steps from an order     | `getTransactionSteps(quote.order)`                                     |
+| Track an order (single provider)        | `createOrderTracker(provider)` → `tracker.watchOrder({ txHash, ... })` |
+| Track an order (aggregator)             | `aggregator.track({ txHash, providerId, originChainId, ... })`         |
+| Discover supported tokens               | `aggregator.discoverAssets()`                                          |
 
 ## Next steps
 

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -142,7 +142,7 @@ response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`)
 2. **Get quotes** → `provider.getQuotes(request)` or `aggregator.getQuotes(request)`
 3. **Check order type** → `isSignatureOnlyOrder(quote.order)`
     - **Signature (gasless):** `signTypedData()` → `provider.submitOrder(quote, signature)`
-    - **Transaction (user pays gas):** `walletClient.sendTransaction({ to, data, value: BigInt(value) })`
+    - **Transaction (user pays gas):** `walletClient.sendTransaction(step.transaction)`
 4. **Track** → `aggregator.track({ txHash, providerId, originChainId, destinationChainId })`
 
 ### Which function should I use?

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -134,6 +134,31 @@ console.log(`Got ${response.quotes.length} quotes`);
 response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`));
 ```
 
+## Quick reference
+
+### Execution flow
+
+1. **Create provider** → `createCrossChainProvider("across")` (or use `createAggregator` for multiple)
+2. **Get quotes** → `provider.getQuotes(request)` or `aggregator.getQuotes(request)`
+3. **Check order type** → `isSignatureOnlyOrder(quote.order)`
+    - **Signature (gasless):** `signTypedData()` → `provider.submitOrder(quote, signature)`
+    - **Transaction (user pays gas):** `sendTransaction(step.transaction)`
+4. **Track** → `aggregator.track(quote)` or use `createOrderTracker()`
+
+### Which function should I use?
+
+| I want to...                            | Use                                      |
+| --------------------------------------- | ---------------------------------------- |
+| Get quotes from one provider            | `provider.getQuotes(request)`            |
+| Get quotes from multiple providers      | `aggregator.getQuotes(request)`          |
+| Build a quote locally (no provider API) | `aggregator.buildQuote(request)`         |
+| Submit a signed order                   | `provider.submitOrder(quote, signature)` |
+| Check if order is gasless               | `isSignatureOnlyOrder(quote.order)`      |
+| Get signature steps from an order       | `getSignatureSteps(quote.order)`         |
+| Get transaction steps from an order     | `getTransactionSteps(quote.order)`       |
+| Track an order after submission         | `aggregator.track(quote)`                |
+| Discover supported tokens               | `aggregator.discoverAssets()`            |
+
 ## Next steps
 
 -   [Order Tracking](./intent-tracking.md) — monitor your transfer from initiation to completion

--- a/apps/docs/docs/cross-chain/providers.md
+++ b/apps/docs/docs/cross-chain/providers.md
@@ -11,8 +11,45 @@ This document lists all cross-chain providers supported by the Interop SDK.
 | [Across Protocol](./across-provider.md) | Active | Cross-chain token transfers using Across bridge |
 | [Relay Protocol](./relay-provider.md)   | Active | Cross-chain token transfers using Relay bridge  |
 | [OIF](./oif-provider.md)                | Active | Direct integration with OIF-compliant solvers   |
+| LiFi Intents                            | Active | Cross-chain via LiFi intent solver              |
 
-> Additional protocols are planned for future releases.
+## Provider Configuration
+
+```typescript
+import { createCrossChainProvider } from "@wonderland/interop-cross-chain";
+
+// Across — no required config
+createCrossChainProvider("across");
+createCrossChainProvider("across", { isTestnet: true });
+
+// Relay — no required config
+createCrossChainProvider("relay");
+createCrossChainProvider("relay", { apiKey: "...", isTestnet: true });
+
+// OIF — solverId and url are required
+createCrossChainProvider("oif", { solverId: "my-solver", url: "https://solver.example.com" });
+
+// LiFi Intents — orderServerUrl is required
+createCrossChainProvider("lifi-intents", { orderServerUrl: "https://..." });
+```
+
+| Provider       | Required Config   | Optional Config       |
+| -------------- | ----------------- | --------------------- |
+| `across`       | (none)            | `isTestnet`           |
+| `relay`        | (none)            | `apiKey`, `isTestnet` |
+| `oif`          | `solverId`, `url` | —                     |
+| `lifi-intents` | `orderServerUrl`  | —                     |
+
+## Order Tracking Requirements
+
+Different providers use different tracking mechanisms. Some need RPC URLs, others are fully API-based:
+
+| Provider         | Opened Intent Parser | Fill Watcher | RPC URLs Needed?            |
+| ---------------- | -------------------- | ------------ | --------------------------- |
+| Across (mainnet) | OIF event-based      | API-based    | Origin chain only           |
+| Across (testnet) | OIF event-based      | Event-based  | Origin + destination chains |
+| Relay            | API-based            | API-based    | None                        |
+| OIF              | OIF event-based      | Event-based  | Origin + destination chains |
 
 ## Creating Custom Providers
 

--- a/apps/sdk/README.md
+++ b/apps/sdk/README.md
@@ -52,11 +52,11 @@ Available scripts that can be run using `pnpm`:
 import { InteropAddressProvider, nameToBinary } from "@wonderland/interop";
 
 // Using the Provider
-const interoperableName = "alice.eth@eip155:1#ABCD1234";
+const interoperableName = "alice.eth@eip155:1";
 const binaryAddress = await InteropAddressProvider.nameToBinary(interoperableName);
 
 // Or just importing the method directly
-const binaryAddress2 = await nameToBinary("alice.eth@eip155:1#ABCD1234");
+const binaryAddress2 = await nameToBinary("alice.eth@eip155:1");
 ```
 
 ### Cross-Chain Operations

--- a/examples/ui/app/components/InputSection.tsx
+++ b/examples/ui/app/components/InputSection.tsx
@@ -89,7 +89,7 @@ export function InputSection({
               type='text'
               value={readableName}
               onChange={(e) => setReadableName(e.target.value)}
-              placeholder='alice.eth@eip155:1#4CA88C9C'
+              placeholder='alice.eth@eip155:1'
               autoComplete='off'
               data-1p-ignore
               className='w-full px-4 py-3 bg-background/50 border border-border/50 rounded-xl font-mono text-sm focus:border-accent focus:ring-2 focus:ring-accent/20 mt-2'

--- a/packages/addresses/README.md
+++ b/packages/addresses/README.md
@@ -220,7 +220,7 @@ All methods are available as static methods on `InteropAddressProvider` or as st
 -   `isValidChainType(chainType: string): chainType is ChainTypeName`
 -   `resolveAddress(address: string, chainType: ChainTypeName, chainReference: string | undefined): Promise<ResolvedAddress>`
 -   `resolveChain(input: { chainType?: string; chainReference?: string }): Promise<ResolvedChain>`
--   `shortnameToChainId(shortname: string): number | null`
+-   `shortnameToChainId(shortname: string): Promise<number | undefined>`
 
 ## Types
 
@@ -238,7 +238,7 @@ type InteroperableAddress =
       }
     | {
           version: number;
-          chainType: "eip155" | "solana"; // Text variant
+          chainType: "eip155" | "bip122" | "solana" | "starknet"; // Text variant
           chainReference?: string;
           address?: string;
       };
@@ -257,7 +257,7 @@ import { isTextAddress } from "@wonderland/interop-addresses";
 const addr = decodeAddress("0x00010000010114d8da6bf26964af9d7eed9e03e53415D37aa96045");
 
 if (isTextAddress(addr)) {
-    // TypeScript knows addr.chainType is "eip155" | "solana"
+    // TypeScript knows addr.chainType is "eip155" | "bip122" | "solana" | "starknet"
     console.log(addr.chainType); // "eip155"
     console.log(addr.chainReference); // "1" (string)
     console.log(addr.address); // "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" (string)
@@ -305,7 +305,7 @@ The result from `parseName`:
 ```typescript
 {
   name: ParsedInteropNameComponents;      // Original parsed components
-  address: InteroperableAddress;          // Address in specified representation (defaults to "text")
+  interoperableAddress: InteroperableAddress; // Address in specified representation (defaults to "text")
   meta: {
     checksum: Checksum;                    // Calculated checksum (always present)
     checksumMismatch?: {                   // Present if provided checksum didn't match
@@ -318,7 +318,7 @@ The result from `parseName`:
 }
 ```
 
-The `address` field contains the `InteroperableAddress` type in the requested representation (defaults to "text"). Use type guards to access fields:
+The `interoperableAddress` field contains the `InteroperableAddress` type in the requested representation (defaults to "text"). Use type guards to access fields:
 
 ```typescript
 import { isTextAddress } from "@wonderland/interop-addresses";

--- a/packages/addresses/README.md
+++ b/packages/addresses/README.md
@@ -219,8 +219,7 @@ All methods are available as static methods on `InteropAddressProvider` or as st
 -   `isValidChain(chainType: ChainTypeName, chainReference: string): boolean`
 -   `isValidChainType(chainType: string): chainType is ChainTypeName`
 -   `resolveAddress(address: string, chainType: ChainTypeName, chainReference: string | undefined): Promise<ResolvedAddress>`
--   `resolveChain(input: { chainType?: string; chainReference?: string }): Promise<ResolvedChain>`
--   `resolveChain(input): Promise<ResolvedChain>` — resolve a chain shortname or label to a chain identifier
+-   `resolveChain(input: { chainType?: string; chainReference?: string }): Promise<ResolvedChain>` — resolve a chain shortname or label to a chain identifier
 
 ## Types
 

--- a/packages/addresses/README.md
+++ b/packages/addresses/README.md
@@ -57,7 +57,7 @@ import {
 } from "@wonderland/interop-addresses";
 
 // Convert name to binary (async - may resolve ENS)
-const binary = await nameToBinary("vitalik.eth@eip155:1#4CA88C9C", { format: "hex" });
+const binary = await nameToBinary("vitalik.eth@eip155:1", { format: "hex" });
 
 // Convert binary to name (synchronous)
 const name = binaryToName("0x00010000010114d8da6bf26964af9d7eed9e03e53415D37aa96045");
@@ -93,7 +93,7 @@ import {
 } from "@wonderland/interop-addresses";
 
 // Parse name with full result (includes metadata) - defaults to text representation
-const result = await parseName("vitalik.eth@eip155:1#4CA88C9C");
+const result = await parseName("vitalik.eth@eip155:1");
 // result.name - original parsed components
 // result.interoperableAddress - address in text representation (default)
 //   - result.interoperableAddress.chainType - "eip155" (string)
@@ -105,7 +105,7 @@ const result = await parseName("vitalik.eth@eip155:1#4CA88C9C");
 // result.meta.isChainLabel - whether chain reference was a label
 
 // Parse to binary representation
-const resultBinary = await parseName("vitalik.eth@eip155:1#4CA88C9C", { representation: "binary" });
+const resultBinary = await parseName("vitalik.eth@eip155:1", { representation: "binary" });
 // resultBinary.interoperableAddress.chainType - Uint8Array
 // resultBinary.interoperableAddress.chainReference - Uint8Array
 // resultBinary.interoperableAddress.address - Uint8Array
@@ -152,11 +152,11 @@ const name = formatName(textAddr); // Automatically converts if needed and inclu
 import { getAddress, getChainId } from "@wonderland/interop-addresses";
 
 // Get address from binary or name
-const address = await getAddress("vitalik.eth@eip155:1#4CA88C9C");
+const address = await getAddress("vitalik.eth@eip155:1");
 // Returns: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 
 // Get chain ID from binary or name
-const chainId = await getChainId("vitalik.eth@eip155:1#4CA88C9C");
+const chainId = await getChainId("vitalik.eth@eip155:1");
 // Returns: "1"
 ```
 
@@ -280,7 +280,7 @@ The text variant uses CAIP-350's text encoding rules, which are chainType-specif
 The ERC-7828-style human-readable name string:
 
 ```typescript
-type InteroperableName = string; // e.g., "vitalik.eth@eip155:1#4CA88C9C"
+type InteroperableName = string; // e.g., "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1#4CA88C9C"
 ```
 
 ### ParsedInteropNameComponents
@@ -323,7 +323,7 @@ The `address` field contains the `InteroperableAddress` type in the requested re
 ```typescript
 import { isTextAddress } from "@wonderland/interop-addresses";
 
-const result = await parseName("vitalik.eth@eip155:1#4CA88C9C");
+const result = await parseName("vitalik.eth@eip155:1");
 
 if (isTextAddress(result.interoperableAddress)) {
     // Access text fields directly

--- a/packages/addresses/README.md
+++ b/packages/addresses/README.md
@@ -220,7 +220,7 @@ All methods are available as static methods on `InteropAddressProvider` or as st
 -   `isValidChainType(chainType: string): chainType is ChainTypeName`
 -   `resolveAddress(address: string, chainType: ChainTypeName, chainReference: string | undefined): Promise<ResolvedAddress>`
 -   `resolveChain(input: { chainType?: string; chainReference?: string }): Promise<ResolvedChain>`
--   `shortnameToChainId(shortname: string): Promise<number | undefined>`
+-   `resolveChain(input): Promise<ResolvedChain>` — resolve a chain shortname or label to a chain identifier
 
 ## Types
 

--- a/packages/addresses/src/external.ts
+++ b/packages/addresses/src/external.ts
@@ -33,10 +33,37 @@ export { toChainIdentifier, fromChainIdentifier } from "./address/chainIdentifie
 export {
     parseName,
     formatName,
+    resolveAddress,
+    resolveChain,
     resolveChainFromRegistry,
     getRegisteredChains,
+    shortnameToChainId,
+    isValidChain,
+    isValidChainType,
 } from "./name/index.js";
 export type { RegisteredChain, GetRegisteredChainsOptions } from "./name/index.js";
+
+// Error classes
+export {
+    AddressResolutionFailed,
+    BytesConversionFailed,
+    ChecksumMismatchWarning,
+    ENSLookupFailed,
+    ENSNotFound,
+    FieldNotPresent,
+    InvalidAddress,
+    InvalidBinaryInteropAddress,
+    InvalidChainIdentifier,
+    InvalidChainReference,
+    InvalidChainType,
+    InvalidChecksum,
+    InvalidConversionType,
+    InvalidDecimal,
+    InvalidInteroperableAddress,
+    InvalidInteroperableName,
+    MissingInteroperableName,
+    UnsupportedChainType,
+} from "./errors/index.js";
 
 // Type guards
 export { isTextAddress, isBinaryAddress } from "./types/interopAddress.js";

--- a/packages/addresses/src/external.ts
+++ b/packages/addresses/src/external.ts
@@ -37,7 +37,6 @@ export {
     resolveChain,
     resolveChainFromRegistry,
     getRegisteredChains,
-    shortnameToChainId,
     isValidChain,
     isValidChainType,
 } from "./name/index.js";

--- a/packages/addresses/src/name/parseInteropNameString.ts
+++ b/packages/addresses/src/name/parseInteropNameString.ts
@@ -27,7 +27,7 @@ const INTEROP_NAME_REGEX = new RegExp(
  * If there is a <chain> but no <chainType>, checks if the <chain> is a valid chain type.
  * If it is, returns it as the chainType (with chain empty). Otherwise, returns it as chainReference.
  *
- * @param value - The Interoperable Name string (e.g., "alice.eth@eip155:1#ABCD1234")
+ * @param value - The Interoperable Name string (e.g., "alice.eth@eip155:1")
  * @returns Raw components extracted from the string
  * @throws {InvalidInteroperableName} If the string doesn't match the expected format
  */

--- a/packages/addresses/src/providers/InteropAddressProvider.ts
+++ b/packages/addresses/src/providers/InteropAddressProvider.ts
@@ -44,7 +44,7 @@ export class InteropAddressProvider {
      * @returns The binary address in the specified format
      * @example
      * ```ts
-     * const binaryAddress = await InteropAddressProvider.nameToBinary("alice.eth@eip155:1#ABCD1234");
+     * const binaryAddress = await InteropAddressProvider.nameToBinary("alice.eth@eip155:1");
      * ```
      */
     public static async nameToBinary<T extends "hex" | "bytes" | undefined = undefined>(
@@ -153,7 +153,7 @@ export class InteropAddressProvider {
      * @returns boolean - true if the address is a valid interop address, false otherwise
      * @example
      * ```ts
-     * const isValid = await InteropAddressProvider.isValidInteropAddress("alice.eth@eip155:1#ABCD1234", { validateChecksumFlag: true });
+     * const isValid = await InteropAddressProvider.isValidInteropAddress("alice.eth@eip155:1", { validateChecksumFlag: true });
      * ```
      */
     public static async isValidInteropAddress(
@@ -171,7 +171,7 @@ export class InteropAddressProvider {
      * @returns boolean - true if the address is a valid interop address, false otherwise
      * @example
      * ```ts
-     * const isValid = await InteropAddressProvider.isValidInteroperableName("alice.eth@eip155:1#ABCD1234", { validateChecksumFlag: true });
+     * const isValid = await InteropAddressProvider.isValidInteroperableName("alice.eth@eip155:1", { validateChecksumFlag: true });
      * ```
      */
     public static async isValidInteroperableName(
@@ -353,10 +353,10 @@ export class InteropAddressProvider {
      * @example
      * ```ts
      * // Get text representation (default)
-     * const result = await InteropAddressProvider.parseName("vitalik.eth@eip155:1#4CA88C9C");
+     * const result = await InteropAddressProvider.parseName("vitalik.eth@eip155:1");
      *
      * // Get binary representation
-     * const result2 = await InteropAddressProvider.parseName("vitalik.eth@eip155:1#4CA88C9C", { representation: "binary" });
+     * const result2 = await InteropAddressProvider.parseName("vitalik.eth@eip155:1", { representation: "binary" });
      * ```
      */
     public static parseName(
@@ -448,7 +448,7 @@ export class InteropAddressProvider {
  * @returns The binary address in the specified format
  * @example
  * ```ts
- * const binaryAddress = await nameToBinary("alice.eth@eip155:1#ABCD1234");
+ * const binaryAddress = await nameToBinary("alice.eth@eip155:1");
  * ```
  */
 export async function nameToBinary<T extends "hex" | "bytes" | undefined = undefined>(
@@ -477,7 +477,7 @@ export const binaryToName = InteropAddressProvider.binaryToName;
  * @returns The chain ID in the format of the chain type
  * @example
  * ```ts
- * const chainId = await getChainId("vitalik.eth@eip155:1#4CA88C9C");
+ * const chainId = await getChainId("vitalik.eth@eip155:1");
  * // Returns: "1"
  * ```
  */
@@ -490,7 +490,7 @@ export const getChainId = InteropAddressProvider.getChainId;
  * @returns The address in the format of the chain type
  * @example
  * ```ts
- * const address = await getAddress("vitalik.eth@eip155:1#4CA88C9C");
+ * const address = await getAddress("vitalik.eth@eip155:1");
  * // Returns: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
  * ```
  */
@@ -518,7 +518,7 @@ export const computeChecksum = InteropAddressProvider.computeChecksum;
  * @returns true if the address is a valid interop address, false otherwise
  * @example
  * ```ts
- * const isValid = await isValidInteropAddress("alice.eth@eip155:1#ABCD1234", { validateChecksumFlag: true });
+ * const isValid = await isValidInteropAddress("alice.eth@eip155:1", { validateChecksumFlag: true });
  * ```
  */
 export const isValidInteropAddress = InteropAddressProvider.isValidInteropAddress;
@@ -532,7 +532,7 @@ export const isValidInteropAddress = InteropAddressProvider.isValidInteropAddres
  * @returns true if the address is a valid interop address, false otherwise
  * @example
  * ```ts
- * const isValid = await isValidInteroperableName("alice.eth@eip155:1#ABCD1234", { validateChecksumFlag: true });
+ * const isValid = await isValidInteroperableName("alice.eth@eip155:1", { validateChecksumFlag: true });
  * ```
  */
 export const isValidInteroperableName = InteropAddressProvider.isValidInteroperableName;

--- a/packages/cross-chain/README.md
+++ b/packages/cross-chain/README.md
@@ -169,13 +169,10 @@ console.log(usdc?.decimals); // 6
 import { createAssetDiscoveryService } from "@wonderland/interop-cross-chain";
 
 const service = createAssetDiscoveryService(provider);
-if (!service) {
-    // Provider does not support asset discovery
-    return;
+if (service) {
+    const discovered = await service.getSupportedAssets();
+    const ethTokens = discovered.tokensByChain[1];
 }
-const discovered = await service.getSupportedAssets();
-
-const ethTokens = discovered.tokensByChain[1];
 ```
 
 **Key concepts:**

--- a/packages/cross-chain/README.md
+++ b/packages/cross-chain/README.md
@@ -169,7 +169,11 @@ console.log(usdc?.decimals); // 6
 import { createAssetDiscoveryService } from "@wonderland/interop-cross-chain";
 
 const service = createAssetDiscoveryService(provider);
-const discovered = await service.getSupportedAssets(); // Returns DiscoveredAssets directly
+if (!service) {
+    // Provider does not support asset discovery
+    return;
+}
+const discovered = await service.getSupportedAssets();
 
 const ethTokens = discovered.tokensByChain[1];
 ```


### PR DESCRIPTION
## Summary

- **Addresses docs rewrite**: Lead with the problem (addresses don't tell you which chain) instead of architecture. Add visual examples of both ERC-7828 and EIP-7930 formats. Clean up checksum fragments from all examples.
- **Fix broken exports**: 18 error classes and 4 functions (`resolveAddress`, `resolveChain`, `isValidChain`, `isValidChainType`) were documented but not exported from the public API. Anyone copying the docs would get import errors.
- **Fix doc accuracy**: Wrong field name in README (`address` → `interoperableAddress`), incomplete chainType list, missing null check in cross-chain example.
- **Add decision trees**: "Which function should I use?" tables for both packages. Provider config table and tracking requirements table for cross-chain.

## Test plan

- [x] `pnpm run build` passes for both packages
- [x] 242 addresses tests pass
- [x] Docs site builds cleanly
- [ ] Verify docs render correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)