### PR TITLE
fix(chore): changelog headers to match @wonderland package scope

### DIFF
--- a/apps/sdk/CHANGELOG.md
+++ b/apps/sdk/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @defi-wonderland/interop
+# @wonderland/interop
 
 ## 0.3.3
 

--- a/packages/addresses/CHANGELOG.md
+++ b/packages/addresses/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @defi-wonderland/interop-addresses
+# @wonderland/interop-addresses
 
 ## 0.5.1
 

--- a/packages/cross-chain/CHANGELOG.md
+++ b/packages/cross-chain/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @defi-wonderland/interop-cross-chain
+# @wonderland/interop-cross-chain
 
 ## 0.5.0
 


### PR DESCRIPTION
CHANGELOG.md headers in three packages still used the old @defi-wonderland/* scope while package.json already uses @wonderland/*. Changesets only appends new entries and never rewrites the header, so this needed a manual fix.

Changed:
- apps/sdk/CHANGELOG.md
- packages/addresses/CHANGELOG.md
- packages/cross-chain/CHANGELOG.md