### PR TITLE
fix: remove 4xx special-casing in LI.FI Intents provider

### DIFF
--- a/.changeset/lifi-uniform-errors.md
+++ b/.changeset/lifi-uniform-errors.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Remove 4xx special-casing in LI.FI Intents provider for uniform error handling

--- a/packages/cross-chain/src/protocols/lifi-intents/provider.ts
+++ b/packages/cross-chain/src/protocols/lifi-intents/provider.ts
@@ -88,13 +88,6 @@ export class LifiIntentsProvider extends CrossChainProvider {
                 .map((q) => adaptQuoteResponse(q, this.providerId));
         } catch (error) {
             if (error instanceof ProviderGetQuoteFailure) throw error;
-            if (error instanceof AxiosError && error.response) {
-                const status = error.response.status;
-                // 400/404/422 = unsupported route or bad request, not a real error
-                if (status === 400 || status === 404 || status === 422) {
-                    return [];
-                }
-            }
             if (error instanceof AxiosError) {
                 throw new ProviderGetQuoteFailure(
                     `LI.FI Intents quote failed: ${error.message}`,

--- a/packages/cross-chain/test/providers/LifiIntentsProvider.spec.ts
+++ b/packages/cross-chain/test/providers/LifiIntentsProvider.spec.ts
@@ -180,7 +180,7 @@ describe("LifiIntentsProvider", () => {
             expect(quotes).toHaveLength(0);
         });
 
-        it("returns empty array on 4xx HTTP error (unsupported route)", async () => {
+        it("throws ProviderGetQuoteFailure on 4xx HTTP error", async () => {
             const error = new AxiosError("Request failed", "ERR_BAD_REQUEST");
             error.response = {
                 status: 400,
@@ -191,8 +191,9 @@ describe("LifiIntentsProvider", () => {
             } as AxiosError["response"];
             vi.mocked(axios.post).mockRejectedValue(error);
 
-            const quotes = await provider.getQuotes(mockQuoteRequest);
-            expect(quotes).toHaveLength(0);
+            await expect(provider.getQuotes(mockQuoteRequest)).rejects.toThrow(
+                ProviderGetQuoteFailure,
+            );
         });
 
         it("throws ProviderGetQuoteFailure on 5xx server error", async () => {


### PR DESCRIPTION
LI.FI Intents was the only provider returning empty arrays for 4xx responses instead of throwing ProviderGetQuoteFailure. Across, OIF, and Relay all wrap HTTP errors uniformly. Removed the special-casing so LI.FI matches the rest.

Updated the corresponding test to expect ProviderGetQuoteFailure on 4xx errors.