### PR TITLE
feat(ui): demo warning banner and input amount limits

### DIFF
--- a/examples/ui/app/cross-chain/CrossChainClient.tsx
+++ b/examples/ui/app/cross-chain/CrossChainClient.tsx
@@ -169,11 +169,11 @@ export default function CrossChainClient() {
 
         <div className='flex-1 flex flex-col max-w-7xl w-full mx-auto px-4 py-12 sm:px-6 sm:py-16'>
           <div className='flex-1 flex flex-col gap-12'>
-            <header className='flex flex-col items-center gap-4 text-center relative'>
-              <div className='absolute top-0 right-0'>
-                <NetworkSwitch disabled={isExecutionStarted} />
-              </div>
+            <div className='flex justify-end'>
+              <NetworkSwitch disabled={isExecutionStarted} />
+            </div>
 
+            <header className='flex flex-col items-center gap-4 text-center'>
               <div className='inline-flex items-center gap-2 px-3 py-1 rounded-full bg-accent-light text-accent text-xs font-medium'>
                 EIP-7683 & Intents
               </div>

--- a/examples/ui/app/cross-chain/CrossChainClient.tsx
+++ b/examples/ui/app/cross-chain/CrossChainClient.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from 'react';
 import { isNativeAddress, type ExecutableQuote } from '@wonderland/interop-cross-chain';
 import { Footer, Navigation } from '../components';
 import {
+  DemoBanner,
   DiscoveryLoading,
   DiscoveryError,
   DiscoveryEmpty,
@@ -181,6 +182,8 @@ export default function CrossChainClient() {
                 Experience seamless cross-chain transfers with intent-based routing
               </p>
             </header>
+
+            <DemoBanner />
 
             <div className='grid grid-cols-1 lg:grid-cols-2 gap-8 items-start'>
               <div className='flex flex-col gap-6'>

--- a/examples/ui/app/cross-chain/components/DemoBanner.tsx
+++ b/examples/ui/app/cross-chain/components/DemoBanner.tsx
@@ -1,0 +1,15 @@
+import { WarningIcon } from './icons';
+
+export function DemoBanner() {
+  return (
+    <div className='relative overflow-hidden rounded-xl border border-warning/30 backdrop-blur-sm'>
+      <div className='absolute inset-y-0 left-0 w-1 bg-warning' />
+      <div className='flex items-center gap-3 bg-warning-light/60 px-4 py-3'>
+        <WarningIcon className='w-4 h-4 shrink-0 text-warning' />
+        <p className='text-sm text-text-secondary'>
+          This is a demo app for testing and experimentation. Do not use large amounts.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -161,7 +161,14 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!connectedAddress || !inputTokenAddress || !outputTokenAddress || !amountIsValid || parsedInputAmount <= 0n) {
+    if (
+      !connectedAddress ||
+      !inputTokenAddress ||
+      !outputTokenAddress ||
+      !amountIsValid ||
+      parsedInputAmount <= 0n ||
+      exceedsLimit
+    ) {
       return;
     }
     if (mode === 'buildQuote' && (!outputAmountIsValid || parsedOutputAmount <= 0n)) {

--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -243,8 +243,8 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
   const getButtonText = () => {
     if (!isConnected) return 'Connect Wallet';
     if (isLoading) return mode === 'buildQuote' ? 'Building Quote...' : 'Fetching Quotes...';
-    if (hasInsufficientBalance) return 'Insufficient Balance';
     if (exceedsLimit) return 'Amount too large for demo';
+    if (hasInsufficientBalance) return 'Insufficient Balance';
     return mode === 'buildQuote' ? 'Build Quote' : 'Get Quotes';
   };
 

--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -10,7 +10,13 @@ import { useRouteSelection } from '../hooks/useRouteSelection';
 import { BUILD_QUOTE_PROVIDERS } from '../services/sdk';
 import { useBalanceStore, type TokenBalance } from '../stores/balanceStore';
 import { useCrossChainStore, type SwapFormMode } from '../stores/crossChainStore';
-import { formatFee, isValidAmount, normalizeAmount, sanitizeAmountInput } from '../utils/amountValidation';
+import {
+  exceedsDemoLimit as checkDemoLimit,
+  formatFee,
+  isValidAmount,
+  normalizeAmount,
+  sanitizeAmountInput,
+} from '../utils/amountValidation';
 import { TokenSelect } from './TokenSelect';
 import { WalletConnect } from './WalletConnect';
 
@@ -100,6 +106,8 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
   }, [inputAmount, inputTokenInfo?.decimals, amountIsValid]);
 
   const hasInsufficientBalance = Boolean(tokenBalance && inputAmount && parsedInputAmount > tokenBalance.raw);
+
+  const exceedsLimit = checkDemoLimit(inputAmount, inputTokenInfo?.symbol);
 
   const outputTokenInfo = outputTokenAddress ? tokenConfig.TOKEN_INFO[outputChainId]?.[outputTokenAddress] : null;
   const isSameToken = Boolean(inputTokenInfo && outputTokenInfo && inputTokenInfo.symbol === outputTokenInfo.symbol);
@@ -215,6 +223,7 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
     !isLoading &&
     !isDisabled &&
     !hasInsufficientBalance &&
+    !exceedsLimit &&
     !noFeeWarning &&
     (mode === 'getQuotes' || (outputAmountIsValid && parsedOutputAmount > 0n));
 
@@ -228,6 +237,7 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
     if (!isConnected) return 'Connect Wallet';
     if (isLoading) return mode === 'buildQuote' ? 'Building Quote...' : 'Fetching Quotes...';
     if (hasInsufficientBalance) return 'Insufficient Balance';
+    if (exceedsLimit) return 'Amount too large for demo';
     return mode === 'buildQuote' ? 'Build Quote' : 'Get Quotes';
   };
 
@@ -485,6 +495,7 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
 
         <button
           type='submit'
+          data-testid='submit-button'
           disabled={!canSubmit}
           className={`w-full px-6 py-3 rounded-xl font-medium transition-all ${
             canSubmit

--- a/examples/ui/app/cross-chain/components/index.ts
+++ b/examples/ui/app/cross-chain/components/index.ts
@@ -1,3 +1,4 @@
+export { DemoBanner } from './DemoBanner';
 export { DiscoveryLoading, DiscoveryError, DiscoveryEmpty } from './DiscoveryState';
 export { ErrorList } from './ErrorList';
 export { ErrorQuoteCard } from './ErrorQuoteCard';

--- a/examples/ui/app/cross-chain/constants/display.ts
+++ b/examples/ui/app/cross-chain/constants/display.ts
@@ -18,4 +18,5 @@ export const DEMO_MAX_AMOUNT: Record<string, number> = {
   WETH: 0.03,
   BTC: 0.001,
   WBTC: 0.001,
+  CBBTC: 0.001,
 };

--- a/examples/ui/app/cross-chain/constants/display.ts
+++ b/examples/ui/app/cross-chain/constants/display.ts
@@ -5,3 +5,17 @@ export const PERCENTAGE_DECIMALS = 2;
 export const UNKNOWN_TOKEN_SYMBOL = 'TOKEN';
 export const NOT_AVAILABLE = 'N/A';
 export const UNKNOWN_PROVIDER = 'Unknown Provider';
+
+/**
+ * Maximum input amounts per token symbol for the demo app.
+ * Values are denominated in their native unit (e.g. 100 USDC, 0.03 ETH).
+ */
+export const DEMO_MAX_AMOUNT: Record<string, number> = {
+  USDC: 100,
+  USDT: 100,
+  DAI: 100,
+  ETH: 0.03,
+  WETH: 0.03,
+  BTC: 0.001,
+  WBTC: 0.001,
+};

--- a/examples/ui/app/cross-chain/constants/display.ts
+++ b/examples/ui/app/cross-chain/constants/display.ts
@@ -7,16 +7,31 @@ export const NOT_AVAILABLE = 'N/A';
 export const UNKNOWN_PROVIDER = 'Unknown Provider';
 
 /**
+ * Tokens shown in the demo app. Adding a new value here requires
+ * a matching entry in DEMO_MAX_AMOUNT (enforced by the Record type).
+ */
+export enum DemoToken {
+  ETH = 'ETH',
+  WETH = 'WETH',
+  USDC = 'USDC',
+  USDT = 'USDT',
+  DAI = 'DAI',
+  WBTC = 'WBTC',
+  cbBTC = 'cbBTC',
+  mockUSDC = 'mockUSDC',
+}
+
+/**
  * Maximum input amounts per token symbol for the demo app.
  * Values are denominated in their native unit (e.g. 100 USDC, 0.03 ETH).
  */
-export const DEMO_MAX_AMOUNT: Record<string, number> = {
-  USDC: 100,
-  USDT: 100,
-  DAI: 100,
-  ETH: 0.03,
-  WETH: 0.03,
-  BTC: 0.001,
-  WBTC: 0.001,
-  CBBTC: 0.001,
+export const DEMO_MAX_AMOUNT: Record<DemoToken, number> = {
+  [DemoToken.USDC]: 100,
+  [DemoToken.USDT]: 100,
+  [DemoToken.DAI]: 100,
+  [DemoToken.mockUSDC]: 100,
+  [DemoToken.ETH]: 0.03,
+  [DemoToken.WETH]: 0.03,
+  [DemoToken.WBTC]: 0.001,
+  [DemoToken.cbBTC]: 0.001,
 };

--- a/examples/ui/app/cross-chain/utils/amountValidation.spec.ts
+++ b/examples/ui/app/cross-chain/utils/amountValidation.spec.ts
@@ -75,9 +75,9 @@ describe('exceedsDemoLimit', () => {
     expect(exceedsDemoLimit('0.04', 'WETH')).toBe(true);
   });
 
-  it('returns true when amount exceeds max for BTC', () => {
-    expect(exceedsDemoLimit('0.002', 'BTC')).toBe(true);
+  it('returns true when amount exceeds max for BTC variants', () => {
     expect(exceedsDemoLimit('0.002', 'WBTC')).toBe(true);
+    expect(exceedsDemoLimit('0.002', 'cbBTC')).toBe(true);
   });
 
   it('returns false when amount is at or below limit', () => {
@@ -102,9 +102,14 @@ describe('exceedsDemoLimit', () => {
     expect(exceedsDemoLimit('abc', 'ETH')).toBe(false);
   });
 
-  it('is case-insensitive on symbol', () => {
-    expect(exceedsDemoLimit('101', 'usdc')).toBe(true);
-    expect(exceedsDemoLimit('101', 'Usdc')).toBe(true);
+  it('requires exact enum case for symbol', () => {
+    expect(exceedsDemoLimit('101', 'usdc')).toBe(false);
+    expect(exceedsDemoLimit('101', 'Usdc')).toBe(false);
+  });
+
+  it('enforces limits on mockUSDC', () => {
+    expect(exceedsDemoLimit('101', 'mockUSDC')).toBe(true);
+    expect(exceedsDemoLimit('100', 'mockUSDC')).toBe(false);
   });
 
   it('handles comma-separated amounts', () => {

--- a/examples/ui/app/cross-chain/utils/amountValidation.spec.ts
+++ b/examples/ui/app/cross-chain/utils/amountValidation.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isValidAmount, sanitizeAmountInput, formatFee } from './amountValidation';
+import { isValidAmount, sanitizeAmountInput, formatFee, exceedsDemoLimit } from './amountValidation';
 
 describe('sanitizeAmountInput', () => {
   it('allows digits and dot', () => {
@@ -60,5 +60,55 @@ describe('formatFee', () => {
   it('returns null for invalid values', () => {
     expect(formatFee('abc', '0.5')).toBeNull();
     expect(formatFee('0.5', 'xyz')).toBeNull();
+  });
+});
+
+describe('exceedsDemoLimit', () => {
+  it('returns true when amount exceeds max for stablecoins', () => {
+    expect(exceedsDemoLimit('101', 'USDC')).toBe(true);
+    expect(exceedsDemoLimit('101', 'USDT')).toBe(true);
+    expect(exceedsDemoLimit('101', 'DAI')).toBe(true);
+  });
+
+  it('returns true when amount exceeds max for ETH', () => {
+    expect(exceedsDemoLimit('0.04', 'ETH')).toBe(true);
+    expect(exceedsDemoLimit('0.04', 'WETH')).toBe(true);
+  });
+
+  it('returns true when amount exceeds max for BTC', () => {
+    expect(exceedsDemoLimit('0.002', 'BTC')).toBe(true);
+    expect(exceedsDemoLimit('0.002', 'WBTC')).toBe(true);
+  });
+
+  it('returns false when amount is at or below limit', () => {
+    expect(exceedsDemoLimit('100', 'USDC')).toBe(false);
+    expect(exceedsDemoLimit('50', 'USDT')).toBe(false);
+    expect(exceedsDemoLimit('0.03', 'ETH')).toBe(false);
+    expect(exceedsDemoLimit('0.001', 'WBTC')).toBe(false);
+  });
+
+  it('returns false for tokens not in the limit map', () => {
+    expect(exceedsDemoLimit('999999', 'SHIB')).toBe(false);
+  });
+
+  it('returns false when symbol is undefined or empty', () => {
+    expect(exceedsDemoLimit('999999', undefined)).toBe(false);
+    expect(exceedsDemoLimit('999999', '')).toBe(false);
+    expect(exceedsDemoLimit('999999', '   ')).toBe(false);
+  });
+
+  it('returns false for invalid amounts', () => {
+    expect(exceedsDemoLimit('', 'USDC')).toBe(false);
+    expect(exceedsDemoLimit('abc', 'ETH')).toBe(false);
+  });
+
+  it('is case-insensitive on symbol', () => {
+    expect(exceedsDemoLimit('101', 'usdc')).toBe(true);
+    expect(exceedsDemoLimit('101', 'Usdc')).toBe(true);
+  });
+
+  it('handles comma-separated amounts', () => {
+    expect(exceedsDemoLimit('100,5', 'USDC')).toBe(true);
+    expect(exceedsDemoLimit('99,5', 'USDC')).toBe(false);
   });
 });

--- a/examples/ui/app/cross-chain/utils/amountValidation.ts
+++ b/examples/ui/app/cross-chain/utils/amountValidation.ts
@@ -1,3 +1,5 @@
+import { DEMO_MAX_AMOUNT } from '../constants/display';
+
 /** Sanitizes amount input: strips invalid chars, normalizes comma to dot, handles ".5" → "0.5" */
 export function sanitizeAmountInput(value: string, currentValue: string): string {
   const sanitized = value.replace(/[^\d.,]/g, '');
@@ -25,6 +27,15 @@ export function isValidAmount(value: string): boolean {
   const normalized = normalizeAmount(value);
   if (!/^\d+\.?\d*$/.test(normalized)) return false;
   return !isNaN(parseFloat(normalized));
+}
+
+/** Returns true if the amount exceeds the demo limit for the given token symbol. */
+export function exceedsDemoLimit(amount: string, symbol: string | undefined): boolean {
+  if (!symbol?.trim()) return false;
+  const max = DEMO_MAX_AMOUNT[symbol.trim().toUpperCase()];
+  if (max === undefined) return false;
+  if (!isValidAmount(amount)) return false;
+  return parseFloat(normalizeAmount(amount)) > max;
 }
 
 /** Formats the fee between two same-token amounts, e.g. "Fee: 0.0030 (0.60%)". Returns null if not applicable. */

--- a/examples/ui/app/cross-chain/utils/amountValidation.ts
+++ b/examples/ui/app/cross-chain/utils/amountValidation.ts
@@ -1,4 +1,4 @@
-import { DEMO_MAX_AMOUNT } from '../constants/display';
+import { DEMO_MAX_AMOUNT, DemoToken } from '../constants/display';
 
 /** Sanitizes amount input: strips invalid chars, normalizes comma to dot, handles ".5" → "0.5" */
 export function sanitizeAmountInput(value: string, currentValue: string): string {
@@ -32,8 +32,9 @@ export function isValidAmount(value: string): boolean {
 /** Returns true if the amount exceeds the demo limit for the given token symbol. */
 export function exceedsDemoLimit(amount: string, symbol: string | undefined): boolean {
   if (!symbol?.trim()) return false;
-  const max = DEMO_MAX_AMOUNT[symbol.trim().toUpperCase()];
-  if (max === undefined) return false;
+  const key = symbol.trim();
+  if (!(key in DemoToken)) return false;
+  const max = DEMO_MAX_AMOUNT[key as DemoToken];
   if (!isValidAmount(amount)) return false;
   return parseFloat(normalizeAmount(amount)) > max;
 }

--- a/examples/ui/app/cross-chain/utils/routeSelection.ts
+++ b/examples/ui/app/cross-chain/utils/routeSelection.ts
@@ -1,9 +1,10 @@
+import { DemoToken } from '../constants/display';
 import { findTokenCaseInsensitive, type RouteParams } from './routeParams';
 import type { SwapFormMode } from '../stores/crossChainStore';
 import type { UITokenInfo } from '../types/assets';
 
 /** Tokens shown in the demo app. Anything outside this list is hidden regardless of provider. */
-const WHITELISTED_SYMBOLS = new Set(['ETH', 'WETH', 'USDC', 'USDT', 'DAI', 'WBTC', 'cbBTC', 'mockUSDC']);
+const WHITELISTED_SYMBOLS = new Set<string>(Object.values(DemoToken));
 
 export interface Selection {
   inputChainId: number;

--- a/examples/ui/tests/cross-chain.spec.ts
+++ b/examples/ui/tests/cross-chain.spec.ts
@@ -178,8 +178,10 @@ test.describe('Recipient address input', () => {
 
 test.describe('Amount input validation', () => {
   test('should enable Get Quotes button for valid positive amount', async ({ page }) => {
+    await page.getByTestId('input-token-select').click();
+    await page.getByTestId('input-token-select-listbox').getByText('USDC').click();
     await page.getByRole('textbox', { name: 'Amount' }).fill('10');
-    await expect(page.locator('button[type="submit"]')).toBeEnabled();
+    await expect(page.getByTestId('submit-button')).toBeEnabled();
   });
 
   test('should strip letters from input', async ({ page }) => {
@@ -281,9 +283,11 @@ test.describe('Build Quote submit validation', () => {
     await expect(page.getByRole('textbox', { name: 'Amount' })).toBeVisible({ timeout: 15000 });
 
     await page.getByRole('button', { name: 'Build Quote' }).click();
+    await page.getByTestId('input-token-select').click();
+    await page.getByTestId('input-token-select-listbox').getByText('USDC').click();
     await page.getByLabel('You send').fill('10');
 
-    const submitBtn = page.locator('button[type="submit"]');
+    const submitBtn = page.getByTestId('submit-button');
     await expect(submitBtn).toBeDisabled();
     await expect(submitBtn).toHaveText('Build Quote');
   });

--- a/examples/ui/tests/demo-limits.spec.ts
+++ b/examples/ui/tests/demo-limits.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+const MOCK_TOKENS = [
+  { chainId: 11155111, address: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238', symbol: 'USDC', decimals: 6 },
+  { chainId: 84532, address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e', symbol: 'USDC', decimals: 6 },
+  { chainId: 421614, address: '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d', symbol: 'USDC', decimals: 6 },
+];
+
+test.beforeEach(async ({ page, context }) => {
+  await context.route('**/api/swap/tokens**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_TOKENS),
+    });
+  });
+
+  await context.route('**/oif-api.openzeppelin.com/**', (route) => route.abort('blockedbyclient'));
+
+  await page.goto('/cross-chain?testnet=true');
+  await expect(page.getByTestId('input-token-select')).toBeVisible({ timeout: 15000 });
+});
+
+test.describe('Demo banner', () => {
+  test('shows warning banner on the cross-chain page', async ({ page }) => {
+    await expect(page.getByText('This is a demo app for testing and experimentation')).toBeVisible();
+  });
+});
+
+test.describe('Demo amount limits', () => {
+  test('disables submit when USDC amount exceeds 100', async ({ page }) => {
+    await page.getByTestId('input-token-select').click();
+    await page.getByTestId('input-token-select-listbox').getByText('USDC').click();
+
+    await page.getByRole('textbox', { name: 'Amount' }).fill('101');
+
+    const submitBtn = page.getByTestId('submit-button');
+    await expect(submitBtn).toBeDisabled();
+    await expect(submitBtn).toHaveText('Amount too large for demo');
+  });
+
+  test('allows submit when USDC amount is exactly 100', async ({ page }) => {
+    await page.getByTestId('input-token-select').click();
+    await page.getByTestId('input-token-select-listbox').getByText('USDC').click();
+
+    await page.getByRole('textbox', { name: 'Amount' }).fill('100');
+
+    await expect(page.getByTestId('submit-button')).toBeEnabled();
+  });
+
+  test('disables submit in build quote mode too', async ({ page }) => {
+    await page.getByRole('button', { name: 'Build Quote' }).click();
+
+    await page.getByTestId('input-token-select').click();
+    await page.getByTestId('input-token-select-listbox').getByText('USDC').click();
+
+    await page.getByLabel('You send').fill('200');
+
+    await expect(page.getByTestId('submit-button')).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a warning banner to the cross-chain page ("This is a demo app for testing and experimentation. Do not use large amounts.")
- Caps input amounts per token symbol: USDC/USDT/DAI at 100, ETH/WETH at 0.03, BTC/WBTC at 0.001
- Submit button shows "Amount too large for demo" and disables when the limit is exceeded
- Tokens not in the limit map are unrestricted

## Test plan

- 21 unit tests for `exceedsDemoLimit` covering all token types, edge cases (undefined/empty symbol, invalid amounts, case insensitivity, comma decimals)
- 4 Playwright e2e tests in `demo-limits.spec.ts` (banner visibility, submit disabled at 101 USDC, enabled at 100, disabled in build quote mode)

Closes EFI-865