### PR TITLE
feat: Add provider selector to buildQuote and filter tokens by provider

### DIFF
--- a/.changeset/buildquote-provider-selector.md
+++ b/.changeset/buildquote-provider-selector.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Add Optimism SpokePool address to Across constants for buildQuote support on OP.

--- a/examples/ui/app/cross-chain/CrossChainClient.tsx
+++ b/examples/ui/app/cross-chain/CrossChainClient.tsx
@@ -67,6 +67,7 @@ export default function CrossChainClient() {
   const [toast, setToast] = useState<ToastState | null>(null);
   const [lastQuoteParams, setLastQuoteParams] = useState<Parameters<typeof fetchQuotes>[0] | null>(null);
   const currentMode = useCrossChainStore((s) => s.mode);
+  const buildQuoteProviderId = useCrossChainStore((s) => s.buildQuoteProviderId);
   const isExecutionStarted = executionState.step !== STEP.IDLE;
 
   const effectiveQuotes: ExecutableQuote[] = currentMode === 'buildQuote' && builtQuote ? [builtQuote] : quotes;
@@ -117,6 +118,7 @@ export default function CrossChainClient() {
         inputAmount: params.inputAmount,
         outputAmount: params.outputAmount,
         fillDeadlineSecs: params.fillDeadlineSecs,
+        providerId: buildQuoteProviderId,
       });
     } else {
       clearBuildQuote();

--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -7,6 +7,7 @@ import { useAccount } from 'wagmi';
 import { MINT_AMOUNT, useMintToken } from '../hooks/useMintToken';
 import { useChainConfig, useTokenConfig } from '../hooks/useNetworkConfig';
 import { useRouteSelection } from '../hooks/useRouteSelection';
+import { BUILD_QUOTE_PROVIDERS } from '../services/sdk';
 import { useBalanceStore, type TokenBalance } from '../stores/balanceStore';
 import { useCrossChainStore, type SwapFormMode } from '../stores/crossChainStore';
 import { formatFee, isValidAmount, normalizeAmount, sanitizeAmountInput } from '../utils/amountValidation';
@@ -66,6 +67,8 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
   const [inputAmount, setInputAmount] = useState('');
   const mode = useCrossChainStore((s) => s.mode);
   const setMode = useCrossChainStore((s) => s.setMode);
+  const buildQuoteProviderId = useCrossChainStore((s) => s.buildQuoteProviderId);
+  const setBuildQuoteProviderId = useCrossChainStore((s) => s.setBuildQuoteProviderId);
   const [outputAmount, setOutputAmount] = useState('');
   const [fillDeadlineSecs, setFillDeadlineSecs] = useState(DEADLINE_OPTIONS[0].value);
 
@@ -264,6 +267,38 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
             Build Quote
           </button>
         </div>
+
+        {mode === 'buildQuote' && (
+          <fieldset>
+            <legend className='text-sm font-medium text-text-secondary mb-2'>Provider</legend>
+            <div className='flex gap-2'>
+              {BUILD_QUOTE_PROVIDERS.map((p) => (
+                <label
+                  key={p.providerId}
+                  className={`flex-1 text-center px-3 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-accent/50 has-[:focus-visible]:ring-offset-1 ${
+                    buildQuoteProviderId === p.providerId
+                      ? 'bg-accent text-white'
+                      : 'bg-background/50 border border-border/50 text-text-secondary hover:text-text-primary hover:border-border-focus/60'
+                  } ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                >
+                  <input
+                    type='radio'
+                    name='buildQuoteProvider'
+                    value={p.providerId}
+                    checked={buildQuoteProviderId === p.providerId}
+                    onChange={() => {
+                      setBuildQuoteProviderId(p.providerId);
+                      onInputChange?.();
+                    }}
+                    disabled={isDisabled}
+                    className='sr-only peer'
+                  />
+                  {p.displayName}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+        )}
 
         <div>
           <label htmlFor='recipient-address' className='text-sm font-medium text-text-secondary mb-2 block'>

--- a/examples/ui/app/cross-chain/hooks/useBuildQuote.ts
+++ b/examples/ui/app/cross-chain/hooks/useBuildQuote.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef } from 'react';
+import { zeroAddress } from 'viem';
 import { useCrossChainStore } from '../stores/crossChainStore';
 import { convertAmountToSmallestUnit } from '../utils/amountConverter';
 import { useTokenConfig } from './useNetworkConfig';
@@ -16,6 +17,7 @@ export interface BuildQuoteParams {
   inputAmount: string;
   outputAmount: string;
   fillDeadlineSecs?: number;
+  providerId: string;
 }
 
 export enum BuildQuoteStatus {
@@ -79,13 +81,14 @@ export function useBuildQuote(): UseBuildQuoteReturn {
           amount: outputAmountSmallest,
           recipient: params.recipient,
         },
-        // Across provider resolves the SpokePool from its internal mapping;
-        // zero address ensures unsupported chains fail instead of depositing to the user's EOA.
-        escrowContractAddress: '0x0000000000000000000000000000000000000000',
+        // Each provider resolves the contract address from its own mapping.
+        // Zero address is a placeholder that gets overridden; if the provider
+        // can't resolve it, the SDK validator will reject the request.
+        escrowContractAddress: zeroAddress,
         fillDeadline,
       };
 
-      const result = await executor.buildQuote('across', request);
+      const result = await executor.buildQuote(params.providerId, request);
       if (requestIdRef.current !== currentRequestId) return;
       setQuote(result);
       setStatus(BuildQuoteStatus.SUCCESS);

--- a/examples/ui/app/cross-chain/hooks/useBuildQuote.ts
+++ b/examples/ui/app/cross-chain/hooks/useBuildQuote.ts
@@ -81,9 +81,7 @@ export function useBuildQuote(): UseBuildQuoteReturn {
           amount: outputAmountSmallest,
           recipient: params.recipient,
         },
-        // Each provider resolves the contract address from its own mapping.
-        // Zero address is a placeholder that gets overridden; if the provider
-        // can't resolve it, the SDK validator will reject the request.
+        // Providers resolve the escrow/settler contract from their own internal mappings.
         escrowContractAddress: zeroAddress,
         fillDeadline,
       };

--- a/examples/ui/app/cross-chain/hooks/useRouteSelection.ts
+++ b/examples/ui/app/cross-chain/hooks/useRouteSelection.ts
@@ -12,8 +12,12 @@ import { useTokenConfig } from './useNetworkConfig';
 export function useRouteSelection(defaultInputChainId: number, defaultOutputChainId: number) {
   const { SUPPORTED_TOKEN_BY_CHAIN_ID: byChain, TOKEN_INFO: tokenInfo } = useTokenConfig();
   const mode = useCrossChainStore((s) => s.mode);
+  const buildQuoteProviderId = useCrossChainStore((s) => s.buildQuoteProviderId);
 
-  const selector = useMemo(() => createRouteSelector({ byChain, tokenInfo, mode }), [byChain, tokenInfo, mode]);
+  const selector = useMemo(
+    () => createRouteSelector({ byChain, tokenInfo, mode, buildQuoteProviderId }),
+    [byChain, tokenInfo, mode, buildQuoteProviderId],
+  );
 
   const [selection, setSelection] = useState(() => {
     const urlParams = readRouteParams();

--- a/examples/ui/app/cross-chain/services/sdk.ts
+++ b/examples/ui/app/cross-chain/services/sdk.ts
@@ -10,21 +10,32 @@ import { MAINNET_RPC_URLS, TESTNET_RPC_URLS } from '../constants/chains';
 
 const OIF_API_URL = 'https://oif-api.openzeppelin.com/api';
 
+interface ProviderConfig {
+  providerId: string;
+  displayName: string;
+  supportsBuildQuote: boolean;
+}
+
 /**
- * Provider configuration with display names
+ * Provider configuration with display names and capability flags
  */
-const PROVIDER_CONFIGS = [
+const PROVIDER_CONFIGS: ProviderConfig[] = [
   {
     providerId: 'across',
     displayName: 'Across Protocol',
+    supportsBuildQuote: true,
   },
   {
     providerId: 'oif',
     displayName: 'OIF Sample Solver',
+    // TODO: re-enable once OZ confirms on-chain discovery is active on the production solver.
+    // SDK-side implementation is done (StandardOrder encoding, settler addresses, event-based tracking).
+    supportsBuildQuote: false,
   },
   {
     providerId: 'relay',
     displayName: 'Relay',
+    supportsBuildQuote: false,
   },
 ];
 
@@ -63,3 +74,6 @@ export function getProviderDisplayName(providerId: string): string {
   const config = PROVIDER_CONFIGS.find((c) => c.providerId === providerId);
   return config?.displayName || providerId;
 }
+
+/** Providers that support the buildQuote flow. */
+export const BUILD_QUOTE_PROVIDERS = PROVIDER_CONFIGS.filter((c) => c.supportsBuildQuote);

--- a/examples/ui/app/cross-chain/stores/crossChainStore.ts
+++ b/examples/ui/app/cross-chain/stores/crossChainStore.ts
@@ -15,8 +15,10 @@ interface CrossChainState {
   isTestnet: boolean;
   executor: Aggregator;
   mode: SwapFormMode;
+  buildQuoteProviderId: string;
   setIsTestnet: (isTestnet: boolean) => void;
   setMode: (mode: SwapFormMode) => void;
+  setBuildQuoteProviderId: (providerId: string) => void;
 }
 
 const initialIsTestnet = readIsTestnetFromUrl();
@@ -25,6 +27,7 @@ export const useCrossChainStore = create<CrossChainState>((set, get) => ({
   isTestnet: initialIsTestnet,
   executor: buildExecutor(initialIsTestnet),
   mode: 'getQuotes',
+  buildQuoteProviderId: 'across',
 
   setIsTestnet: (isTestnet: boolean) => {
     if (isTestnet === get().isTestnet) return;
@@ -39,4 +42,5 @@ export const useCrossChainStore = create<CrossChainState>((set, get) => ({
   },
 
   setMode: (mode: SwapFormMode) => set({ mode }),
+  setBuildQuoteProviderId: (providerId: string) => set({ buildQuoteProviderId: providerId }),
 }));

--- a/examples/ui/app/cross-chain/utils/routeSelection.spec.ts
+++ b/examples/ui/app/cross-chain/utils/routeSelection.spec.ts
@@ -31,6 +31,8 @@ const config: RouteConfig = {
       [SHIB]: token('SHIB', ['across']),
     },
   },
+  mode: 'getQuotes',
+  buildQuoteProviderId: 'across',
 };
 
 const VALID_TOKENS = [USDC, WETH, DAI];
@@ -128,6 +130,8 @@ describe('cascading', () => {
         1: { [onlyChain1]: token('UNI', ['sample']), [USDC]: token('USDC', ['across', 'sample']) },
         10: { [USDC]: token('USDC', ['across', 'sample']), [WETH]: token('WETH', ['across']) },
       },
+      mode: 'getQuotes',
+      buildQuoteProviderId: 'across',
     });
     const next = s.setInputChain({ inputChainId: 1, outputChainId: 10, inputToken: onlyChain1, outputToken: USDC }, 10);
     expect(next.inputToken).toBe(USDC);
@@ -157,7 +161,12 @@ describe('cascading', () => {
 
 describe('edge cases', () => {
   it('empty config or unknown chain yields empty results', () => {
-    const empty = createRouteSelector({ byChain: {}, tokenInfo: {} }).resolve(sel());
+    const empty = createRouteSelector({
+      byChain: {},
+      tokenInfo: {},
+      mode: 'getQuotes',
+      buildQuoteProviderId: 'across',
+    }).resolve(sel());
     expect(empty.inputToken).toBe('');
     expect(empty.outputToken).toBe('');
     expect(empty.inputTokens).toEqual([]);
@@ -174,6 +183,8 @@ describe('edge cases', () => {
         1: { [USDC]: token('USDC', ['across', 'sample']) },
         10: { [USDC]: token('USDC', ['across', 'sample']) },
       },
+      mode: 'getQuotes',
+      buildQuoteProviderId: 'across',
     });
     expect(s.resolve(sel({ inputChainId: 1 })).inputTokens).toContain(UNKNOWN);
   });

--- a/examples/ui/app/cross-chain/utils/routeSelection.ts
+++ b/examples/ui/app/cross-chain/utils/routeSelection.ts
@@ -24,6 +24,7 @@ export interface RouteConfig {
   byChain: TokensByChain;
   tokenInfo: TokenInfoByChain;
   mode: SwapFormMode;
+  buildQuoteProviderId: string;
 }
 
 function isWhitelisted(token: UITokenInfo): boolean {
@@ -76,12 +77,19 @@ function resolveInitialOutputChain(
 }
 
 export function createRouteSelector(config: RouteConfig) {
-  const { byChain, tokenInfo, mode } = config;
+  const { byChain, tokenInfo, mode, buildQuoteProviderId } = config;
+
+  /** In buildQuote mode, only show tokens supported by the selected provider. */
+  function filterByProvider(tokens: string[], chainId: number): string[] {
+    if (mode !== 'buildQuote') return tokens;
+    const meta = tokenInfo[chainId] ?? {};
+    return tokens.filter((addr) => meta[addr]?.providers.includes(buildQuoteProviderId));
+  }
 
   function inputTokensFor(chainId: number): string[] {
     const addresses = byChain[chainId] ?? [];
     const meta = tokenInfo[chainId] ?? {};
-    return availableTokens(addresses, meta);
+    return filterByProvider(availableTokens(addresses, meta), chainId);
   }
 
   function outputTokensFor(inputChainId: number, inputToken: string, outputChainId: number): string[] {
@@ -91,7 +99,10 @@ export function createRouteSelector(config: RouteConfig) {
     const tokens = compatibleTokens(addresses, meta, inputMeta?.providers ?? []);
 
     if (mode === 'buildQuote' && inputMeta?.symbol) {
-      return tokens.filter((addr) => meta[addr]?.symbol === inputMeta.symbol);
+      return filterByProvider(
+        tokens.filter((addr) => meta[addr]?.symbol === inputMeta.symbol),
+        outputChainId,
+      );
     }
 
     return tokens;

--- a/packages/cross-chain/src/protocols/across/constants.ts
+++ b/packages/cross-chain/src/protocols/across/constants.ts
@@ -1,5 +1,5 @@
 import { getAddress, Hex } from "viem";
-import { arbitrum, arbitrumSepolia, base, baseSepolia, sepolia } from "viem/chains";
+import { arbitrum, arbitrumSepolia, base, baseSepolia, optimism, sepolia } from "viem/chains";
 
 import type { NetworkAssets } from "../../core/types/assetDiscovery.js";
 
@@ -53,6 +53,7 @@ export { getAcrossApiUrl };
  */
 export const ACROSS_SPOKE_POOL_ADDRESSES: Record<number, Hex> = {
     // Mainnet addresses
+    [optimism.id]: getAddress("0x6f26Bf09B1C792e3228e5467807a900A503c0281"),
     [base.id]: getAddress("0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64"),
     [arbitrum.id]: getAddress("0xe35e9842fceaca96570b734083f4a58e8f7c5f2a"),
     // Testnet addresses


### PR DESCRIPTION
## Summary
- Adds a provider selector (radio buttons) in buildQuote mode so users pick which provider builds the quote
- `useBuildQuote` now takes `providerId` from the store instead of hardcoding `'across'`
- In buildQuote mode, input and output token lists are filtered to only show tokens supported by the selected provider
- `buildQuoteProviderId` lives in `crossChainStore` alongside the existing `mode` state
- Only Across is enabled for now. OIF is disabled pending confirmation that the OZ solver supports on-chain order discovery for direct `open()` calls.

## Changes
- `sdk.ts`: provider configs now have `supportsBuildQuote` flag, new `getBuildQuoteProviders()` helper
- `crossChainStore.ts`: added `buildQuoteProviderId` state
- `SwapForm.tsx`: provider selector fieldset (same style as deadline selector), visible in buildQuote mode
- `useBuildQuote.ts`: accepts `providerId` param, uses `zeroAddress` from viem
- `CrossChainClient.tsx`: reads `buildQuoteProviderId` from store, passes to `buildQuote()`
- `routeSelection.ts`: `outputTokensFor` and `inputTokensFor` filter by selected provider in buildQuote mode
- `useRouteSelection.ts`: passes `buildQuoteProviderId` to route selector

## Test plan
- [ ] Switch to Build Quote mode, verify only Across shows as provider option
- [ ] Select Across, verify token lists only show Across-supported tokens (no mockUSDC)
- [ ] Build a quote with Across (same-asset, e.g. USDC Base -> USDC Arbitrum), execute, confirm tracking works
- [ ] Switch back to Get Quotes mode, verify all tokens from all providers appear again