### PR TITLE
feat(cross-chain): make buildQuote iterate all providers

### DIFF
--- a/.changeset/build-quote-multi-provider.md
+++ b/.changeset/build-quote-multi-provider.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+`buildQuote()` no longer requires a `providerId` — it iterates all providers in parallel and returns `GetQuotesResponse`

--- a/.changeset/build-quote-multi-provider.md
+++ b/.changeset/build-quote-multi-provider.md
@@ -2,4 +2,4 @@
 "@wonderland/interop-cross-chain": minor
 ---
 
-`buildQuote()` no longer requires a `providerId` — it iterates all providers in parallel and returns `GetQuotesResponse`
+`buildQuotes()` (renamed from `buildQuote()`) no longer requires a `providerId` — it iterates all providers in parallel and returns `GetQuotesResponse`

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -168,12 +168,12 @@ A class that manages multiple cross-chain providers and coordinates their operat
     response.errors.forEach((error) => console.error(error.errorMsg));
     ```
 
--   **buildQuote**(params: BuildQuoteRequest): Promise\<GetQuotesResponse\>
+-   **buildQuotes**(params: BuildQuoteRequest): Promise\<GetQuotesResponse\>
 
     Builds quotes locally without calling a solver API. Iterates all providers that implement `buildQuote` in parallel, returning sorted quotes and any provider errors. The user provides both amounts (controlling the fee) and a fill deadline. Providers that don't support this method are silently skipped.
 
     ```typescript
-    const response = await aggregator.buildQuote({
+    const response = await aggregator.buildQuotes({
         user: "0xYourAddress",
         input: { chainId: 11155111, assetAddress: "0xInputToken", amount: "1000000" },
         output: { chainId: 84532, assetAddress: "0xOutputToken", amount: "980000" },

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -168,18 +168,23 @@ A class that manages multiple cross-chain providers and coordinates their operat
     response.errors.forEach((error) => console.error(error.errorMsg));
     ```
 
--   **buildQuote**(providerId: string, params: BuildQuoteRequest): Promise\<ExecutableQuote\>
+-   **buildQuote**(params: BuildQuoteRequest): Promise\<GetQuotesResponse\>
 
-    Builds a quote locally for a specific provider without calling a solver API. The user provides both amounts (controlling the fee) and a fill deadline. The returned quote feeds into the same execution and tracking pipeline as API-fetched quotes.
+    Builds quotes locally without calling a solver API. Iterates all providers that implement `buildQuote` in parallel, returning sorted quotes and any provider errors. The user provides both amounts (controlling the fee) and a fill deadline. Providers that don't support this method are silently skipped.
 
     ```typescript
-    const quote = await aggregator.buildQuote("across", {
+    const response = await aggregator.buildQuote({
         user: "0xYourAddress",
         input: { chainId: 11155111, assetAddress: "0xInputToken", amount: "1000000" },
         output: { chainId: 84532, assetAddress: "0xOutputToken", amount: "980000" },
         escrowContractAddress: "0xSpokePoolAddress",
         fillDeadline: Math.floor(Date.now() / 1000) + 3600,
     });
+
+    if (response.quotes.length > 0) {
+        const bestQuote = response.quotes[0];
+    }
+    response.errors.forEach((error) => console.error(error.errorMsg));
     ```
 
 -   **submitOrder**(quote: ExecutableQuote, signatureOrResults: Hex | StepResult[]): Promise\<SubmitOrderResponse\>

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -151,7 +151,7 @@ response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`)
 | --------------------------------------- | ---------------------------------------------------------------------- |
 | Get quotes from one provider            | `provider.getQuotes(request)`                                          |
 | Get quotes from multiple providers      | `aggregator.getQuotes(request)`                                        |
-| Build a quote locally (no provider API) | `aggregator.buildQuote(providerId, request)`                           |
+| Build a quote locally (no provider API) | `aggregator.buildQuote(request)`                                       |
 | Submit a signed order                   | `provider.submitOrder(quote, signature)`                               |
 | Check if order is gasless               | `isSignatureOnlyOrder(quote.order)`                                    |
 | Get signature steps from an order       | `getSignatureSteps(quote.order)`                                       |

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -151,7 +151,7 @@ response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`)
 | --------------------------------------- | ---------------------------------------------------------------------- |
 | Get quotes from one provider            | `provider.getQuotes(request)`                                          |
 | Get quotes from multiple providers      | `aggregator.getQuotes(request)`                                        |
-| Build a quote locally (no provider API) | `aggregator.buildQuote(request)`                                       |
+| Build a quote locally (no provider API) | `aggregator.buildQuotes(request)`                                      |
 | Submit a signed order                   | `provider.submitOrder(quote, signature)`                               |
 | Check if order is gasless               | `isSignatureOnlyOrder(quote.order)`                                    |
 | Get signature steps from an order       | `getSignatureSteps(quote.order)`                                       |

--- a/examples/ui/app/cross-chain/CrossChainClient.tsx
+++ b/examples/ui/app/cross-chain/CrossChainClient.tsx
@@ -47,8 +47,8 @@ function mapBuildStatusToQuoteStatus(buildStatus: BuildQuoteStatus): QuoteStatus
 export default function CrossChainClient() {
   const { quotes, errors, status: quoteStatus, fetchQuotes, clearQuotes } = useQuotes();
   const {
-    quote: builtQuote,
-    error: buildError,
+    quotes: builtQuotes,
+    errors: buildErrors,
     status: buildStatus,
     buildQuote,
     clear: clearBuildQuote,
@@ -69,9 +69,8 @@ export default function CrossChainClient() {
   const [currentMode, setCurrentMode] = useState<SwapFormMode>('getQuotes');
   const isExecutionStarted = executionState.step !== STEP.IDLE;
 
-  const effectiveQuotes: ExecutableQuote[] = currentMode === 'buildQuote' && builtQuote ? [builtQuote] : quotes;
-  const effectiveErrors =
-    currentMode === 'buildQuote' && buildError ? [{ errorMsg: buildError, error: new Error(buildError) }] : errors;
+  const effectiveQuotes: ExecutableQuote[] = currentMode === 'buildQuote' ? builtQuotes : quotes;
+  const effectiveErrors = currentMode === 'buildQuote' ? buildErrors : errors;
   const effectiveStatus = currentMode === 'buildQuote' ? mapBuildStatusToQuoteStatus(buildStatus) : quoteStatus;
 
   const closeToast = useCallback(() => {

--- a/examples/ui/app/cross-chain/hooks/useBuildQuote.ts
+++ b/examples/ui/app/cross-chain/hooks/useBuildQuote.ts
@@ -86,7 +86,7 @@ export function useBuildQuote(): UseBuildQuoteReturn {
         fillDeadline,
       };
 
-      const response = await executor.buildQuote(request);
+      const response = await executor.buildQuotes(request);
       if (requestIdRef.current !== currentRequestId) return;
 
       if (response.quotes?.length) {
@@ -96,6 +96,9 @@ export function useBuildQuote(): UseBuildQuoteReturn {
       if (response.errors?.length) {
         setErrors(response.errors);
       }
+
+      if (requestIdRef.current !== currentRequestId) return;
+      setStatus(BuildQuoteStatus.SUCCESS);
     } catch (err) {
       if (requestIdRef.current !== currentRequestId) return;
       setStatus(BuildQuoteStatus.ERROR);
@@ -105,11 +108,7 @@ export function useBuildQuote(): UseBuildQuoteReturn {
           error: err instanceof Error ? err : new Error(String(err)),
         },
       ]);
-      return;
     }
-
-    if (requestIdRef.current !== currentRequestId) return;
-    setStatus(BuildQuoteStatus.SUCCESS);
   };
 
   const clear = useCallback(() => {

--- a/examples/ui/app/cross-chain/hooks/useBuildQuote.ts
+++ b/examples/ui/app/cross-chain/hooks/useBuildQuote.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef } from 'react';
 import { useCrossChainStore } from '../stores/crossChainStore';
 import { convertAmountToSmallestUnit } from '../utils/amountConverter';
 import { useTokenConfig } from './useNetworkConfig';
+import type { GetQuotesError } from './useQuotes';
 import type { ExecutableQuote, BuildQuoteRequest } from '@wonderland/interop-cross-chain';
 
 const DEFAULT_FILL_DEADLINE_SECS = 3600; // 1 hour
@@ -26,8 +27,8 @@ export enum BuildQuoteStatus {
 }
 
 interface UseBuildQuoteReturn {
-  quote: ExecutableQuote | null;
-  error: string | null;
+  quotes: ExecutableQuote[];
+  errors: GetQuotesError[];
   status: BuildQuoteStatus;
   buildQuote: (params: BuildQuoteParams) => Promise<void>;
   clear: () => void;
@@ -36,16 +37,16 @@ interface UseBuildQuoteReturn {
 export function useBuildQuote(): UseBuildQuoteReturn {
   const executor = useCrossChainStore((s) => s.executor);
   const tokenConfig = useTokenConfig();
-  const [quote, setQuote] = useState<ExecutableQuote | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [quotes, setQuotes] = useState<ExecutableQuote[]>([]);
+  const [errors, setErrors] = useState<GetQuotesError[]>([]);
   const [status, setStatus] = useState<BuildQuoteStatus>(BuildQuoteStatus.IDLE);
   const requestIdRef = useRef(0);
 
   const buildQuote = async (params: BuildQuoteParams) => {
     const currentRequestId = ++requestIdRef.current;
     setStatus(BuildQuoteStatus.LOADING);
-    setQuote(null);
-    setError(null);
+    setQuotes([]);
+    setErrors([]);
 
     try {
       const inputTokenInfo = tokenConfig.TOKEN_INFO[params.inputChainId] ?? {};
@@ -85,23 +86,38 @@ export function useBuildQuote(): UseBuildQuoteReturn {
         fillDeadline,
       };
 
-      const result = await executor.buildQuote('across', request);
+      const response = await executor.buildQuote(request);
       if (requestIdRef.current !== currentRequestId) return;
-      setQuote(result);
-      setStatus(BuildQuoteStatus.SUCCESS);
+
+      if (response.quotes?.length) {
+        setQuotes(response.quotes);
+      }
+
+      if (response.errors?.length) {
+        setErrors(response.errors);
+      }
     } catch (err) {
       if (requestIdRef.current !== currentRequestId) return;
       setStatus(BuildQuoteStatus.ERROR);
-      setError(err instanceof Error ? err.message : String(err));
+      setErrors([
+        {
+          errorMsg: err instanceof Error ? err.message : String(err),
+          error: err instanceof Error ? err : new Error(String(err)),
+        },
+      ]);
+      return;
     }
+
+    if (requestIdRef.current !== currentRequestId) return;
+    setStatus(BuildQuoteStatus.SUCCESS);
   };
 
   const clear = useCallback(() => {
     requestIdRef.current++;
-    setQuote(null);
-    setError(null);
+    setQuotes([]);
+    setErrors([]);
     setStatus(BuildQuoteStatus.IDLE);
   }, []);
 
-  return { quote, error, status, buildQuote, clear };
+  return { quotes, errors, status, buildQuote, clear };
 }

--- a/examples/ui/app/cross-chain/utils/errorMessages.ts
+++ b/examples/ui/app/cross-chain/utils/errorMessages.ts
@@ -133,6 +133,20 @@ const ERROR_PATTERNS: Array<{ pattern: RegExp; result: ParsedError }> = [
     },
   },
   {
+    pattern: /SameChainIntentNotAllowed|same-chain intents/i,
+    result: {
+      title: 'Same Chain Not Allowed',
+      message: 'Cross-chain quotes require different origin and destination chains.',
+    },
+  },
+  {
+    pattern: /DifferentAssetNotAllowed|same-asset transfers/i,
+    result: {
+      title: 'Different Asset Not Allowed',
+      message: 'Build quote only supports same-asset transfers. Use get quotes for cross-token swaps.',
+    },
+  },
+  {
     pattern: /execution reverted/i,
     result: {
       title: 'Transaction Failed',

--- a/packages/cross-chain/README.md
+++ b/packages/cross-chain/README.md
@@ -134,7 +134,7 @@ if (selectedQuote) {
     -   Config: `{ providers: CrossChainProvider[], sortingStrategy?, timeoutMs?, trackerFactory? }`
 -   `Aggregator`
     -   `.getQuotes(params: QuoteRequest)` -- Get quotes from all providers. Returns `{ quotes: ExecutableQuote[], errors: GetQuotesError[] }`.
-    -   `.buildQuote(providerId, params: BuildQuoteRequest)` -- Build a quote locally for a specific provider without calling a solver API.
+    -   `.buildQuotes(params: BuildQuoteRequest)` -- Build quotes locally from all providers without calling a solver API.
     -   `.submitOrder(quote, signature)` -- Submit a signed order.
     -   `.prepareTracking(providerId)` -- Prepare order tracking for a provider.
     -   `.track(params)` -- Track an existing transaction.

--- a/packages/cross-chain/src/core/errors/DifferentAssetNotAllowed.exception.ts
+++ b/packages/cross-chain/src/core/errors/DifferentAssetNotAllowed.exception.ts
@@ -1,8 +1,8 @@
-/** Thrown when buildQuote is called with different input and output assets. */
+/** Thrown when buildQuotes is called with different input and output assets. */
 export class DifferentAssetNotAllowed extends Error {
     constructor() {
         super(
-            "buildQuote only supports same-asset transfers. Cross-token swaps are supported through getQuotes(), where solvers handle pricing and fee calculation.",
+            "buildQuotes only supports same-asset transfers. Cross-token swaps are supported through getQuotes(), where solvers handle pricing and fee calculation.",
         );
         this.name = "DifferentAssetNotAllowed";
     }

--- a/packages/cross-chain/src/core/errors/SameChainIntentNotAllowed.exception.ts
+++ b/packages/cross-chain/src/core/errors/SameChainIntentNotAllowed.exception.ts
@@ -1,7 +1,7 @@
-/** Thrown when buildQuote is called with the same asset on the same chain. */
+/** Thrown when buildQuotes is called with the same asset on the same chain. */
 export class SameChainIntentNotAllowed extends Error {
     constructor() {
-        super("buildQuote does not support same-chain intents. Use a direct transfer instead.");
+        super("buildQuotes does not support same-chain intents. Use a direct transfer instead.");
         this.name = "SameChainIntentNotAllowed";
     }
 }

--- a/packages/cross-chain/src/core/services/aggregator.ts
+++ b/packages/cross-chain/src/core/services/aggregator.ts
@@ -129,6 +129,16 @@ class Aggregator {
         }
     }
 
+    private withTimeout<T>(promise: Promise<T>): Promise<T> {
+        let timeout: NodeJS.Timeout;
+        const timeoutPromise = new Promise<never>((_, reject) => {
+            timeout = setTimeout(() => {
+                reject(new ProviderTimeout(`Timeout after ${this.timeoutMs}ms`));
+            }, this.timeoutMs);
+        });
+        return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timeout));
+    }
+
     private splitQuotesAndErrors(quotes: (ExecutableQuote | GetQuotesError)[]): GetQuotesResponse {
         return {
             quotes: quotes.filter((quote) => "order" in quote) as ExecutableQuote[],
@@ -224,8 +234,23 @@ class Aggregator {
         return provider.submitOrder(quote, signature);
     }
 
+    private async fetchBuildQuoteFromProvider(
+        provider: CrossChainProvider,
+        params: BuildQuoteRequest,
+    ): Promise<ExecutableQuote> {
+        if (!params.allowDangerousParameters) {
+            const isSupported = await this.supportsRequestedAssets(provider, params);
+            if (!isSupported) {
+                throw new ProviderExecuteNotImplemented("Asset not supported");
+            }
+        }
+
+        const quote = await this.withTimeout(provider.buildQuote(params));
+        return { ...quote, _providerId: provider.getProviderId() };
+    }
+
     /**
-     * Build a quote locally without calling a solver API.
+     * Build quotes locally without calling a solver API.
      *
      * Iterates all registered providers that implement `buildQuote`,
      * collecting results in parallel (same pattern as {@link getQuotes}).
@@ -235,52 +260,30 @@ class Aggregator {
      * @returns Sorted quotes and any provider errors
      * @throws ZeroAmount, InsufficientFee, InvalidDeadline, SameChainIntentNotAllowed, DifferentAssetNotAllowed for invalid request parameters
      */
-    async buildQuote(params: BuildQuoteRequest): Promise<GetQuotesResponse> {
+    async buildQuotes(params: BuildQuoteRequest): Promise<GetQuotesResponse> {
         const discovered = await this.discoverAssets();
         validateBuildQuoteParams(params, discovered.tokenMetadata);
 
-        const resultQuotes = await Promise.all(
-            Object.values(this.providers).map(async (provider) => {
-                try {
-                    if (!params.allowDangerousParameters) {
-                        const isSupported = await this.supportsRequestedAssets(provider, params);
-                        if (!isSupported) {
-                            return [];
-                        }
-                    }
+        const settled = await Promise.allSettled(
+            Object.values(this.providers).map((provider) =>
+                this.fetchBuildQuoteFromProvider(provider, params),
+            ),
+        );
 
-                    const quotePromise = provider.buildQuote(params).then(
-                        (quote): ExecutableQuote => ({
-                            ...quote,
-                            _providerId: provider.getProviderId(),
-                        }),
-                    );
-
-                    let timeout: NodeJS.Timeout;
-
-                    const timeoutPromise = new Promise<never>((_, reject) => {
-                        timeout = setTimeout(() => {
-                            reject(new ProviderTimeout(`Timeout after ${this.timeoutMs}ms`));
-                        }, this.timeoutMs);
-                    });
-
-                    return await Promise.race([quotePromise, timeoutPromise]).finally(() => {
-                        clearTimeout(timeout);
-                    });
-                } catch (error) {
-                    if (error instanceof ProviderExecuteNotImplemented) {
-                        return [];
-                    }
-                    if (error instanceof ProviderTimeout) {
-                        return { error: error, errorMsg: error.message };
-                    }
-                    return {
-                        error: new Error(String(error)),
-                        errorMsg: (error as Error)?.message ?? "Unknown error",
-                    };
+        const resultQuotes = settled
+            .map((result) => {
+                if (result.status === "fulfilled") return result.value;
+                const error = result.reason;
+                if (error instanceof ProviderExecuteNotImplemented) return null;
+                if (error instanceof ProviderTimeout) {
+                    return { error, errorMsg: error.message } as GetQuotesError;
                 }
-            }),
-        ).then((results) => results.flat());
+                return {
+                    error: new Error(String(error)),
+                    errorMsg: (error as Error)?.message ?? "Unknown error",
+                } as GetQuotesError;
+            })
+            .filter((item): item is ExecutableQuote | GetQuotesError => item !== null);
 
         const response = this.splitQuotesAndErrors(resultQuotes);
 

--- a/packages/cross-chain/src/core/services/aggregator.ts
+++ b/packages/cross-chain/src/core/services/aggregator.ts
@@ -16,16 +16,14 @@ import type {
 } from "../types/assetDiscovery.js";
 import type { OrderTrackingInfo, WatchOrderParams } from "../types/orderTracking.js";
 import { AssetDiscoveryFailure } from "../errors/AssetDiscoveryFailure.exception.js";
+import { ProviderExecuteNotImplemented } from "../errors/ProviderExecuteNotImplemented.exception.js";
 import { ProviderNotFound } from "../errors/ProviderNotFound.exception.js";
 import { ProviderTimeout } from "../errors/ProviderTimeout.exception.js";
 import { CrossChainProvider } from "../interfaces/crossChainProvider.interface.js";
 import { SortingStrategy } from "../interfaces/sortingStrategy.interface.js";
 import { BestOutputStrategy } from "../sorting_strategies/bestOutput.strategy.js";
 import { mergeDiscoveredAssets } from "../utils/toDiscoveredAssets.js";
-import {
-    validateAssetSupport,
-    validateBuildQuoteParams,
-} from "../validators/buildQuoteValidator.js";
+import { validateBuildQuoteParams } from "../validators/buildQuoteValidator.js";
 import { OrderTracker } from "./OrderTracker.js";
 
 interface AggregatorConfig {
@@ -229,28 +227,67 @@ class Aggregator {
     /**
      * Build a quote locally without calling a solver API.
      *
-     * Routes the request to the specified provider's `buildQuote` implementation.
-     * The returned quote contains a TransactionStep that the consumer can execute
-     * directly via `walletClient.sendTransaction`.
+     * Iterates all registered providers that implement `buildQuote`,
+     * collecting results in parallel (same pattern as {@link getQuotes}).
+     * Providers that do not implement the method are silently skipped.
      *
-     * @param providerId - The provider to use for building the quote
      * @param params - The build quote request with required amounts and contract address
-     * @returns An executable quote containing a TransactionStep
+     * @returns Sorted quotes and any provider errors
+     * @throws ZeroAmount, InsufficientFee, InvalidDeadline for invalid request parameters
      */
-    async buildQuote(providerId: string, params: BuildQuoteRequest): Promise<ExecutableQuote> {
-        const provider = this.providers[providerId];
-        if (!provider) {
-            throw new ProviderNotFound(providerId);
-        }
-
+    async buildQuote(params: BuildQuoteRequest): Promise<GetQuotesResponse> {
         const discovered = await this.discoverAssets();
         validateBuildQuoteParams(params, discovered.tokenMetadata);
 
-        const isSupported = await this.supportsRequestedAssets(provider, params);
-        validateAssetSupport(params, providerId, isSupported);
+        const resultQuotes = await Promise.all(
+            Object.values(this.providers).map(async (provider) => {
+                try {
+                    if (!params.allowDangerousParameters) {
+                        const isSupported = await this.supportsRequestedAssets(provider, params);
+                        if (!isSupported) {
+                            return [];
+                        }
+                    }
 
-        const quote = await provider.buildQuote(params);
-        return { ...quote, _providerId: providerId };
+                    const quotePromise = provider.buildQuote(params).then(
+                        (quote): ExecutableQuote => ({
+                            ...quote,
+                            _providerId: provider.getProviderId(),
+                        }),
+                    );
+
+                    let timeout: NodeJS.Timeout;
+
+                    const timeoutPromise = new Promise<never>((_, reject) => {
+                        timeout = setTimeout(() => {
+                            reject(new ProviderTimeout(`Timeout after ${this.timeoutMs}ms`));
+                        }, this.timeoutMs);
+                    });
+
+                    return await Promise.race([quotePromise, timeoutPromise]).finally(() => {
+                        clearTimeout(timeout);
+                    });
+                } catch (error) {
+                    if (error instanceof ProviderExecuteNotImplemented) {
+                        return [];
+                    }
+                    if (error instanceof ProviderTimeout) {
+                        return { error: error, errorMsg: error.message };
+                    }
+                    return {
+                        error: new Error(String(error)),
+                        errorMsg: (error as Error)?.message ?? "Unknown error",
+                    };
+                }
+            }),
+        ).then((results) => results.flat());
+
+        const response = this.splitQuotesAndErrors(resultQuotes);
+
+        return {
+            quotes: this.sortingStrategy.sort(response.quotes),
+            errors: response.errors,
+        };
     }
 
     /**

--- a/packages/cross-chain/src/core/services/aggregator.ts
+++ b/packages/cross-chain/src/core/services/aggregator.ts
@@ -233,7 +233,7 @@ class Aggregator {
      *
      * @param params - The build quote request with required amounts and contract address
      * @returns Sorted quotes and any provider errors
-     * @throws ZeroAmount, InsufficientFee, InvalidDeadline for invalid request parameters
+     * @throws ZeroAmount, InsufficientFee, InvalidDeadline, SameChainIntentNotAllowed, DifferentAssetNotAllowed for invalid request parameters
      */
     async buildQuote(params: BuildQuoteRequest): Promise<GetQuotesResponse> {
         const discovered = await this.discoverAssets();

--- a/packages/cross-chain/src/core/validators/buildQuoteValidator.ts
+++ b/packages/cross-chain/src/core/validators/buildQuoteValidator.ts
@@ -3,7 +3,6 @@ import { DifferentAssetNotAllowed } from "../errors/DifferentAssetNotAllowed.exc
 import { InsufficientFee } from "../errors/InsufficientFee.exception.js";
 import { InvalidDeadline } from "../errors/InvalidDeadline.exception.js";
 import { SameChainIntentNotAllowed } from "../errors/SameChainIntentNotAllowed.exception.js";
-import { UnsupportedAsset } from "../errors/UnsupportedAsset.exception.js";
 import { ZeroAmount } from "../errors/ZeroAmount.exception.js";
 
 /** Minimum seconds between now and fillDeadline. */
@@ -112,28 +111,4 @@ function resolveAssetRelationship(
 
     if (inputSymbol === undefined || outputSymbol === undefined) return "unknown";
     return inputSymbol === outputSymbol ? "same" : "different";
-}
-
-// ── Asset support ──────────────────────────────────────────────────
-
-/**
- * Validates that the provider supports the requested assets.
- *
- * Skipped when `allowDangerousParameters` is set on the request.
- *
- * @param params - The build quote request to validate
- * @param providerId - The provider being targeted
- * @param isSupported - Pre-resolved result from the discovery cache
- * @throws UnsupportedAsset if the provider does not support the requested asset
- */
-export function validateAssetSupport(
-    params: BuildQuoteRequest,
-    providerId: string,
-    isSupported: boolean,
-): void {
-    if (params.allowDangerousParameters) return;
-
-    if (!isSupported) {
-        throw new UnsupportedAsset(providerId, params.input, params.output);
-    }
 }

--- a/packages/cross-chain/test/services/aggregator.buildQuote.spec.ts
+++ b/packages/cross-chain/test/services/aggregator.buildQuote.spec.ts
@@ -3,14 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Quote } from "../../src/core/schemas/quote.js";
 import type { BuildQuoteRequest } from "../../src/core/schemas/quoteRequest.js";
-import { Aggregator, createAggregator } from "../../src/external.js";
+import { createAggregator } from "../../src/external.js";
 import {
-    AssetDiscoveryFailure,
     CrossChainProvider,
     InsufficientFee,
     InvalidDeadline,
-    ProviderNotFound,
-    UnsupportedAsset,
+    ProviderExecuteNotImplemented,
     ZeroAmount,
 } from "../../src/internal.js";
 
@@ -63,8 +61,7 @@ const FULL_DISCOVERY_CONFIG = {
 
 function createMockProvider(
     providerId: string,
-    discoveryConfig: ReturnType<CrossChainProvider["getDiscoveryConfig"]> = null,
-    buildQuoteResult: Quote = MOCK_QUOTE,
+    discoveryConfig: ReturnType<CrossChainProvider["getDiscoveryConfig"]> = FULL_DISCOVERY_CONFIG,
 ): CrossChainProvider {
     return {
         protocolName: providerId,
@@ -72,9 +69,8 @@ function createMockProvider(
         getProviderId: vi.fn(() => providerId),
         getProtocolName: vi.fn(() => providerId),
         getQuotes: vi.fn(() => Promise.resolve([])),
-        buildQuote: vi.fn(() => Promise.resolve(buildQuoteResult)),
+        buildQuote: vi.fn(() => Promise.resolve(MOCK_QUOTE)),
         submitOrder: vi.fn(),
-        submitSignedOrder: vi.fn(),
         getTrackingConfig: vi.fn(),
         getDiscoveryConfig: vi.fn(() => discoveryConfig),
     } as unknown as CrossChainProvider;
@@ -96,30 +92,23 @@ describe("Aggregator - buildQuote", () => {
         vi.clearAllMocks();
     });
 
-    it("returns quote with _providerId appended", async () => {
-        const provider = createMockProvider("across", FULL_DISCOVERY_CONFIG);
-        const aggregator = createAggregator({ providers: [provider] });
-        const params = buildParams();
-
-        const result = await aggregator.buildQuote("across", params);
-
-        expect(result._providerId).toBe("across");
-        expect(result.order).toEqual(MOCK_QUOTE.order);
-        expect(result.preview).toEqual(MOCK_QUOTE.preview);
-        expect(provider.buildQuote).toHaveBeenCalledWith(params);
-    });
-
-    it("throws ProviderNotFound for unknown provider", async () => {
-        const provider = createMockProvider("across", FULL_DISCOVERY_CONFIG);
-        const aggregator = createAggregator({ providers: [provider] });
-
-        await expect(aggregator.buildQuote("unknown", buildParams())).rejects.toThrow(
-            ProviderNotFound,
+    it("collects quotes from all supporting providers, skipping not-implemented ones", async () => {
+        const across = createMockProvider("across");
+        const oif = createMockProvider("oif");
+        const relay = createMockProvider("relay");
+        (relay.buildQuote as ReturnType<typeof vi.fn>).mockRejectedValue(
+            new ProviderExecuteNotImplemented("relay"),
         );
+        const aggregator = createAggregator({ providers: [across, oif, relay] });
+
+        const result = await aggregator.buildQuote(buildParams());
+
+        expect(result.quotes.map((q) => q._providerId)).toEqual(["across", "oif"]);
+        expect(result.errors).toHaveLength(0);
     });
 
-    it("throws UnsupportedAsset when provider lacks the requested route", async () => {
-        const across = createMockProvider("across", {
+    it("skips providers that do not support the requested assets", async () => {
+        const partial = createMockProvider("across", {
             type: "static",
             config: {
                 networks: [
@@ -127,88 +116,59 @@ describe("Aggregator - buildQuote", () => {
                 ],
             },
         });
-        const helper = createMockProvider("helper", FULL_DISCOVERY_CONFIG);
-        const aggregator = createAggregator({ providers: [across, helper] });
+        const full = createMockProvider("oif");
+        const aggregator = createAggregator({ providers: [partial, full] });
 
-        await expect(aggregator.buildQuote("across", buildParams())).rejects.toThrow(
-            UnsupportedAsset,
-        );
-        expect(across.buildQuote).not.toHaveBeenCalled();
+        const result = await aggregator.buildQuote(buildParams());
+
+        expect(result.quotes).toHaveLength(1);
+        expect(result.quotes[0]._providerId).toBe("oif");
+        expect(partial.buildQuote).not.toHaveBeenCalled();
     });
 
-    it("builds quote without discoveryFactory using allowDangerousParameters", async () => {
+    it("captures provider errors in errors array", async () => {
+        const failing = createMockProvider("across");
+        (failing.buildQuote as ReturnType<typeof vi.fn>).mockRejectedValue(
+            new Error("provider failure"),
+        );
+        const working = createMockProvider("oif");
+        const aggregator = createAggregator({ providers: [failing, working] });
+
+        const result = await aggregator.buildQuote(buildParams());
+
+        expect(result.quotes).toHaveLength(1);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].errorMsg).toContain("provider failure");
+    });
+
+    it.each([
+        {
+            label: "ZeroAmount",
+            overrides: { input: { chainId: 1, assetAddress: USDC_ETH, amount: "0" } },
+            expectedError: ZeroAmount,
+        },
+        {
+            label: "InvalidDeadline",
+            overrides: { fillDeadline: Math.floor(Date.now() / 1000) - 100 },
+            expectedError: InvalidDeadline,
+        },
+        {
+            label: "InsufficientFee",
+            overrides: {
+                input: { chainId: 1, assetAddress: USDC_ETH, amount: "1000000" },
+                output: { chainId: 10, assetAddress: USDC_OPT, amount: "1000000" },
+            },
+            expectedError: InsufficientFee,
+        },
+    ])("throws $label before calling any provider", async ({ overrides, expectedError }) => {
         const provider = createMockProvider("across");
-        const aggregator = new Aggregator({ providers: [provider] });
-        const params = buildParams({ allowDangerousParameters: true });
-
-        const result = await aggregator.buildQuote("across", params);
-
-        expect(result._providerId).toBe("across");
-        expect(provider.buildQuote).toHaveBeenCalledWith(params);
-    });
-
-    it("falls back gracefully when discovery throws AssetDiscoveryFailure", async () => {
-        const provider = createMockProvider("across", FULL_DISCOVERY_CONFIG);
         const aggregator = createAggregator({ providers: [provider] });
 
-        const cache = (
-            aggregator as unknown as {
-                discoveryCache: Map<
-                    string,
-                    { isAssetSupported: (...args: unknown[]) => Promise<unknown> }
-                >;
-            }
-        ).discoveryCache;
-        const service = cache.get("across")!;
-        vi.spyOn(service, "isAssetSupported").mockRejectedValue(
-            new AssetDiscoveryFailure("boom", "discovery failed"),
-        );
-
-        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-        const params = buildParams();
-
-        const result = await aggregator.buildQuote("across", params);
-
-        expect(result._providerId).toBe("across");
-        expect(provider.buildQuote).toHaveBeenCalledWith(params);
-        expect(warnSpy).toHaveBeenCalled();
-
-        warnSpy.mockRestore();
-    });
-
-    it("propagates ZeroAmount from validation", async () => {
-        const provider = createMockProvider("across", FULL_DISCOVERY_CONFIG);
-        const aggregator = createAggregator({ providers: [provider] });
-        const params = buildParams({
-            input: { chainId: 1, assetAddress: USDC_ETH, amount: "0" },
-        });
-
-        await expect(aggregator.buildQuote("across", params)).rejects.toThrow(ZeroAmount);
+        await expect(aggregator.buildQuote(buildParams(overrides))).rejects.toThrow(expectedError);
         expect(provider.buildQuote).not.toHaveBeenCalled();
     });
 
-    it("propagates InvalidDeadline for past deadline", async () => {
-        const provider = createMockProvider("across", FULL_DISCOVERY_CONFIG);
-        const aggregator = createAggregator({ providers: [provider] });
-        const params = buildParams({ fillDeadline: Math.floor(Date.now() / 1000) - 100 });
-
-        await expect(aggregator.buildQuote("across", params)).rejects.toThrow(InvalidDeadline);
-        expect(provider.buildQuote).not.toHaveBeenCalled();
-    });
-
-    it("propagates InsufficientFee when output >= input on same asset", async () => {
-        const provider = createMockProvider("across", FULL_DISCOVERY_CONFIG);
-        const aggregator = createAggregator({ providers: [provider] });
-        const params = buildParams({
-            input: { chainId: 1, assetAddress: USDC_ETH, amount: "1000000" },
-            output: { chainId: 10, assetAddress: USDC_OPT, amount: "1000000" },
-        });
-
-        await expect(aggregator.buildQuote("across", params)).rejects.toThrow(InsufficientFee);
-        expect(provider.buildQuote).not.toHaveBeenCalled();
-    });
-
-    it("allowDangerousParameters bypasses all validation", async () => {
+    it("allowDangerousParameters bypasses validation and asset support checks", async () => {
         const provider = createMockProvider("across", {
             type: "static",
             config: { networks: [] },
@@ -221,9 +181,9 @@ describe("Aggregator - buildQuote", () => {
             allowDangerousParameters: true,
         });
 
-        const result = await aggregator.buildQuote("across", params);
+        const result = await aggregator.buildQuote(params);
 
-        expect(result._providerId).toBe("across");
+        expect(result.quotes).toHaveLength(1);
         expect(provider.buildQuote).toHaveBeenCalledWith(params);
     });
 });

--- a/packages/cross-chain/test/services/aggregator.buildQuotes.spec.ts
+++ b/packages/cross-chain/test/services/aggregator.buildQuotes.spec.ts
@@ -87,7 +87,7 @@ function buildParams(overrides?: Partial<BuildQuoteRequest>): BuildQuoteRequest 
     };
 }
 
-describe("Aggregator - buildQuote", () => {
+describe("Aggregator - buildQuotes", () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
@@ -101,7 +101,7 @@ describe("Aggregator - buildQuote", () => {
         );
         const aggregator = createAggregator({ providers: [across, oif, relay] });
 
-        const result = await aggregator.buildQuote(buildParams());
+        const result = await aggregator.buildQuotes(buildParams());
 
         expect(result.quotes.map((q) => q._providerId)).toEqual(["across", "oif"]);
         expect(result.errors).toHaveLength(0);
@@ -119,7 +119,7 @@ describe("Aggregator - buildQuote", () => {
         const full = createMockProvider("oif");
         const aggregator = createAggregator({ providers: [partial, full] });
 
-        const result = await aggregator.buildQuote(buildParams());
+        const result = await aggregator.buildQuotes(buildParams());
 
         expect(result.quotes).toHaveLength(1);
         expect(result.quotes[0]._providerId).toBe("oif");
@@ -134,7 +134,7 @@ describe("Aggregator - buildQuote", () => {
         const working = createMockProvider("oif");
         const aggregator = createAggregator({ providers: [failing, working] });
 
-        const result = await aggregator.buildQuote(buildParams());
+        const result = await aggregator.buildQuotes(buildParams());
 
         expect(result.quotes).toHaveLength(1);
         expect(result.errors).toHaveLength(1);
@@ -164,7 +164,7 @@ describe("Aggregator - buildQuote", () => {
         const provider = createMockProvider("across");
         const aggregator = createAggregator({ providers: [provider] });
 
-        await expect(aggregator.buildQuote(buildParams(overrides))).rejects.toThrow(expectedError);
+        await expect(aggregator.buildQuotes(buildParams(overrides))).rejects.toThrow(expectedError);
         expect(provider.buildQuote).not.toHaveBeenCalled();
     });
 
@@ -181,7 +181,7 @@ describe("Aggregator - buildQuote", () => {
             allowDangerousParameters: true,
         });
 
-        const result = await aggregator.buildQuote(params);
+        const result = await aggregator.buildQuotes(params);
 
         expect(result.quotes).toHaveLength(1);
         expect(provider.buildQuote).toHaveBeenCalledWith(params);

--- a/packages/cross-chain/test/validators/buildQuoteValidator.spec.ts
+++ b/packages/cross-chain/test/validators/buildQuoteValidator.spec.ts
@@ -7,11 +7,9 @@ import { DifferentAssetNotAllowed } from "../../src/core/errors/DifferentAssetNo
 import { InsufficientFee } from "../../src/core/errors/InsufficientFee.exception.js";
 import { InvalidDeadline } from "../../src/core/errors/InvalidDeadline.exception.js";
 import { SameChainIntentNotAllowed } from "../../src/core/errors/SameChainIntentNotAllowed.exception.js";
-import { UnsupportedAsset } from "../../src/core/errors/UnsupportedAsset.exception.js";
 import { ZeroAmount } from "../../src/core/errors/ZeroAmount.exception.js";
 import {
     MIN_DEADLINE_BUFFER_SECONDS,
-    validateAssetSupport,
     validateBuildQuoteParams,
 } from "../../src/core/validators/buildQuoteValidator.js";
 
@@ -191,23 +189,6 @@ describe("validateBuildQuoteParams", () => {
 
         it("accepts far future deadline", () => {
             expect(() => validate(buildParams({ fillDeadline: NOW + 86400 }))).not.toThrow();
-        });
-    });
-
-    describe("asset support", () => {
-        it("rejects token the provider does not support", () => {
-            const params = buildParams();
-            expect(() => validateAssetSupport(params, "across", false)).toThrow(UnsupportedAsset);
-        });
-
-        it("accepts token the provider supports", () => {
-            const params = buildParams();
-            expect(() => validateAssetSupport(params, "across", true)).not.toThrow();
-        });
-
-        it("skips validation when allowDangerousParameters is set", () => {
-            const params = buildParams({ allowDangerousParameters: true });
-            expect(() => validateAssetSupport(params, "across", false)).not.toThrow();
         });
     });
 


### PR DESCRIPTION
## Summary

`buildQuote` no longer requires a `providerId`. It now iterates all registered providers in parallel and returns a `GetQuotesResponse`, matching `getQuotes`.

Providers without `buildQuote` are skipped via `ProviderExecuteNotImplemented`.

### Error handling changes

**Removed:** `ProviderNotFound`, `UnsupportedAsset`

**Added** (via `validateBuildQuoteParams`, before any provider runs — skipped with `allowDangerousParameters`):
- `ZeroAmount` — amount is zero
- `InvalidDeadline` — deadline in the past or < 60s from now
- `SameChainIntentNotAllowed` — same chain
- `DifferentAssetNotAllowed` — different assets or missing metadata
- `InsufficientFee` — output amount ≥ input amount

```mermaid
classDiagram
    class Aggregator {
        +getQuotes(params: QuoteRequest) GetQuotesResponse
        +buildQuote(params: BuildQuoteRequest) GetQuotesResponse
    }

    class CrossChainProvider {
        <<abstract>>
        +getQuotes(params: QuoteRequest) Quote[]*
        +buildQuote(params: BuildQuoteRequest) Quote
    }

    class AcrossProvider {
        +buildQuote(params) Quote
    }

    class OifProvider {
        +buildQuote(params) Quote
    }

    class RelayProvider {
        buildQuote not implemented
    }

    Aggregator --> CrossChainProvider : iterates all
    CrossChainProvider <|-- AcrossProvider
    CrossChainProvider <|-- OifProvider
    CrossChainProvider <|-- RelayProvider
```

## Test plan

- [x] All existing `aggregator.buildQuote` tests updated and passing
- [x] `getQuotes` tests unaffected
- [x] Frontend builds successfully

closes EFI-854