### PR TITLE
Re-enable buildQuote tab in cross-chain UI

### DIFF
--- a/examples/ui/app/cross-chain/CrossChainClient.tsx
+++ b/examples/ui/app/cross-chain/CrossChainClient.tsx
@@ -22,8 +22,8 @@ import { useBuildQuote, BuildQuoteStatus } from './hooks/useBuildQuote';
 import { useQuotes, QuoteStatus } from './hooks/useQuotes';
 import { useDiscoveredAssets } from './providers';
 import { useFillWorkaround } from './services/orderExecution/fillDetection';
+import { useCrossChainStore, type SwapFormMode } from './stores/crossChainStore';
 import { STEP } from './types/execution';
-import type { SwapFormMode } from './components/SwapForm';
 import type { Address } from 'viem';
 
 interface ToastState {
@@ -66,7 +66,7 @@ export default function CrossChainClient() {
   const [outputChainId, setOutputChainId] = useState<number>(0);
   const [toast, setToast] = useState<ToastState | null>(null);
   const [lastQuoteParams, setLastQuoteParams] = useState<Parameters<typeof fetchQuotes>[0] | null>(null);
-  const [currentMode, setCurrentMode] = useState<SwapFormMode>('getQuotes');
+  const currentMode = useCrossChainStore((s) => s.mode);
   const isExecutionStarted = executionState.step !== STEP.IDLE;
 
   const effectiveQuotes: ExecutableQuote[] = currentMode === 'buildQuote' && builtQuote ? [builtQuote] : quotes;
@@ -97,7 +97,6 @@ export default function CrossChainClient() {
     setInputChainId(params.inputChainId);
     setOutputChainId(params.outputChainId);
     setSelectedQuote(null);
-    setCurrentMode(params.mode);
     resetExecution();
 
     if (params.mode === 'buildQuote') {

--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -63,8 +63,7 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
   const [recipient, setRecipient] = useState('');
   const hasAutoFilledRef = useRef(false);
   const [inputAmount, setInputAmount] = useState('');
-  // TODO: restore setMode when buildQuote tab is re-enabled (EFI-856)
-  const [mode] = useState<SwapFormMode>('getQuotes');
+  const [mode, setMode] = useState<SwapFormMode>('getQuotes');
   const [outputAmount, setOutputAmount] = useState('');
   const [fillDeadlineSecs, setFillDeadlineSecs] = useState(DEADLINE_OPTIONS[0].value);
 
@@ -232,7 +231,6 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
       <div className='relative flex flex-col gap-6'>
         <WalletConnect />
 
-        {/* TODO: re-enable once buildQuote simulation issues are resolved (EFI-856)
         <div className='flex border border-border/50 rounded-xl'>
           <button
             type='button'
@@ -265,7 +263,6 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
             Build Quote
           </button>
         </div>
-        */}
 
         <div>
           <label htmlFor='recipient-address' className='text-sm font-medium text-text-secondary mb-2 block'>

--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -8,11 +8,12 @@ import { MINT_AMOUNT, useMintToken } from '../hooks/useMintToken';
 import { useChainConfig, useTokenConfig } from '../hooks/useNetworkConfig';
 import { useRouteSelection } from '../hooks/useRouteSelection';
 import { useBalanceStore, type TokenBalance } from '../stores/balanceStore';
+import { useCrossChainStore, type SwapFormMode } from '../stores/crossChainStore';
 import { formatFee, isValidAmount, normalizeAmount, sanitizeAmountInput } from '../utils/amountValidation';
 import { TokenSelect } from './TokenSelect';
 import { WalletConnect } from './WalletConnect';
 
-export type SwapFormMode = 'getQuotes' | 'buildQuote';
+export type { SwapFormMode } from '../stores/crossChainStore';
 
 interface SwapFormSubmitParams {
   sender: string;
@@ -63,7 +64,8 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
   const [recipient, setRecipient] = useState('');
   const hasAutoFilledRef = useRef(false);
   const [inputAmount, setInputAmount] = useState('');
-  const [mode, setMode] = useState<SwapFormMode>('getQuotes');
+  const mode = useCrossChainStore((s) => s.mode);
+  const setMode = useCrossChainStore((s) => s.setMode);
   const [outputAmount, setOutputAmount] = useState('');
   const [fillDeadlineSecs, setFillDeadlineSecs] = useState(DEADLINE_OPTIONS[0].value);
 
@@ -190,6 +192,11 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
     onInputChange?.();
   };
 
+  const handleModeChange = (newMode: SwapFormMode) => {
+    setMode(newMode);
+    onInputChange?.();
+  };
+
   const handleOutputTokenChange = (address: string) => {
     setOutputToken(address);
     onInputChange?.();
@@ -235,10 +242,7 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
           <button
             type='button'
             disabled={isDisabled}
-            onClick={() => {
-              setMode('getQuotes');
-              onInputChange?.();
-            }}
+            onClick={() => handleModeChange('getQuotes')}
             className={`flex-1 px-4 py-2 rounded-l-xl text-sm font-medium transition-colors ${
               mode === 'getQuotes'
                 ? 'bg-accent text-white'
@@ -250,10 +254,7 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
           <button
             type='button'
             disabled={isDisabled}
-            onClick={() => {
-              setMode('buildQuote');
-              onInputChange?.();
-            }}
+            onClick={() => handleModeChange('buildQuote')}
             className={`flex-1 px-4 py-2 rounded-r-xl text-sm font-medium transition-colors ${
               mode === 'buildQuote'
                 ? 'bg-accent text-white'

--- a/examples/ui/app/cross-chain/hooks/useRouteSelection.ts
+++ b/examples/ui/app/cross-chain/hooks/useRouteSelection.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCrossChainStore } from '../stores/crossChainStore';
 import { readRouteParams, syncRouteParams } from '../utils/routeParams';
 import { createRouteSelector } from '../utils/routeSelection';
 import { useTokenConfig } from './useNetworkConfig';
@@ -10,8 +11,9 @@ import { useTokenConfig } from './useNetworkConfig';
  */
 export function useRouteSelection(defaultInputChainId: number, defaultOutputChainId: number) {
   const { SUPPORTED_TOKEN_BY_CHAIN_ID: byChain, TOKEN_INFO: tokenInfo } = useTokenConfig();
+  const mode = useCrossChainStore((s) => s.mode);
 
-  const selector = useMemo(() => createRouteSelector({ byChain, tokenInfo }), [byChain, tokenInfo]);
+  const selector = useMemo(() => createRouteSelector({ byChain, tokenInfo, mode }), [byChain, tokenInfo, mode]);
 
   const [selection, setSelection] = useState(() => {
     const urlParams = readRouteParams();

--- a/examples/ui/app/cross-chain/stores/crossChainStore.ts
+++ b/examples/ui/app/cross-chain/stores/crossChainStore.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand';
 import { buildExecutor } from '../services/sdk';
 import type { Aggregator } from '@wonderland/interop-cross-chain';
 
+export type SwapFormMode = 'getQuotes' | 'buildQuote';
+
 const TESTNET_QUERY_PARAM = 'testnet';
 
 function readIsTestnetFromUrl(): boolean {
@@ -12,7 +14,9 @@ function readIsTestnetFromUrl(): boolean {
 interface CrossChainState {
   isTestnet: boolean;
   executor: Aggregator;
+  mode: SwapFormMode;
   setIsTestnet: (isTestnet: boolean) => void;
+  setMode: (mode: SwapFormMode) => void;
 }
 
 const initialIsTestnet = readIsTestnetFromUrl();
@@ -20,6 +24,7 @@ const initialIsTestnet = readIsTestnetFromUrl();
 export const useCrossChainStore = create<CrossChainState>((set, get) => ({
   isTestnet: initialIsTestnet,
   executor: buildExecutor(initialIsTestnet),
+  mode: 'getQuotes',
 
   setIsTestnet: (isTestnet: boolean) => {
     if (isTestnet === get().isTestnet) return;
@@ -32,4 +37,6 @@ export const useCrossChainStore = create<CrossChainState>((set, get) => ({
     window.history.replaceState({}, '', url.toString());
     set({ isTestnet, executor: buildExecutor(isTestnet) });
   },
+
+  setMode: (mode: SwapFormMode) => set({ mode }),
 }));

--- a/examples/ui/app/cross-chain/utils/routeSelection.ts
+++ b/examples/ui/app/cross-chain/utils/routeSelection.ts
@@ -1,4 +1,5 @@
 import { findTokenCaseInsensitive, type RouteParams } from './routeParams';
+import type { SwapFormMode } from '../stores/crossChainStore';
 import type { UITokenInfo } from '../types/assets';
 
 /** Tokens shown in the demo app. Anything outside this list is hidden regardless of provider. */
@@ -22,6 +23,7 @@ export type TokenInfoByChain = Record<number, Record<string, UITokenInfo>>;
 export interface RouteConfig {
   byChain: TokensByChain;
   tokenInfo: TokenInfoByChain;
+  mode: SwapFormMode;
 }
 
 function isWhitelisted(token: UITokenInfo): boolean {
@@ -74,7 +76,7 @@ function resolveInitialOutputChain(
 }
 
 export function createRouteSelector(config: RouteConfig) {
-  const { byChain, tokenInfo } = config;
+  const { byChain, tokenInfo, mode } = config;
 
   function inputTokensFor(chainId: number): string[] {
     const addresses = byChain[chainId] ?? [];
@@ -86,7 +88,13 @@ export function createRouteSelector(config: RouteConfig) {
     const inputMeta = tokenInfo[inputChainId]?.[inputToken];
     const addresses = byChain[outputChainId] ?? [];
     const meta = tokenInfo[outputChainId] ?? {};
-    return compatibleTokens(addresses, meta, inputMeta?.providers ?? []);
+    const tokens = compatibleTokens(addresses, meta, inputMeta?.providers ?? []);
+
+    if (mode === 'buildQuote' && inputMeta?.symbol) {
+      return tokens.filter((addr) => meta[addr]?.symbol === inputMeta.symbol);
+    }
+
+    return tokens;
   }
 
   function bestOutputToken(

--- a/examples/ui/tests/cross-chain.spec.ts
+++ b/examples/ui/tests/cross-chain.spec.ts
@@ -236,8 +236,7 @@ test.describe('Address menu', () => {
   });
 });
 
-// TODO: re-enable when buildQuote tab is restored (EFI-856)
-test.describe.skip('Build quote fee display', () => {
+test.describe('Build quote fee display', () => {
   test('shows fee percentage for same-token with output < input', async ({ page }) => {
     await page.getByRole('button', { name: 'Build Quote' }).click();
 
@@ -277,8 +276,7 @@ test.describe.skip('Build quote fee display', () => {
   });
 });
 
-// TODO: re-enable when buildQuote tab is restored (EFI-856)
-test.describe.skip('Build Quote submit validation', () => {
+test.describe('Build Quote submit validation', () => {
   test('should disable submit when "You receive" is empty', async ({ page }) => {
     await expect(page.getByRole('textbox', { name: 'Amount' })).toBeVisible({ timeout: 15000 });
 


### PR DESCRIPTION
## Summary
- Restores the Get Quotes / Build Quote tab switcher that was disabled in #228 due to mainnet simulation issues
- Removes `test.describe.skip` from the two buildQuote test suites so they run in CI again

## Test plan
- [ ] Verify the tab switcher renders and toggles between Get Quotes and Build Quote modes
- [ ] Run `pnpm exec playwright test examples/ui/tests/cross-chain.spec.ts` and confirm the previously-skipped suites pass