### PR TITLE
fix: restrict RelayPostBodySchema.api to valid enum values

### DIFF
--- a/.changeset/relay-schema-api-enum.md
+++ b/.changeset/relay-schema-api-enum.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Restrict RelayPostBodySchema.api to valid enum values matching the submit schema

--- a/packages/cross-chain/src/protocols/relay/schemas.ts
+++ b/packages/cross-chain/src/protocols/relay/schemas.ts
@@ -166,7 +166,7 @@ const RelaySignDataSchema = z.discriminatedUnion("signatureKind", [
 const RelayPostBodySchema = z.object({
     kind: z.string(),
     requestId: z.string().optional(),
-    api: z.string().optional(),
+    api: z.enum(["bridge", "swap", "user-swap"]).optional(),
 });
 
 /** Schema for the post endpoint info in a signature step. */


### PR DESCRIPTION
Aligned RelayPostBodySchema.api with the submit schema (RelaySubmitPermitRequestSchema) by replacing z.string() with z.enum(["bridge", "swap", "user-swap"]). Invalid values now fail at parse time instead of at submission.

Source: Relay OpenAPI spec (api.relay.link/documentation/json), /execute/permits endpoint:

```json
"api": {
  "type": "string",
  "enum": ["bridge", "swap", "user-swap"],
  "description": "The API value returned from the quote API steps body field."
}
```