### PR TITLE
docs(cross-chain): add mainnet example and ERC-20 approval flow

### DIFF
--- a/apps/docs/docs/cross-chain/example.md
+++ b/apps/docs/docs/cross-chain/example.md
@@ -145,18 +145,21 @@ const allowances = quote.order.checks?.allowances ?? [];
 
 if (allowances.length > 0) {
     for (const { tokenAddress, spender, required } of allowances) {
+        const token = tokenAddress as `0x${string}`;
+        const spenderAddr = spender as `0x${string}`;
+
         const allowance = await publicClient.readContract({
-            address: tokenAddress,
+            address: token,
             abi: erc20Abi,
             functionName: "allowance",
-            args: [privateAccount.address, spender],
+            args: [privateAccount.address, spenderAddr],
         });
         if (allowance < BigInt(required)) {
             const hash = await walletClient.writeContract({
-                address: tokenAddress,
+                address: token,
                 abi: erc20Abi,
                 functionName: "approve",
-                args: [spender, BigInt(required)],
+                args: [spenderAddr, BigInt(required)],
             });
             await publicClient.waitForTransactionReceipt({ hash });
         }
@@ -168,18 +171,19 @@ if (allowances.length > 0) {
     // Fallback: provider didn't supply checks (e.g. Across).
     // Approve the transaction target for the quoted input amount.
     const step = getTransactionSteps(quote.order)[0];
-    const spender = step.transaction.to;
+    const spender = step.transaction.to as `0x${string}`;
     const inputPreview = quote.preview.inputs[0];
+    const token = inputPreview.assetAddress as `0x${string}`;
 
     const allowance = await publicClient.readContract({
-        address: inputPreview.assetAddress as `0x${string}`,
+        address: token,
         abi: erc20Abi,
         functionName: "allowance",
         args: [privateAccount.address, spender],
     });
     if (allowance < BigInt(inputPreview.amount)) {
         const hash = await walletClient.writeContract({
-            address: inputPreview.assetAddress as `0x${string}`,
+            address: token,
             abi: erc20Abi,
             functionName: "approve",
             args: [spender, BigInt(inputPreview.amount)],
@@ -191,7 +195,7 @@ if (allowances.length > 0) {
 
 :::info Why two paths?
 
-Not all providers populate `order.checks.allowances` on `getQuotes` — for example, Across does not. The fallback derives the spender from the transaction step's `to` address (the contract that will pull tokens). Signature-only (gasless) orders and native token inputs are skipped because they don't require an ERC-20 approval.
+Always honor `order.checks.allowances` when present — some providers (e.g. Relay) include required approvals there even for signature-only orders. Not all providers populate this field though (e.g. Across does not), so the fallback derives the spender from the transaction step's `to` address. The fallback only runs for transaction-based orders with ERC-20 inputs; signature-only orders without checks and native token inputs are skipped.
 
 :::
 

--- a/apps/docs/docs/cross-chain/example.md
+++ b/apps/docs/docs/cross-chain/example.md
@@ -166,22 +166,23 @@ if (allowances.length > 0) {
     !isNativeAddress(request.input.assetAddress, "eip155")
 ) {
     // Fallback: provider didn't supply checks (e.g. Across).
-    // Approve the transaction target for the input amount.
+    // Approve the transaction target for the quoted input amount.
     const step = getTransactionSteps(quote.order)[0];
     const spender = step.transaction.to;
+    const inputPreview = quote.preview.inputs[0];
 
     const allowance = await publicClient.readContract({
-        address: request.input.assetAddress as `0x${string}`,
+        address: inputPreview.assetAddress as `0x${string}`,
         abi: erc20Abi,
         functionName: "allowance",
         args: [privateAccount.address, spender],
     });
-    if (allowance < BigInt(request.input.amount)) {
+    if (allowance < BigInt(inputPreview.amount)) {
         const hash = await walletClient.writeContract({
-            address: request.input.assetAddress as `0x${string}`,
+            address: inputPreview.assetAddress as `0x${string}`,
             abi: erc20Abi,
             functionName: "approve",
-            args: [spender, BigInt(request.input.amount)],
+            args: [spender, BigInt(inputPreview.amount)],
         });
         await publicClient.waitForTransactionReceipt({ hash });
     }

--- a/apps/docs/docs/cross-chain/example.md
+++ b/apps/docs/docs/cross-chain/example.md
@@ -10,7 +10,7 @@ This guide demonstrates how to execute a cross-chain intent using the SDK. The p
 
 First, import the required libraries and set up your environment variables, such as your private key and a generic RPC URL.
 
-```js
+```typescript
 import {
     createAggregator,
     createCrossChainProvider,
@@ -35,7 +35,7 @@ const privateAccount = privateKeyToAccount(PRIVATE_KEY);
 
 Create public and wallet clients for interacting with the blockchain, using the generic RPC URL.
 
-```js
+```typescript
 const publicClient = createPublicClient({
     chain: sepolia,
     transport: http(RPC_URL),
@@ -52,9 +52,24 @@ const walletClient = createWalletClient({
 
 Initialize the cross-chain provider and aggregator, which will handle quoting and executing cross-chain transfers.
 
-```js
+### Testnet (Sepolia → Base Sepolia)
+
+```typescript
 const acrossProvider = createCrossChainProvider("across", { isTestnet: true });
 const relayProvider = createCrossChainProvider("relay", { isTestnet: true });
+
+const aggregator = createAggregator({
+    providers: [acrossProvider, relayProvider],
+});
+```
+
+### Mainnet (Base → Arbitrum)
+
+For mainnet, omit `isTestnet` (or set it to `false`) and use the corresponding mainnet chain IDs when building your clients (step 2) and quote request (step 4).
+
+```typescript
+const acrossProvider = createCrossChainProvider("across");
+const relayProvider = createCrossChainProvider("relay");
 
 const aggregator = createAggregator({
     providers: [acrossProvider, relayProvider],
@@ -65,41 +80,95 @@ const aggregator = createAggregator({
 
 Request a quote for a cross-chain transfer using the SDK `QuoteRequest` format.
 
-```js
+### Testnet example
+
+```typescript
 const response = await aggregator.getQuotes({
     user: "0xYourAddress",
     input: {
-        chainId: 11155111,
+        chainId: 11155111, // Sepolia
         assetAddress: "0xInputTokenAddress",
         amount: "100000000000000000", // 0.1 in wei
     },
     output: {
-        chainId: 84532,
+        chainId: 84532, // Base Sepolia
+        assetAddress: "0xOutputTokenAddress",
+        recipient: "0xRecipientAddress",
+    },
+    swapType: "exact-input",
+});
+```
+
+### Mainnet example (Base → Arbitrum)
+
+```typescript
+const response = await aggregator.getQuotes({
+    user: "0xYourAddress",
+    input: {
+        chainId: 8453, // Base
+        assetAddress: "0xInputTokenAddress",
+        amount: "100000000000000000", // 0.1 in wei
+    },
+    output: {
+        chainId: 42161, // Arbitrum One
         assetAddress: "0xOutputTokenAddress",
         recipient: "0xRecipientAddress",
     },
     swapType: "exact-input",
 });
 
-// Check for errors
 if (response.errors.length > 0) {
     console.error("Errors:", response.errors);
 }
 
-// Check if we got quotes
 if (response.quotes.length === 0) {
     console.error("No quotes available");
     return;
 }
 ```
 
-## 5. Execute the Cross-Chain Transaction
+## 5. Check and Handle ERC-20 Approvals
+
+Before submitting the transaction, check whether the selected provider requires an ERC-20 token approval.
+
+```typescript
+import { erc20Abi } from "viem";
+
+const quote = response.quotes[0];
+
+const allowances = quote.order.checks?.allowances ?? [];
+for (const { tokenAddress, spender, required } of allowances) {
+    const allowance = await publicClient.readContract({
+        address: tokenAddress,
+        abi: erc20Abi,
+        functionName: "allowance",
+        args: [account.address, spender],
+    });
+    if (allowance < BigInt(required)) {
+        const hash = await walletClient.writeContract({
+            address: tokenAddress,
+            abi: erc20Abi,
+            functionName: "approve",
+            args: [spender, BigInt(required)],
+        });
+        await publicClient.waitForTransactionReceipt({ hash });
+    }
+}
+```
+
+:::warning ERC-20 approval behaviour varies by provider
+
+- `checks.allowances` is only populated by **some providers** (OIF, Bungee). When it is present, the loop above handles approvals automatically.
+- **Across does NOT populate `checks.allowances`.** If you are bridging an ERC-20 with Across, you must approve the input token to `step.transaction.to` yourself before calling `walletClient.sendTransaction`.
+- For **native ETH transfers**, no approval is needed regardless of which provider you use.
+
+:::
+
+## 6. Execute the Cross-Chain Transaction
 
 Execute the quote based on its order step type:
 
-```js
-const quote = response.quotes[0];
-
+```typescript
 if (isSignatureOnlyOrder(quote.order)) {
     // Protocol mode: sign and submit (gasless for user)
     // Note: production code should handle all steps, not just the first
@@ -129,11 +198,11 @@ if (isSignatureOnlyOrder(quote.order)) {
 }
 ```
 
-## 6. Run the Main Function
+## 7. Run the Main Function
 
 Finally, call the main function to execute the workflow.
 
-```js
+```typescript
 const main = async (): Promise<void> => {
     // ...all the above steps go here...
 };

--- a/apps/docs/docs/cross-chain/example.md
+++ b/apps/docs/docs/cross-chain/example.md
@@ -17,6 +17,7 @@ import {
     getSignatureSteps,
     getTransactionSteps,
     isSignatureOnlyOrder,
+    isNativeAddress,
 } from "@wonderland/interop-cross-chain";
 import { createPublicClient, createWalletClient, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
@@ -131,36 +132,65 @@ if (response.quotes.length === 0) {
 
 Before submitting the transaction, check whether the selected provider requires an ERC-20 token approval.
 
+Some providers (Relay, Bungee, OIF) populate `quote.order.checks.allowances` with the exact spender and amount. Others (e.g. Across) do not. The snippet below handles both cases: when checks are present it uses them directly, otherwise it derives the approval from the transaction step's `to` address.
+
 ```typescript
 import { erc20Abi } from "viem";
 
 const quote = response.quotes[0];
+const request = { /* the QuoteRequest you passed to getQuotes */ };
 
+// Primary path: use checks.allowances when the provider populates it
 const allowances = quote.order.checks?.allowances ?? [];
-for (const { tokenAddress, spender, required } of allowances) {
-    const allowance = await publicClient.readContract({
-        address: tokenAddress,
-        abi: erc20Abi,
-        functionName: "allowance",
-        args: [account.address, spender],
-    });
-    if (allowance < BigInt(required)) {
-        const hash = await walletClient.writeContract({
+
+if (allowances.length > 0) {
+    for (const { tokenAddress, spender, required } of allowances) {
+        const allowance = await publicClient.readContract({
             address: tokenAddress,
             abi: erc20Abi,
+            functionName: "allowance",
+            args: [privateAccount.address, spender],
+        });
+        if (allowance < BigInt(required)) {
+            const hash = await walletClient.writeContract({
+                address: tokenAddress,
+                abi: erc20Abi,
+                functionName: "approve",
+                args: [spender, BigInt(required)],
+            });
+            await publicClient.waitForTransactionReceipt({ hash });
+        }
+    }
+} else if (
+    !isSignatureOnlyOrder(quote.order) &&
+    !isNativeAddress(request.input.assetAddress, "eip155")
+) {
+    // Fallback: provider didn't supply checks (e.g. Across).
+    // Approve the transaction target for the input amount.
+    const step = getTransactionSteps(quote.order)[0];
+    const spender = step.transaction.to;
+
+    const allowance = await publicClient.readContract({
+        address: request.input.assetAddress as `0x${string}`,
+        abi: erc20Abi,
+        functionName: "allowance",
+        args: [privateAccount.address, spender],
+    });
+    if (allowance < BigInt(request.input.amount)) {
+        const hash = await walletClient.writeContract({
+            address: request.input.assetAddress as `0x${string}`,
+            abi: erc20Abi,
             functionName: "approve",
-            args: [spender, BigInt(required)],
+            args: [spender, BigInt(request.input.amount)],
         });
         await publicClient.waitForTransactionReceipt({ hash });
     }
 }
 ```
 
-:::warning ERC-20 approval behaviour varies by provider
+:::info Why two paths?
 
-- `checks.allowances` is only populated by **some providers** (OIF, Bungee). When it is present, the loop above handles approvals automatically.
-- **Across does NOT populate `checks.allowances`.** If you are bridging an ERC-20 with Across, you must approve the input token to `step.transaction.to` yourself before calling `walletClient.sendTransaction`.
-- For **native ETH transfers**, no approval is needed regardless of which provider you use.
+Not all providers populate `order.checks.allowances` on `getQuotes` — for example, Across does not. The fallback derives the spender from the transaction step's `to` address (the contract that will pull tokens). Signature-only (gasless) orders and native token inputs are skipped because they don't require an ERC-20 approval.
 
 :::
 

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -80,6 +80,42 @@ const quote = quotes[0];
 console.log(`Quote from ${quote.provider}`);
 ```
 
+### Native tokens (ETH, MATIC, etc.)
+
+To bridge a native asset, use `NATIVE_ASSET_ADDRESS` as the `assetAddress`:
+
+```typescript
+import {
+    createCrossChainProvider,
+    NATIVE_ASSET_ADDRESS,
+} from "@wonderland/interop-cross-chain";
+
+const quotes = await provider.getQuotes({
+    user: account.address,
+    input: {
+        chainId: 11155111, // Sepolia
+        assetAddress: NATIVE_ASSET_ADDRESS,
+        amount: "100000000000000000", // 0.1 ETH in wei
+    },
+    output: {
+        chainId: 84532, // Base Sepolia
+        assetAddress: NATIVE_ASSET_ADDRESS,
+        recipient: account.address,
+    },
+    swapType: "exact-input",
+});
+```
+
+:::info
+Both `0x0000000000000000000000000000000000000000` (zero address) and `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` ([EIP-7528](https://eips.ethereum.org/EIPS/eip-7528)) are accepted by the SDK as native asset sentinels. `NATIVE_ASSET_ADDRESS` exports the EIP-7528 form (`0xeeee...eeee`) and is the canonical constant used in all SDK examples.
+:::
+
+## Handle ERC-20 approvals
+
+Some providers (OIF, Bungee) populate `order.checks.allowances` with the approvals needed before the transaction can be submitted. Check this array and approve as required. For Across, `checks.allowances` is not populated — you must approve the input token to `step.transaction.to` yourself when bridging an ERC-20. Native ETH transfers never need an approval.
+
+See the [full approval pattern](./example.md#5-check-and-handle-erc-20-approvals) in the Execute Intent guide.
+
 ## Execute the transaction
 
 Quotes contain either signature steps (gasless) or transaction steps (user pays gas). Handle both:
@@ -140,10 +176,11 @@ response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`)
 
 1. **Create provider** → `createCrossChainProvider("across")` (or use `createAggregator` for multiple)
 2. **Get quotes** → `provider.getQuotes(request)` or `aggregator.getQuotes(request)`
-3. **Check order type** → `isSignatureOnlyOrder(quote.order)`
+3. **Approve ERC-20 (if needed)** → check `order.checks?.allowances` and approve before submitting (see [approval guide](./example.md#5-check-and-handle-erc-20-approvals))
+4. **Check order type** → `isSignatureOnlyOrder(quote.order)`
     - **Signature (gasless):** `signTypedData()` → `provider.submitOrder(quote, signature)`
     - **Transaction (user pays gas):** `walletClient.sendTransaction(...)` (see [example above](#execute-the-transaction) — convert string `value` to `BigInt`)
-4. **Track** → `createOrderTracker(provider)` for single-provider or `aggregator.track({ txHash, providerId, originChainId, destinationChainId })` for aggregator
+5. **Track** → `createOrderTracker(provider)` for single-provider or `aggregator.track({ txHash, providerId, originChainId, destinationChainId })` for aggregator
 
 ### Which function should I use?
 

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -112,7 +112,7 @@ Both `0x0000000000000000000000000000000000000000` (zero address) and `0xeeeeeeee
 
 ## Handle ERC-20 approvals
 
-Some providers (OIF, Bungee) populate `order.checks.allowances` with the approvals needed before the transaction can be submitted. Check this array and approve as required. For Across, `checks.allowances` is not populated — you must approve the input token to `step.transaction.to` yourself when bridging an ERC-20. Native ETH transfers never need an approval.
+Some providers (Relay, Bungee, OIF) populate `order.checks.allowances` with the exact spender and amount. Others (e.g. Across) do not — in that case, derive the spender from the transaction step's `to` address. Native token inputs and signature-only (gasless) orders don't need an approval.
 
 See the [full approval pattern](./example.md#5-check-and-handle-erc-20-approvals) in the Execute Intent guide.
 

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -112,7 +112,7 @@ Both `0x0000000000000000000000000000000000000000` (zero address) and `0xeeeeeeee
 
 ## Handle ERC-20 approvals
 
-Some providers (Relay, Bungee, OIF) populate `order.checks.allowances` with the exact spender and amount. Others (e.g. Across) do not — in that case, derive the spender from the transaction step's `to` address. Native token inputs and signature-only (gasless) orders don't need an approval.
+Always check `order.checks.allowances` first — some providers (Relay, Bungee, OIF) populate it with the exact spender and amount, even for signature-only orders. When checks are missing (e.g. Across), derive the spender from the transaction step's `to` address. Native token inputs never need an approval.
 
 See the [full approval pattern](./example.md#5-check-and-handle-erc-20-approvals) in the Execute Intent guide.
 


### PR DESCRIPTION
## Summary

- Adds a mainnet snippet to `example.md` (Base → Arbitrum, chain IDs 8453/42161) demonstrating provider setup without `isTestnet`
- Adds a full ERC-20 approval flow using `order.checks.allowances` with a `:::warning` callout explaining that OIF/Bungee populate this field but Across does not (requiring manual approval to `step.transaction.to`)
- Updates `getting-started.md` with an "Handle ERC-20 approvals" section linking to the full pattern, and inserts approval as step 3 in the Quick Reference flow

## Test plan

- [x] `pnpm build` in `apps/docs` passes without errors
- [ ] Verify rendered output: mainnet section appears in step 3 and step 4 of Execute Intent guide
- [ ] Verify warning callout renders correctly in Docusaurus
- [ ] Verify anchor link `./example.md#5-check-and-handle-erc-20-approvals` from getting-started resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)