### PR TITLE
docs(cross-chain): add OrderStatus table, tracker API matrix, mixed-step note

### DIFF
--- a/apps/docs/docs/cross-chain/intent-tracking.md
+++ b/apps/docs/docs/cross-chain/intent-tracking.md
@@ -38,12 +38,12 @@ The SDK exposes three ways to track an order. Choose based on your use case:
 
 | API | How to call | Input | Use when |
 |-----|-------------|-------|----------|
-| `aggregator.track()` | Event-emitter | `txHash` + `providerId` | You have a tx hash and want real-time events |
-| `tracker.watchOrder()` | Async generator | `txHash` or `orderId` | You need `orderId`-based tracking (required for signature-based/gasless orders), or prefer async iteration |
-| `aggregator.getOrderStatus()` | One-shot promise | `txHash` + `providerId` | You only need the current status without streaming |
+| `aggregator.track()` | Event-emitter | `txHash` + `providerId` + `originChainId` + `destinationChainId` | You have a tx hash and want real-time events |
+| `tracker.watchOrder()` | Async generator | (`txHash` + `originChainId`) or (`orderId` + `originChainId` + `destinationChainId`) | You need `orderId`-based tracking (required for signature-based/gasless orders), or prefer async iteration |
+| `aggregator.getOrderStatus()` | One-shot promise | `txHash` + `providerId` + `originChainId` | You only need the current status without streaming |
 
 :::warning
-`watchOrder` is currently the only path that supports tracking by `orderId`. Signature-based (gasless) orders may not have a `txHash` at open time — for those, `orderId` tracking is required. Pass a `WatchOrderByOrderId` param (with `orderId` and `destinationChainId`) instead of `WatchOrderByTxHash`.
+`watchOrder` is currently the only path that supports tracking by `orderId`. Signature-based (gasless) orders may not have a `txHash` at open time — for those, `orderId` tracking is required. Pass a `WatchOrderByOrderId` param (with `orderId`, `originChainId`, and `destinationChainId`) instead of `WatchOrderByTxHash`.
 :::
 
 :::info Mixed-step orders

--- a/apps/docs/docs/cross-chain/intent-tracking.md
+++ b/apps/docs/docs/cross-chain/intent-tracking.md
@@ -11,24 +11,44 @@ Tracking supports **two ways of observing the same lifecycle**, depending on the
 
 ## Overview
 
-The `OrderTracker` streams updates using the full OIF `OrderStatus` set (see the OIF Order API docs for the canonical list). Depending on the provider, you may observe statuses such as:
+The `OrderTracker` streams updates using the full OIF `OrderStatus` set (from `@openintentsframework/oif-specs`). Not every provider emits every status — the table below shows which statuses each provider actually produces:
 
--   **Created**
--   **Pending**
--   **Executing**
--   **Executed**
--   **Settling**
--   **Settled**
--   **Finalized**
--   **Failed**
--   **Refunded**
+| Status | Description | Across | Relay | OIF | Bungee |
+|--------|-------------|--------|-------|-----|--------|
+| `Created` | Order created on-chain | — | — | ✓ | — |
+| `Pending` | Awaiting execution | ✓ | ✓ | ✓ | ✓ |
+| `Executing` | Filler is processing the order | — | ✓ | ✓ | ✓ |
+| `Executed` | Fill transaction submitted | — | — | ✓ | — |
+| `Settling` | Settlement in progress | — | ✓ | — | — |
+| `Settled` | Settlement complete (reserved) | — | — | — | — |
+| `Finalized` | Order fully complete | ✓ | ✓ | ✓ | ✓ |
+| `Failed` | Order failed | ✓ | ✓ | ✓ | ✓ |
+| `Refunded` | Funds returned to sender | ✓ | ✓ | ✓ | ✓ |
 
-In other words, you can subscribe to **any** `OrderStatus` via `tracker.on(OrderStatus.<status>, ...)` --- the examples below just show the most common ones.
+You can subscribe to **any** `OrderStatus` via `tracker.on(OrderStatus.<status>, ...)` — the examples below show the most common ones.
 
 In addition, the tracker can emit:
 
 -   `Timeout` - the SDK stopped watching (the order may still finalize before its onchain deadline)
 -   `Error` - an unexpected error occurred
+
+## Which Tracker API to Use?
+
+The SDK exposes three ways to track an order. Choose based on your use case:
+
+| API | How to call | Input | Use when |
+|-----|-------------|-------|----------|
+| `aggregator.track()` | Event-emitter | `txHash` + `providerId` | You have a tx hash and want real-time events |
+| `tracker.watchOrder()` | Async generator | `txHash` or `orderId` | You need `orderId`-based tracking (required for signature-based/gasless orders), or prefer async iteration |
+| `aggregator.getOrderStatus()` | One-shot promise | `txHash` + `providerId` | You only need the current status without streaming |
+
+:::warning
+`watchOrder` is currently the only path that supports tracking by `orderId`. Signature-based (gasless) orders may not have a `txHash` at open time — for those, `orderId` tracking is required. Pass a `WatchOrderByOrderId` param (with `orderId` and `destinationChainId`) instead of `WatchOrderByTxHash`.
+:::
+
+:::info Mixed-step orders
+Mixed-step orders (containing both transaction steps and signature steps) are not currently emitted by any supported provider. Consumers can safely handle either `isSignatureOnlyOrder()` or `isTransactionOnlyOrder()` without defensive mixed-order handling.
+:::
 
 ## Basic Usage
 


### PR DESCRIPTION
## Summary

- Replaces the bullet list of `OrderStatus` values in the Overview section with a complete 9-row table showing which statuses each provider (Across, Relay, OIF, Bungee) actually emits — verified directly against provider status-map source files
- Adds a new "Which Tracker API to Use?" section with a comparison table for `aggregator.track()` (event-emitter), `tracker.watchOrder()` (async generator), and `aggregator.getOrderStatus()` (one-shot promise)
- Adds a `:::warning` callout explaining that `watchOrder` is the only path supporting `orderId`-based tracking, required for signature-based/gasless orders that have no `txHash` at open time
- Adds a `:::info` callout clarifying that mixed-step orders are not emitted by any current provider

## Test plan

- [x] `pnpm build` in `apps/docs` passes with no errors
- [x] Status table rows verified against: `AcrossProvider.getFillWatcherConfigAPI()`, `RELAY_STATUS_MAP`, `BUNGEE_STATUS_MAP`, OIF `adaptOrderStatus` passthrough
- [x] `WatchOrderByOrderId` / `WatchOrderByTxHash` discriminated union confirmed in `packages/cross-chain/src/core/types/orderTracking.ts`
- [x] `isSignatureOnlyOrder` / `isTransactionOnlyOrder` confirmed in `packages/cross-chain/src/core/utils/stepHelpers.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)