### PR TITLE
fix: wrap raw errors in ProviderGetQuoteFailure in Relay provider

### DIFF
--- a/.changeset/relay-error-wrapping.md
+++ b/.changeset/relay-error-wrapping.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Wrap raw errors in ProviderGetQuoteFailure in Relay provider collectQuotes

--- a/packages/cross-chain/src/protocols/relay/provider.ts
+++ b/packages/cross-chain/src/protocols/relay/provider.ts
@@ -198,7 +198,14 @@ export class RelayProvider extends CrossChainProvider {
         if (quotes.length > 0) return quotes;
 
         const firstError = results.find((r): r is PromiseRejectedResult => r.status === "rejected");
+        const reason = firstError?.reason;
 
-        throw firstError?.reason ?? new ProviderGetQuoteFailure("No quotes returned");
+        if (reason instanceof ProviderGetQuoteFailure) throw reason;
+
+        throw new ProviderGetQuoteFailure(
+            reason instanceof Error ? reason.message : "No quotes returned",
+            undefined,
+            reason instanceof Error ? reason.stack : undefined,
+        );
     }
 }


### PR DESCRIPTION
## Summary

The `collectQuotes` method in the Relay provider was rethrowing raw errors when all quote modes failed. Any error that wasn't already a `ProviderGetQuoteFailure` would leak through to the aggregator boundary, breaking uniform error handling.

Now the method checks whether the error is already a `ProviderGetQuoteFailure` (rethrows as-is) or wraps it in one, preserving the original message and stack trace.