### PR TITLE
feat(ui): add Bungee provider to cross-chain demo app

### DIFF
--- a/.changeset/bungee-empty-quotes-no-throw.md
+++ b/.changeset/bungee-empty-quotes-no-throw.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Bungee provider now returns an empty array instead of throwing when the API responds successfully with no routes (e.g. amounts below the protocol minimum). Real API errors (4xx/5xx, validation failures) are still surfaced.

--- a/.changeset/bungee-empty-quotes-no-throw.md
+++ b/.changeset/bungee-empty-quotes-no-throw.md
@@ -2,4 +2,4 @@
 "@wonderland/interop-cross-chain": patch
 ---
 
-Bungee provider now returns an empty array instead of throwing when the API responds successfully with no routes (e.g. amounts below the protocol minimum). Real API errors (4xx/5xx, validation failures) are still surfaced.
+Bungee provider returns an empty array when no routes are available instead of throwing.

--- a/examples/ui/app/cross-chain/services/sdk.ts
+++ b/examples/ui/app/cross-chain/services/sdk.ts
@@ -5,6 +5,7 @@ import {
   OrderTrackerFactory,
   LIFI_INTENTS_ORDER_SERVER_URL,
   LIFI_INTENTS_ORDER_SERVER_DEV_URL,
+  BungeeApiTier,
   type Aggregator,
   type CrossChainProvider,
 } from '@wonderland/interop-cross-chain';
@@ -44,6 +45,11 @@ const PROVIDER_CONFIGS: ProviderConfig[] = [
     displayName: 'LI.FI',
     supportsBuildQuote: false,
   },
+  {
+    providerId: 'bungee',
+    displayName: 'Bungee',
+    supportsBuildQuote: false,
+  },
 ];
 
 export function buildExecutor(isTestnet: boolean): Aggregator {
@@ -70,6 +76,15 @@ export function buildExecutor(isTestnet: boolean): Aggregator {
       providerId: 'lifi-intents',
     }),
   ];
+
+  if (!isTestnet) {
+    providers.push(
+      createCrossChainProvider(PROTOCOLS.BUNGEE, {
+        tier: BungeeApiTier.Sandbox,
+        providerId: 'bungee',
+      }),
+    );
+  }
 
   return createAggregator({
     providers,

--- a/packages/cross-chain/src/protocols/bungee/provider.ts
+++ b/packages/cross-chain/src/protocols/bungee/provider.ts
@@ -188,17 +188,7 @@ export class BungeeProvider extends CrossChainProvider {
         };
     }
 
-    /**
-     * Collect quotes from settled results.
-     *
-     * Behavior:
-     * - If any mode produced at least one quote, returns all fulfilled quotes
-     *   (partial failures are tolerated when routes were found).
-     * - If no quotes were produced and any mode threw, surfaces that API
-     *   error so upstream callers see 4xx/5xx/validation failures.
-     * - If every mode responded successfully with zero routes, returns `[]`
-     *   so empty responses are treated as "no routes" rather than an error.
-     */
+    /** Collect quotes from settled results, surfacing errors only when no quotes were produced. */
     private collectQuotes(results: PromiseSettledResult<Quote[]>[]): Quote[] {
         const fulfilled = results.filter(
             (r): r is PromiseFulfilledResult<Quote[]> => r.status === "fulfilled",

--- a/packages/cross-chain/src/protocols/bungee/provider.ts
+++ b/packages/cross-chain/src/protocols/bungee/provider.ts
@@ -111,7 +111,7 @@ export class BungeeProvider extends CrossChainProvider {
             this.submissionModes.map((mode) => this.fetchQuotesForMode(params, mode)),
         );
 
-        return this.collectQuotesOrThrow(results);
+        return this.collectQuotes(results);
     }
 
     /**
@@ -189,22 +189,28 @@ export class BungeeProvider extends CrossChainProvider {
     }
 
     /**
-     * Collect successful quotes from settled results.
-     * Throws only if every mode failed — surfaces the first error.
+     * Collect quotes from settled results.
+     *
+     * Behavior:
+     * - If any mode produced at least one quote, returns all fulfilled quotes
+     *   (partial failures are tolerated when routes were found).
+     * - If no quotes were produced and any mode threw, surfaces that API
+     *   error so upstream callers see 4xx/5xx/validation failures.
+     * - If every mode responded successfully with zero routes, returns `[]`
+     *   so empty responses are treated as "no routes" rather than an error.
      */
-    private collectQuotesOrThrow(results: PromiseSettledResult<Quote[]>[]): Quote[] {
-        const quotes = results
-            .filter((r): r is PromiseFulfilledResult<Quote[]> => r.status === "fulfilled")
-            .flatMap((r) => r.value);
+    private collectQuotes(results: PromiseSettledResult<Quote[]>[]): Quote[] {
+        const fulfilled = results.filter(
+            (r): r is PromiseFulfilledResult<Quote[]> => r.status === "fulfilled",
+        );
+        const quotes = fulfilled.flatMap((r) => r.value);
 
         if (quotes.length > 0) return quotes;
 
         const firstError = results.find((r): r is PromiseRejectedResult => r.status === "rejected");
+        if (firstError) throw firstError.reason as Error;
 
-        throw (
-            (firstError?.reason as Error) ??
-            new ProviderGetQuoteFailure("No quotes returned from any submission mode")
-        );
+        return [];
     }
 
     /** Fetch quotes for a single submission mode. */

--- a/packages/cross-chain/src/protocols/bungee/provider.ts
+++ b/packages/cross-chain/src/protocols/bungee/provider.ts
@@ -188,16 +188,18 @@ export class BungeeProvider extends CrossChainProvider {
         };
     }
 
-    /** Collect quotes from settled results, throwing only when every mode rejected. */
+    /** Collect quotes; surface errors when no quotes were produced so failures are not hidden. */
     private collectQuotes(results: PromiseSettledResult<Quote[]>[]): Quote[] {
-        const fulfilled = results.filter(
-            (r): r is PromiseFulfilledResult<Quote[]> => r.status === "fulfilled",
-        );
+        const quotes = results
+            .filter((r): r is PromiseFulfilledResult<Quote[]> => r.status === "fulfilled")
+            .flatMap((r) => r.value);
 
-        if (fulfilled.length > 0) return fulfilled.flatMap((r) => r.value);
+        if (quotes.length > 0) return quotes;
 
         const firstError = results.find((r): r is PromiseRejectedResult => r.status === "rejected");
-        throw (firstError?.reason as Error) ?? new ProviderGetQuoteFailure("No quotes returned");
+        if (firstError) throw firstError.reason as Error;
+
+        return [];
     }
 
     /** Fetch quotes for a single submission mode. */

--- a/packages/cross-chain/src/protocols/bungee/provider.ts
+++ b/packages/cross-chain/src/protocols/bungee/provider.ts
@@ -188,19 +188,16 @@ export class BungeeProvider extends CrossChainProvider {
         };
     }
 
-    /** Collect quotes from settled results, surfacing errors only when no quotes were produced. */
+    /** Collect quotes from settled results, throwing only when every mode rejected. */
     private collectQuotes(results: PromiseSettledResult<Quote[]>[]): Quote[] {
         const fulfilled = results.filter(
             (r): r is PromiseFulfilledResult<Quote[]> => r.status === "fulfilled",
         );
-        const quotes = fulfilled.flatMap((r) => r.value);
 
-        if (quotes.length > 0) return quotes;
+        if (fulfilled.length > 0) return fulfilled.flatMap((r) => r.value);
 
         const firstError = results.find((r): r is PromiseRejectedResult => r.status === "rejected");
-        if (firstError) throw firstError.reason as Error;
-
-        return [];
+        throw (firstError?.reason as Error) ?? new ProviderGetQuoteFailure("No quotes returned");
     }
 
     /** Fetch quotes for a single submission mode. */

--- a/packages/cross-chain/test/protocols/bungee/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/provider.spec.ts
@@ -249,6 +249,43 @@ describe("BungeeProvider", () => {
             );
         });
 
+        it("returns an empty array when one mode responds with no routes and another fails", async () => {
+            const multiModeProvider = new BungeeProvider({
+                submissionModes: ["gasless", "user-transaction"],
+            });
+
+            const emptyResponse = makeBungeeQuoteResponse({
+                result: {
+                    originChainId: ORIGIN_CHAIN_ID,
+                    destinationChainId: DESTINATION_CHAIN_ID,
+                    userAddress: VALID_ADDRESS,
+                    receiverAddress: VALID_ADDRESS,
+                    input: {
+                        token: {
+                            chainId: ORIGIN_CHAIN_ID,
+                            address: VALID_ADDRESS,
+                            name: "ETH",
+                            symbol: "ETH",
+                            decimals: 18,
+                        },
+                        amount: INPUT_AMOUNT,
+                        priceInUsd: 1,
+                        valueInUsd: 1,
+                    },
+                    autoRoute: null,
+                    autoRoutes: [],
+                    manualRoutes: [],
+                },
+            });
+
+            mockGet
+                .mockResolvedValueOnce({ data: emptyResponse })
+                .mockRejectedValueOnce(new Error("user-transaction failed"));
+
+            const quotes = await multiModeProvider.getQuotes(makeQuoteRequest());
+            expect(quotes).toEqual([]);
+        });
+
         it("returns an empty array when every mode responds with no routes", async () => {
             const emptyResponse = makeBungeeQuoteResponse({
                 result: {

--- a/packages/cross-chain/test/protocols/bungee/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/provider.spec.ts
@@ -249,7 +249,7 @@ describe("BungeeProvider", () => {
             );
         });
 
-        it("returns an empty array when one mode responds with no routes and another fails", async () => {
+        it("throws when a mode fails and the others responded with no routes", async () => {
             const multiModeProvider = new BungeeProvider({
                 submissionModes: ["gasless", "user-transaction"],
             });
@@ -282,8 +282,9 @@ describe("BungeeProvider", () => {
                 .mockResolvedValueOnce({ data: emptyResponse })
                 .mockRejectedValueOnce(new Error("user-transaction failed"));
 
-            const quotes = await multiModeProvider.getQuotes(makeQuoteRequest());
-            expect(quotes).toEqual([]);
+            await expect(multiModeProvider.getQuotes(makeQuoteRequest())).rejects.toThrow(
+                ProviderGetQuoteFailure,
+            );
         });
 
         it("returns an empty array when every mode responds with no routes", async () => {

--- a/packages/cross-chain/test/protocols/bungee/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/provider.spec.ts
@@ -248,6 +248,37 @@ describe("BungeeProvider", () => {
                 ProviderGetQuoteFailure,
             );
         });
+
+        it("returns an empty array when every mode responds with no routes", async () => {
+            const emptyResponse = makeBungeeQuoteResponse({
+                result: {
+                    originChainId: ORIGIN_CHAIN_ID,
+                    destinationChainId: DESTINATION_CHAIN_ID,
+                    userAddress: VALID_ADDRESS,
+                    receiverAddress: VALID_ADDRESS,
+                    input: {
+                        token: {
+                            chainId: ORIGIN_CHAIN_ID,
+                            address: VALID_ADDRESS,
+                            name: "ETH",
+                            symbol: "ETH",
+                            decimals: 18,
+                        },
+                        amount: INPUT_AMOUNT,
+                        priceInUsd: 1,
+                        valueInUsd: 1,
+                    },
+                    autoRoute: null,
+                    autoRoutes: [],
+                    manualRoutes: [],
+                },
+            });
+
+            mockGet.mockResolvedValue({ data: emptyResponse });
+
+            const quotes = await provider.getQuotes(makeQuoteRequest());
+            expect(quotes).toEqual([]);
+        });
     });
 
     describe("submitOrder()", () => {


### PR DESCRIPTION
Closes EFI-858

## Summary

Adds Bungee as cross-chain provider in the examples UI app. Configured with the Sandbox tier (public, no API key needed) and only available on mainnet. Does not appear in testnet mode. Uses the getQuotes flow since Bungee does not support buildQuote.

## Test plan

Tested cross chain USDC -> USDC swap on mainnet. Build passes with pnpm build --filter='@examples/ui'. On mainnet Bungee quotes appear alongside Across, OIF, and Relay. On testnet Bungee does not appear.