### PR TITLE
fix: improve error messages for discovery failures and permit submission

### DIFF
--- a/.changeset/error-message-clarity.md
+++ b/.changeset/error-message-clarity.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Distinguish missing token metadata from different-asset errors in buildQuote validation, fix misleading "Failed to get" prefix in Relay permit submission errors

--- a/packages/cross-chain/src/core/validators/buildQuoteValidator.ts
+++ b/packages/cross-chain/src/core/validators/buildQuoteValidator.ts
@@ -1,4 +1,5 @@
 import type { BuildQuoteRequest } from "../schemas/quoteRequest.js";
+import { AssetDiscoveryFailure } from "../errors/AssetDiscoveryFailure.exception.js";
 import { DifferentAssetNotAllowed } from "../errors/DifferentAssetNotAllowed.exception.js";
 import { InsufficientFee } from "../errors/InsufficientFee.exception.js";
 import { InvalidDeadline } from "../errors/InvalidDeadline.exception.js";
@@ -22,7 +23,8 @@ type AssetRelationship = "same" | "different" | "unknown";
  * @throws ZeroAmount if input or output amount is zero
  * @throws InvalidDeadline if deadline is in the past or too soon
  * @throws SameChainIntentNotAllowed if input and output are on the same chain
- * @throws DifferentAssetNotAllowed if input and output are different assets or metadata is unavailable
+ * @throws AssetDiscoveryFailure if token metadata is unavailable for either asset
+ * @throws DifferentAssetNotAllowed if input and output are confirmed different assets
  * @throws InsufficientFee if same-token output amount >= input amount
  */
 export function validateBuildQuoteParams(
@@ -82,9 +84,17 @@ function validateNotSameChain(inputChainId: number, outputChainId: number): void
     }
 }
 
-/** @throws DifferentAssetNotAllowed if assets are confirmed different or metadata is unavailable. */
+/**
+ * @throws AssetDiscoveryFailure if token metadata is missing for either asset.
+ * @throws DifferentAssetNotAllowed if assets are confirmed different.
+ */
 function validateSameAssetRequired(relationship: AssetRelationship): void {
-    if (relationship !== "same") {
+    if (relationship === "unknown") {
+        throw new AssetDiscoveryFailure(
+            "Token metadata is unavailable for one or both assets. Cannot verify they are the same token. Use allowDangerousParameters to skip this check.",
+        );
+    }
+    if (relationship === "different") {
         throw new DifferentAssetNotAllowed();
     }
 }

--- a/packages/cross-chain/src/protocols/relay/services/RelayApiService.ts
+++ b/packages/cross-chain/src/protocols/relay/services/RelayApiService.ts
@@ -84,7 +84,12 @@ export class RelayApiService {
             });
             return RelaySubmitPermitResponseSchema.parse(response.data);
         } catch (error) {
-            this.throwProviderError(error, ProviderExecuteFailure, "Relay permit submission");
+            this.throwProviderError(
+                error,
+                ProviderExecuteFailure,
+                "Relay permit submission",
+                "submit",
+            );
         }
     }
 
@@ -93,6 +98,7 @@ export class RelayApiService {
         error: unknown,
         ErrorClass: new (message: string, cause?: string, stack?: string) => Error,
         operation: string,
+        verb: string = "get",
     ): never {
         const cause =
             error instanceof AxiosError
@@ -102,7 +108,7 @@ export class RelayApiService {
                   : String(error);
 
         throw new ErrorClass(
-            `Failed to get ${operation}`,
+            `Failed to ${verb} ${operation}`,
             cause,
             error instanceof Error ? error.stack : undefined,
         );

--- a/packages/cross-chain/test/validators/buildQuoteValidator.spec.ts
+++ b/packages/cross-chain/test/validators/buildQuoteValidator.spec.ts
@@ -3,6 +3,7 @@ import { arbitrum, base, mainnet, optimism } from "viem/chains";
 import { describe, expect, it } from "vitest";
 
 import type { BuildQuoteRequest } from "../../src/core/schemas/quoteRequest.js";
+import { AssetDiscoveryFailure } from "../../src/core/errors/AssetDiscoveryFailure.exception.js";
 import { DifferentAssetNotAllowed } from "../../src/core/errors/DifferentAssetNotAllowed.exception.js";
 import { InsufficientFee } from "../../src/core/errors/InsufficientFee.exception.js";
 import { InvalidDeadline } from "../../src/core/errors/InvalidDeadline.exception.js";
@@ -111,7 +112,8 @@ describe("validateBuildQuoteParams", () => {
                 input: { chainId: mainnet.id, assetAddress: USDC_MAINNET, amount: "1000000" },
                 output: { chainId: optimism.id, assetAddress: USDC_OPTIMISM, amount: "990000" },
             });
-            expect(() => validate(params, {})).toThrow(DifferentAssetNotAllowed);
+            expect(() => validate(params, {})).toThrow(AssetDiscoveryFailure);
+            expect(() => validate(params, {})).toThrow("Token metadata is unavailable");
         });
 
         it("matches addresses case-insensitively", () => {


### PR DESCRIPTION
Two error message fixes. buildQuote now distinguishes missing token metadata from actual asset mismatches, so discovery outages don't look like user errors. Relay's throwProviderError accepts a verb parameter so permit submission errors say "submit" instead of "get".