### PR TITLE
feat(cross-chain): canonicalize native token placeholders across providers

### DIFF
--- a/.changeset/native-address-canonicalization.md
+++ b/.changeset/native-address-canonicalization.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Normalize native token placeholders to the canonical `NATIVE_ASSET_ADDRESS` (EIP-7528 `0xEEE…E`) across discovery, routing, validation, and asset-support lookups, deduplicating ETH in `DiscoveredAssets` when providers report different sentinels (Bungee: `0xEEE…E`, Across/Relay/LI.FI Intents/OIF: `0x000…0`). Each provider's quote-request adapter translates the canonical address to the placeholder its API expects, so callers can pass either variant without breaking any provider. Adds the public `toCanonicalNativeAddress` helper.

--- a/.changeset/native-asset-address-export.md
+++ b/.changeset/native-asset-address-export.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Export `NATIVE_ASSET_ADDRESS` constant (EIP-7528 canonical native sentinel address)

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -80,6 +80,42 @@ const quote = quotes[0];
 console.log(`Quote from ${quote.provider}`);
 ```
 
+### Native tokens (ETH, MATIC, etc.)
+
+To bridge a native asset, use `NATIVE_ASSET_ADDRESS` as the `assetAddress`:
+
+```typescript
+import {
+    createCrossChainProvider,
+    NATIVE_ASSET_ADDRESS,
+} from "@wonderland/interop-cross-chain";
+
+const quotes = await provider.getQuotes({
+    user: account.address,
+    input: {
+        chainId: 11155111, // Sepolia
+        assetAddress: NATIVE_ASSET_ADDRESS,
+        amount: "100000000000000000", // 0.1 ETH in wei
+    },
+    output: {
+        chainId: 84532, // Base Sepolia
+        assetAddress: NATIVE_ASSET_ADDRESS,
+        recipient: account.address,
+    },
+    swapType: "exact-input",
+});
+```
+
+:::info
+Both `0x0000000000000000000000000000000000000000` (zero address) and `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` ([EIP-7528](https://eips.ethereum.org/EIPS/eip-7528)) are accepted by the SDK as native asset sentinels. `NATIVE_ASSET_ADDRESS` exports the EIP-7528 form (`0xeeee...eeee`) and is the canonical constant used in all SDK examples.
+:::
+
+## Handle ERC-20 approvals
+
+Some providers (OIF, Bungee) populate `order.checks.allowances` with the approvals needed before the transaction can be submitted. Check this array and approve as required. For Across, `checks.allowances` is not populated — you must approve the input token to `step.transaction.to` yourself when bridging an ERC-20. Native ETH transfers never need an approval.
+
+See the [full approval pattern](./example.md#5-check-and-handle-erc-20-approvals) in the Execute Intent guide.
+
 ## Execute the transaction
 
 Quotes contain either signature steps (gasless) or transaction steps (user pays gas). Handle both:
@@ -140,10 +176,11 @@ response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`)
 
 1. **Create provider** → `createCrossChainProvider("across")` (or use `createAggregator` for multiple)
 2. **Get quotes** → `provider.getQuotes(request)` or `aggregator.getQuotes(request)`
-3. **Check order type** → `isSignatureOnlyOrder(quote.order)`
+3. **Approve ERC-20 (if needed)** → check `order.checks?.allowances` and approve before submitting (see [approval guide](./example.md#5-check-and-handle-erc-20-approvals))
+4. **Check order type** → `isSignatureOnlyOrder(quote.order)`
     - **Signature (gasless):** `signTypedData()` → `provider.submitOrder(quote, signature)`
     - **Transaction (user pays gas):** `walletClient.sendTransaction(...)` (see [example above](#execute-the-transaction) — convert string `value` to `BigInt`)
-4. **Track** → `createOrderTracker(provider)` for single-provider or `aggregator.track({ txHash, providerId, originChainId, destinationChainId })` for aggregator
+5. **Track** → `createOrderTracker(provider)` for single-provider or `aggregator.track({ txHash, providerId, originChainId, destinationChainId })` for aggregator
 
 ### Which function should I use?
 

--- a/packages/cross-chain/src/core/services/BaseAssetDiscoveryService.ts
+++ b/packages/cross-chain/src/core/services/BaseAssetDiscoveryService.ts
@@ -10,6 +10,7 @@ import {
     NetworkAssets,
 } from "../types/assetDiscovery.js";
 import { toDiscoveredAssets } from "../utils/toDiscoveredAssets.js";
+import { toCanonicalNativeAddress } from "../utils/token.js";
 
 /**
  * Shared configuration for all asset discovery services
@@ -108,8 +109,12 @@ export abstract class BaseAssetDiscoveryService implements AssetDiscoveryService
         const network = await this.getAssetsForChain(chainId, options);
         if (!network) return null;
 
-        const normalizedAddress = assetAddress.toLowerCase();
-        return network.assets.find((a) => a.address.toLowerCase() === normalizedAddress) ?? null;
+        const canonicalAddress = toCanonicalNativeAddress(assetAddress, "eip155");
+        return (
+            network.assets.find(
+                (a) => toCanonicalNativeAddress(a.address, "eip155") === canonicalAddress,
+            ) ?? null
+        );
     }
 
     /**

--- a/packages/cross-chain/src/core/services/aggregator.ts
+++ b/packages/cross-chain/src/core/services/aggregator.ts
@@ -22,6 +22,7 @@ import { CrossChainProvider } from "../interfaces/crossChainProvider.interface.j
 import { SortingStrategy } from "../interfaces/sortingStrategy.interface.js";
 import { BestOutputStrategy } from "../sorting_strategies/bestOutput.strategy.js";
 import { mergeDiscoveredAssets } from "../utils/toDiscoveredAssets.js";
+import { toCanonicalNativeAddress } from "../utils/token.js";
 import {
     validateAssetSupport,
     validateBuildQuoteParams,
@@ -333,9 +334,13 @@ class Aggregator {
         const assets = await this.discoverAssets();
 
         const originMeta =
-            assets.tokenMetadata[query.originChainId]?.[query.originAsset.toLowerCase()];
+            assets.tokenMetadata[query.originChainId]?.[
+                toCanonicalNativeAddress(query.originAsset, "eip155")
+            ];
         const destMeta =
-            assets.tokenMetadata[query.destinationChainId]?.[query.destinationAsset.toLowerCase()];
+            assets.tokenMetadata[query.destinationChainId]?.[
+                toCanonicalNativeAddress(query.destinationAsset, "eip155")
+            ];
 
         if (!originMeta || !destMeta) {
             return [];

--- a/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
+++ b/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
@@ -3,14 +3,17 @@ import type {
     DiscoveredAssetInfo,
     DiscoveredAssets,
 } from "../types/assetDiscovery.js";
+import { isNativeAddress, toCanonicalNativeAddress } from "./token.js";
 
 /**
  * Convert one or more AssetDiscoveryResults into a lookup-friendly
  * DiscoveredAssets structure.
  *
  * Chain grouping uses numeric chain IDs. Token metadata is nested by
- * chain ID then lowercase address to prevent cross-chain collisions.
- * All addresses use plain 0x format.
+ * chain ID then canonical address — native placeholders collapse to the
+ * canonical EIP-7528 form so tokens reported under different sentinels
+ * (e.g. `0xEEE…E` vs `0x000…0`) deduplicate across providers. Non-native
+ * addresses are stored lowercase. All addresses use plain 0x format.
  * Each metadata entry includes a `providers` array listing which provider IDs
  * reported the asset.
  *
@@ -34,21 +37,23 @@ export function toDiscoveredAssets(
             tokenMetadata[chainId] ??= {};
 
             for (const asset of assets) {
-                const addr = asset.address;
-                const addrLower = addr.toLowerCase();
+                const canonicalAddr = toCanonicalNativeAddress(asset.address, "eip155");
+                const publicAddr = isNativeAddress(asset.address, "eip155")
+                    ? canonicalAddr
+                    : asset.address;
 
-                if (!tokensByChain[chainId].includes(addrLower)) {
-                    tokensByChain[chainId].push(addrLower);
+                if (!tokensByChain[chainId].includes(canonicalAddr)) {
+                    tokensByChain[chainId].push(canonicalAddr);
                 }
 
-                const existing = tokenMetadata[chainId][addrLower];
+                const existing = tokenMetadata[chainId][canonicalAddr];
                 if (existing) {
                     if (!existing.providers.includes(result.providerId)) {
                         existing.providers.push(result.providerId);
                     }
                 } else {
-                    tokenMetadata[chainId][addrLower] = {
-                        address: asset.address,
+                    tokenMetadata[chainId][canonicalAddr] = {
+                        address: publicAddr,
                         symbol: asset.symbol,
                         decimals: asset.decimals,
                         providers: [result.providerId],
@@ -68,7 +73,8 @@ export function toDiscoveredAssets(
  * Merge multiple DiscoveredAssets into a single structure.
  *
  * Used by Aggregator to combine results from multiple providers.
- * Deduplicates tokens by address; merges `providers` arrays (first-write-wins
+ * Deduplicates tokens by canonical address (native placeholders collapse
+ * to the canonical EIP-7528 form); merges `providers` arrays (first-write-wins
  * for symbol/decimals, union for providers).
  *
  * @internal Used by Aggregator - not exported publicly
@@ -83,8 +89,9 @@ export function mergeDiscoveredAssets(sources: DiscoveredAssets[]): DiscoveredAs
             const chainId = Number(chainKeyStr);
             tokensByChain[chainId] ??= [];
             for (const token of tokens) {
-                if (!tokensByChain[chainId].includes(token)) {
-                    tokensByChain[chainId].push(token);
+                const canonical = toCanonicalNativeAddress(token, "eip155");
+                if (!tokensByChain[chainId].includes(canonical)) {
+                    tokensByChain[chainId].push(canonical);
                 }
             }
         }
@@ -93,7 +100,8 @@ export function mergeDiscoveredAssets(sources: DiscoveredAssets[]): DiscoveredAs
             const chainId = Number(chainKeyStr);
             tokenMetadata[chainId] ??= {};
             for (const [addr, meta] of Object.entries(chainMeta)) {
-                const existing = tokenMetadata[chainId][addr];
+                const canonical = toCanonicalNativeAddress(addr, "eip155");
+                const existing = tokenMetadata[chainId][canonical];
                 if (existing) {
                     for (const pid of meta.providers) {
                         if (!existing.providers.includes(pid)) {
@@ -101,7 +109,14 @@ export function mergeDiscoveredAssets(sources: DiscoveredAssets[]): DiscoveredAs
                         }
                     }
                 } else {
-                    tokenMetadata[chainId][addr] = { ...meta, providers: [...meta.providers] };
+                    const publicAddr = isNativeAddress(meta.address, "eip155")
+                        ? canonical
+                        : meta.address;
+                    tokenMetadata[chainId][canonical] = {
+                        ...meta,
+                        address: publicAddr,
+                        providers: [...meta.providers],
+                    };
                 }
             }
         }

--- a/packages/cross-chain/src/core/utils/token.ts
+++ b/packages/cross-chain/src/core/utils/token.ts
@@ -6,12 +6,18 @@ type ChainType = "eip155" | "solana";
  */
 export const NATIVE_ASSET_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" as const;
 
+/**
+ * Zero-address native placeholder used by providers that pre-date EIP-7528
+ * (Across, OIF, Relay, LI.FI Intents).
+ */
+export const NATIVE_ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
+
 /** Solana canonical native placeholder — the System Program account. */
 const SOLANA_NATIVE_ADDRESS = "11111111111111111111111111111111" as const;
 
 /** Native token placeholder addresses by chain type. */
 const NATIVE_ADDRESSES: Record<ChainType, Set<string>> = {
-    eip155: new Set([NATIVE_ASSET_ADDRESS, "0x0000000000000000000000000000000000000000"]),
+    eip155: new Set([NATIVE_ASSET_ADDRESS, NATIVE_ZERO_ADDRESS]),
     solana: new Set([SOLANA_NATIVE_ADDRESS]),
 };
 
@@ -39,3 +45,13 @@ export const toCanonicalNativeAddress = (address: string, chainType: ChainType):
     if (isNativeAddress(address, chainType)) return CANONICAL_BY_CHAIN_TYPE[chainType];
     return chainType === "eip155" ? address.toLowerCase() : address;
 };
+
+/**
+ * Map any native placeholder variant to the one a specific provider expects.
+ * Non-native addresses pass through unchanged (original casing preserved).
+ */
+export const withNativePlaceholder = (
+    address: string,
+    chainType: ChainType,
+    placeholder: string,
+): string => (isNativeAddress(address, chainType) ? placeholder : address);

--- a/packages/cross-chain/src/core/utils/token.ts
+++ b/packages/cross-chain/src/core/utils/token.ts
@@ -1,9 +1,12 @@
 type ChainType = "eip155" | "solana";
 
+/** EIP-7528 canonical native asset placeholder address. Use this when constructing QuoteRequests for native tokens (ETH, MATIC, etc.). */
+export const NATIVE_ASSET_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" as const;
+
 /** Native token placeholder addresses by chain type. */
 const NATIVE_ADDRESSES: Record<ChainType, Set<string>> = {
     eip155: new Set([
-        "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        NATIVE_ASSET_ADDRESS,
         "0x0000000000000000000000000000000000000000",
     ]),
     solana: new Set([

--- a/packages/cross-chain/src/core/utils/token.ts
+++ b/packages/cross-chain/src/core/utils/token.ts
@@ -1,14 +1,14 @@
 type ChainType = "eip155" | "solana";
 
-/** EIP-7528 canonical native asset placeholder address. Use this when constructing QuoteRequests for native tokens (ETH, MATIC, etc.). */
+/**
+ * EIP-7528 canonical native asset placeholder address.
+ * Use this when constructing QuoteRequests for native tokens (ETH, MATIC, etc.).
+ */
 export const NATIVE_ASSET_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" as const;
 
 /** Native token placeholder addresses by chain type. */
 const NATIVE_ADDRESSES: Record<ChainType, Set<string>> = {
-    eip155: new Set([
-        NATIVE_ASSET_ADDRESS,
-        "0x0000000000000000000000000000000000000000",
-    ]),
+    eip155: new Set([NATIVE_ASSET_ADDRESS, "0x0000000000000000000000000000000000000000"]),
     solana: new Set([
         "11111111111111111111111111111111", // System Program
     ]),

--- a/packages/cross-chain/src/core/utils/token.ts
+++ b/packages/cross-chain/src/core/utils/token.ts
@@ -6,14 +6,35 @@ type ChainType = "eip155" | "solana";
  */
 export const NATIVE_ASSET_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" as const;
 
+/** Solana canonical native placeholder — the System Program account. */
+const SOLANA_NATIVE_ADDRESS = "11111111111111111111111111111111" as const;
+
 /** Native token placeholder addresses by chain type. */
 const NATIVE_ADDRESSES: Record<ChainType, Set<string>> = {
     eip155: new Set([NATIVE_ASSET_ADDRESS, "0x0000000000000000000000000000000000000000"]),
-    solana: new Set([
-        "11111111111111111111111111111111", // System Program
-    ]),
+    solana: new Set([SOLANA_NATIVE_ADDRESS]),
+};
+
+/** Canonical native placeholder by chain type. */
+const CANONICAL_BY_CHAIN_TYPE: Record<ChainType, string> = {
+    eip155: NATIVE_ASSET_ADDRESS,
+    solana: SOLANA_NATIVE_ADDRESS,
 };
 
 /** Returns true if the address is a native token placeholder for the given chain type. */
 export const isNativeAddress = (address: string, chainType: ChainType): boolean =>
     NATIVE_ADDRESSES[chainType].has(address.toLowerCase());
+
+/**
+ * Normalize an address for cross-provider lookup.
+ *
+ * Native placeholders collapse to the canonical form for the given chain type
+ * ({@link NATIVE_ASSET_ADDRESS} on EVM), so native tokens reported under
+ * different sentinels (e.g. `0xEEE…E` vs `0x000…0`) deduplicate in the SDK's
+ * discovery, routing, and validation surfaces. Non-native addresses are
+ * returned lowercase for case-insensitive comparisons.
+ */
+export const toCanonicalNativeAddress = (address: string, chainType: ChainType): string =>
+    isNativeAddress(address, chainType)
+        ? CANONICAL_BY_CHAIN_TYPE[chainType]
+        : address.toLowerCase();

--- a/packages/cross-chain/src/core/utils/token.ts
+++ b/packages/cross-chain/src/core/utils/token.ts
@@ -31,10 +31,11 @@ export const isNativeAddress = (address: string, chainType: ChainType): boolean 
  * Native placeholders collapse to the canonical form for the given chain type
  * ({@link NATIVE_ASSET_ADDRESS} on EVM), so native tokens reported under
  * different sentinels (e.g. `0xEEE…E` vs `0x000…0`) deduplicate in the SDK's
- * discovery, routing, and validation surfaces. Non-native addresses are
- * returned lowercase for case-insensitive comparisons.
+ * discovery, routing, and validation surfaces. Non-native EVM addresses are
+ * returned lowercase for case-insensitive comparisons; Solana addresses keep
+ * their original casing because base58 is case-sensitive.
  */
-export const toCanonicalNativeAddress = (address: string, chainType: ChainType): string =>
-    isNativeAddress(address, chainType)
-        ? CANONICAL_BY_CHAIN_TYPE[chainType]
-        : address.toLowerCase();
+export const toCanonicalNativeAddress = (address: string, chainType: ChainType): string => {
+    if (isNativeAddress(address, chainType)) return CANONICAL_BY_CHAIN_TYPE[chainType];
+    return chainType === "eip155" ? address.toLowerCase() : address;
+};

--- a/packages/cross-chain/src/core/validators/buildQuoteValidator.ts
+++ b/packages/cross-chain/src/core/validators/buildQuoteValidator.ts
@@ -5,6 +5,7 @@ import { InvalidDeadline } from "../errors/InvalidDeadline.exception.js";
 import { SameChainIntentNotAllowed } from "../errors/SameChainIntentNotAllowed.exception.js";
 import { UnsupportedAsset } from "../errors/UnsupportedAsset.exception.js";
 import { ZeroAmount } from "../errors/ZeroAmount.exception.js";
+import { toCanonicalNativeAddress } from "../utils/token.js";
 
 /** Minimum seconds between now and fillDeadline. */
 export const MIN_DEADLINE_BUFFER_SECONDS = 60;
@@ -107,8 +108,10 @@ function resolveAssetRelationship(
     outputAddress: string,
     tokenMetadata: Record<number, Record<string, { symbol: string }>>,
 ): AssetRelationship {
-    const inputSymbol = tokenMetadata[inputChainId]?.[inputAddress.toLowerCase()]?.symbol;
-    const outputSymbol = tokenMetadata[outputChainId]?.[outputAddress.toLowerCase()]?.symbol;
+    const inputSymbol =
+        tokenMetadata[inputChainId]?.[toCanonicalNativeAddress(inputAddress, "eip155")]?.symbol;
+    const outputSymbol =
+        tokenMetadata[outputChainId]?.[toCanonicalNativeAddress(outputAddress, "eip155")]?.symbol;
 
     if (inputSymbol === undefined || outputSymbol === undefined) return "unknown";
     return inputSymbol === outputSymbol ? "same" : "different";

--- a/packages/cross-chain/src/external.ts
+++ b/packages/cross-chain/src/external.ts
@@ -50,6 +50,7 @@ export {
     // Utilities
     isSignableOifOrder,
     isNativeAddress,
+    NATIVE_ASSET_ADDRESS,
     toInteropAccountId,
     fromInteropAccountId,
     getSignatureSteps,

--- a/packages/cross-chain/src/external.ts
+++ b/packages/cross-chain/src/external.ts
@@ -51,6 +51,7 @@ export {
     isSignableOifOrder,
     isNativeAddress,
     NATIVE_ASSET_ADDRESS,
+    toCanonicalNativeAddress,
     toInteropAccountId,
     fromInteropAccountId,
     getSignatureSteps,

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -58,8 +58,16 @@ import { decodeAcrossCalldata } from "./utils.js";
 const ZERO_BYTES32 = pad("0x00" as Hex, { size: 32 });
 const ACROSS_DEFAULT_MESSAGE: Hex = "0x";
 
+/** Native placeholder the Across API expects for EVM chains. */
+const ACROSS_NATIVE_PLACEHOLDER = "0x0000000000000000000000000000000000000000";
+
 function addressToBytes32(address: string): Hex {
     return pad(address as Address, { size: 32 });
+}
+
+/** Map any native placeholder variant to the one Across expects. */
+function toAcrossNativeAddress(address: string): string {
+    return isNativeAddress(address, "eip155") ? ACROSS_NATIVE_PLACEHOLDER : address;
 }
 
 /**
@@ -158,9 +166,9 @@ export class AcrossProvider extends CrossChainProvider {
 
         return AcrossGetQuoteParamsSchema.parse({
             tradeType: swapType,
-            inputToken: input.assetAddress,
+            inputToken: toAcrossNativeAddress(input.assetAddress),
             amount,
-            outputToken: output.assetAddress,
+            outputToken: toAcrossNativeAddress(output.assetAddress),
             originChainId: input.chainId,
             destinationChainId: output.chainId,
             depositor: params.user,

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -44,6 +44,7 @@ import {
     GetFillParams,
     InvalidOpenEventError,
     isNativeAddress,
+    NATIVE_ZERO_ADDRESS,
     NetworkAssets,
     OpenedIntent,
     OpenedIntentParserConfig,
@@ -52,22 +53,15 @@ import {
     parseAbiEncodedFields,
     ProviderConfigFailure,
     ProviderGetQuoteFailure,
+    withNativePlaceholder,
 } from "../../internal.js";
 import { decodeAcrossCalldata } from "./utils.js";
 
 const ZERO_BYTES32 = pad("0x00" as Hex, { size: 32 });
 const ACROSS_DEFAULT_MESSAGE: Hex = "0x";
 
-/** Native placeholder the Across API expects for EVM chains. */
-const ACROSS_NATIVE_PLACEHOLDER = "0x0000000000000000000000000000000000000000";
-
 function addressToBytes32(address: string): Hex {
     return pad(address as Address, { size: 32 });
-}
-
-/** Map any native placeholder variant to the one Across expects. */
-function toAcrossNativeAddress(address: string): string {
-    return isNativeAddress(address, "eip155") ? ACROSS_NATIVE_PLACEHOLDER : address;
 }
 
 /**
@@ -166,9 +160,9 @@ export class AcrossProvider extends CrossChainProvider {
 
         return AcrossGetQuoteParamsSchema.parse({
             tradeType: swapType,
-            inputToken: toAcrossNativeAddress(input.assetAddress),
+            inputToken: withNativePlaceholder(input.assetAddress, "eip155", NATIVE_ZERO_ADDRESS),
             amount,
-            outputToken: toAcrossNativeAddress(output.assetAddress),
+            outputToken: withNativePlaceholder(output.assetAddress, "eip155", NATIVE_ZERO_ADDRESS),
             originChainId: input.chainId,
             destinationChainId: output.chainId,
             depositor: params.user,

--- a/packages/cross-chain/src/protocols/bungee/adapters/quoteRequestAdapter.ts
+++ b/packages/cross-chain/src/protocols/bungee/adapters/quoteRequestAdapter.ts
@@ -2,16 +2,11 @@ import type { FeeConfig, SubmissionMode } from "../../../core/schemas/providerCo
 import type { QuoteRequest } from "../../../internal.js";
 import type { BungeeQuoteRequest } from "../schemas.js";
 import {
-    isNativeAddress,
     NATIVE_ASSET_ADDRESS,
     ProviderGetQuoteFailure,
+    withNativePlaceholder,
 } from "../../../internal.js";
 import { BungeeQuoteRequestSchema } from "../schemas.js";
-
-/** Map any native placeholder variant to the one Bungee expects (EIP-7528). */
-function toBungeeNativeAddress(address: string): string {
-    return isNativeAddress(address, "eip155") ? NATIVE_ASSET_ADDRESS : address;
-}
 
 /** Optional provider-level config that affects a single quote request. */
 export interface BungeeQuoteOptions extends FeeConfig {
@@ -42,10 +37,18 @@ export function adaptQuoteRequest(
         userAddress: params.user,
         originChainId: String(params.input.chainId),
         destinationChainId: String(params.output.chainId),
-        inputToken: toBungeeNativeAddress(params.input.assetAddress),
+        inputToken: withNativePlaceholder(
+            params.input.assetAddress,
+            "eip155",
+            NATIVE_ASSET_ADDRESS,
+        ),
         inputAmount: amount,
         receiverAddress: params.output.recipient ?? params.user,
-        outputToken: toBungeeNativeAddress(params.output.assetAddress),
+        outputToken: withNativePlaceholder(
+            params.output.assetAddress,
+            "eip155",
+            NATIVE_ASSET_ADDRESS,
+        ),
         enableMultipleAutoRoutes: "true",
     };
 

--- a/packages/cross-chain/src/protocols/bungee/adapters/quoteRequestAdapter.ts
+++ b/packages/cross-chain/src/protocols/bungee/adapters/quoteRequestAdapter.ts
@@ -1,8 +1,17 @@
 import type { FeeConfig, SubmissionMode } from "../../../core/schemas/providerConfig.js";
 import type { QuoteRequest } from "../../../internal.js";
 import type { BungeeQuoteRequest } from "../schemas.js";
-import { ProviderGetQuoteFailure } from "../../../internal.js";
+import {
+    isNativeAddress,
+    NATIVE_ASSET_ADDRESS,
+    ProviderGetQuoteFailure,
+} from "../../../internal.js";
 import { BungeeQuoteRequestSchema } from "../schemas.js";
+
+/** Map any native placeholder variant to the one Bungee expects (EIP-7528). */
+function toBungeeNativeAddress(address: string): string {
+    return isNativeAddress(address, "eip155") ? NATIVE_ASSET_ADDRESS : address;
+}
 
 /** Optional provider-level config that affects a single quote request. */
 export interface BungeeQuoteOptions extends FeeConfig {
@@ -33,10 +42,10 @@ export function adaptQuoteRequest(
         userAddress: params.user,
         originChainId: String(params.input.chainId),
         destinationChainId: String(params.output.chainId),
-        inputToken: params.input.assetAddress,
+        inputToken: toBungeeNativeAddress(params.input.assetAddress),
         inputAmount: amount,
         receiverAddress: params.output.recipient ?? params.user,
-        outputToken: params.output.assetAddress,
+        outputToken: toBungeeNativeAddress(params.output.assetAddress),
         enableMultipleAutoRoutes: "true",
     };
 

--- a/packages/cross-chain/src/protocols/lifi-intents/adapters/quoteRequestAdapter.ts
+++ b/packages/cross-chain/src/protocols/lifi-intents/adapters/quoteRequestAdapter.ts
@@ -7,18 +7,10 @@
 
 import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
 import type { LifiIntentsQuoteRequest } from "../schemas.js";
-import { isNativeAddress } from "../../../core/utils/token.js";
-
-/** Native placeholder the LI.FI Intents API expects for EVM chains. */
-const LIFI_INTENTS_NATIVE_PLACEHOLDER = "0x0000000000000000000000000000000000000000";
+import { NATIVE_ZERO_ADDRESS, withNativePlaceholder } from "../../../core/utils/token.js";
 
 function toChainString(chainId: number): string {
     return `eip155:${chainId}`;
-}
-
-/** Map any native placeholder variant to the one LI.FI Intents expects. */
-function toLifiIntentsNativeAddress(address: string): string {
-    return isNativeAddress(address, "eip155") ? LIFI_INTENTS_NATIVE_PLACEHOLDER : address;
 }
 
 export function adaptQuoteRequest(request: QuoteRequest): LifiIntentsQuoteRequest {
@@ -44,7 +36,7 @@ export function adaptQuoteRequest(request: QuoteRequest): LifiIntentsQuoteReques
                 {
                     chain: toChainString(input.chainId),
                     user: request.user,
-                    asset: toLifiIntentsNativeAddress(input.assetAddress),
+                    asset: withNativePlaceholder(input.assetAddress, "eip155", NATIVE_ZERO_ADDRESS),
                     amount: input.amount,
                 },
             ],
@@ -52,7 +44,11 @@ export function adaptQuoteRequest(request: QuoteRequest): LifiIntentsQuoteReques
                 {
                     chain: toChainString(output.chainId),
                     receiver: recipientAddress,
-                    asset: toLifiIntentsNativeAddress(output.assetAddress),
+                    asset: withNativePlaceholder(
+                        output.assetAddress,
+                        "eip155",
+                        NATIVE_ZERO_ADDRESS,
+                    ),
                     amount: null,
                 },
             ],

--- a/packages/cross-chain/src/protocols/lifi-intents/adapters/quoteRequestAdapter.ts
+++ b/packages/cross-chain/src/protocols/lifi-intents/adapters/quoteRequestAdapter.ts
@@ -7,9 +7,18 @@
 
 import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
 import type { LifiIntentsQuoteRequest } from "../schemas.js";
+import { isNativeAddress } from "../../../core/utils/token.js";
+
+/** Native placeholder the LI.FI Intents API expects for EVM chains. */
+const LIFI_INTENTS_NATIVE_PLACEHOLDER = "0x0000000000000000000000000000000000000000";
 
 function toChainString(chainId: number): string {
     return `eip155:${chainId}`;
+}
+
+/** Map any native placeholder variant to the one LI.FI Intents expects. */
+function toLifiIntentsNativeAddress(address: string): string {
+    return isNativeAddress(address, "eip155") ? LIFI_INTENTS_NATIVE_PLACEHOLDER : address;
 }
 
 export function adaptQuoteRequest(request: QuoteRequest): LifiIntentsQuoteRequest {
@@ -35,7 +44,7 @@ export function adaptQuoteRequest(request: QuoteRequest): LifiIntentsQuoteReques
                 {
                     chain: toChainString(input.chainId),
                     user: request.user,
-                    asset: input.assetAddress,
+                    asset: toLifiIntentsNativeAddress(input.assetAddress),
                     amount: input.amount,
                 },
             ],
@@ -43,7 +52,7 @@ export function adaptQuoteRequest(request: QuoteRequest): LifiIntentsQuoteReques
                 {
                     chain: toChainString(output.chainId),
                     receiver: recipientAddress,
-                    asset: output.assetAddress,
+                    asset: toLifiIntentsNativeAddress(output.assetAddress),
                     amount: null,
                 },
             ],

--- a/packages/cross-chain/src/protocols/oif/adapters/quoteRequestAdapter.ts
+++ b/packages/cross-chain/src/protocols/oif/adapters/quoteRequestAdapter.ts
@@ -8,15 +8,7 @@ import type { GetQuoteRequest } from "@openintentsframework/oif-specs";
 
 import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
 import { fromInteropAccountId } from "../../../core/utils/interopAccountId.js";
-import { isNativeAddress } from "../../../core/utils/token.js";
-
-/** Native placeholder the OIF solver expects for EVM chains. */
-const OIF_NATIVE_PLACEHOLDER = "0x0000000000000000000000000000000000000000";
-
-/** Map any native placeholder variant to the one OIF expects. */
-function toOifNativeAddress(address: string): string {
-    return isNativeAddress(address, "eip155") ? OIF_NATIVE_PLACEHOLDER : address;
-}
+import { NATIVE_ZERO_ADDRESS, withNativePlaceholder } from "../../../core/utils/token.js";
 
 /**
  * Options passed from the provider to control OIF-specific request behaviour.
@@ -110,7 +102,7 @@ export function adaptQuoteRequest(request: QuoteRequest, options?: AdaptOptions)
             user: userOnInputChain,
             asset: fromInteropAccountId({
                 chainId: input.chainId,
-                address: toOifNativeAddress(input.assetAddress),
+                address: withNativePlaceholder(input.assetAddress, "eip155", NATIVE_ZERO_ADDRESS),
             }),
             ...(input.amount !== undefined && { amount: input.amount }),
         },
@@ -123,7 +115,7 @@ export function adaptQuoteRequest(request: QuoteRequest, options?: AdaptOptions)
             receiver: fromInteropAccountId({ chainId: output.chainId, address: recipientAddress }),
             asset: fromInteropAccountId({
                 chainId: output.chainId,
-                address: toOifNativeAddress(output.assetAddress),
+                address: withNativePlaceholder(output.assetAddress, "eip155", NATIVE_ZERO_ADDRESS),
             }),
             ...(output.amount !== undefined && { amount: output.amount }),
             ...(output.calldata !== undefined && { calldata: output.calldata }),

--- a/packages/cross-chain/src/protocols/oif/adapters/quoteRequestAdapter.ts
+++ b/packages/cross-chain/src/protocols/oif/adapters/quoteRequestAdapter.ts
@@ -8,6 +8,15 @@ import type { GetQuoteRequest } from "@openintentsframework/oif-specs";
 
 import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
 import { fromInteropAccountId } from "../../../core/utils/interopAccountId.js";
+import { isNativeAddress } from "../../../core/utils/token.js";
+
+/** Native placeholder the OIF solver expects for EVM chains. */
+const OIF_NATIVE_PLACEHOLDER = "0x0000000000000000000000000000000000000000";
+
+/** Map any native placeholder variant to the one OIF expects. */
+function toOifNativeAddress(address: string): string {
+    return isNativeAddress(address, "eip155") ? OIF_NATIVE_PLACEHOLDER : address;
+}
 
 /**
  * Options passed from the provider to control OIF-specific request behaviour.
@@ -99,7 +108,10 @@ export function adaptQuoteRequest(request: QuoteRequest, options?: AdaptOptions)
     const inputs = [
         {
             user: userOnInputChain,
-            asset: fromInteropAccountId({ chainId: input.chainId, address: input.assetAddress }),
+            asset: fromInteropAccountId({
+                chainId: input.chainId,
+                address: toOifNativeAddress(input.assetAddress),
+            }),
             ...(input.amount !== undefined && { amount: input.amount }),
         },
     ];
@@ -109,7 +121,10 @@ export function adaptQuoteRequest(request: QuoteRequest, options?: AdaptOptions)
     const outputs = [
         {
             receiver: fromInteropAccountId({ chainId: output.chainId, address: recipientAddress }),
-            asset: fromInteropAccountId({ chainId: output.chainId, address: output.assetAddress }),
+            asset: fromInteropAccountId({
+                chainId: output.chainId,
+                address: toOifNativeAddress(output.assetAddress),
+            }),
             ...(output.amount !== undefined && { amount: output.amount }),
             ...(output.calldata !== undefined && { calldata: output.calldata }),
         },

--- a/packages/cross-chain/src/protocols/relay/adapters/quoteRequestAdapter.ts
+++ b/packages/cross-chain/src/protocols/relay/adapters/quoteRequestAdapter.ts
@@ -1,15 +1,11 @@
 import type { QuoteRequest } from "../../../internal.js";
 import type { RelayQuoteRequest } from "../schemas.js";
-import { isNativeAddress, ProviderGetQuoteFailure } from "../../../internal.js";
+import {
+    NATIVE_ZERO_ADDRESS,
+    ProviderGetQuoteFailure,
+    withNativePlaceholder,
+} from "../../../internal.js";
 import { RelayQuoteRequestSchema } from "../schemas.js";
-
-/** Native placeholder the Relay API expects for EVM chains. */
-const RELAY_NATIVE_PLACEHOLDER = "0x0000000000000000000000000000000000000000";
-
-/** Map any native placeholder variant to the one Relay expects. */
-function toRelayNativeAddress(address: string): string {
-    return isNativeAddress(address, "eip155") ? RELAY_NATIVE_PLACEHOLDER : address;
-}
 
 /** Options forwarded from the provider to the quote request adapter. */
 export interface AdaptQuoteOptions {
@@ -40,9 +36,17 @@ export function adaptQuoteRequest(
     return RelayQuoteRequestSchema.parse({
         user: params.user,
         originChainId: params.input.chainId,
-        originCurrency: toRelayNativeAddress(params.input.assetAddress),
+        originCurrency: withNativePlaceholder(
+            params.input.assetAddress,
+            "eip155",
+            NATIVE_ZERO_ADDRESS,
+        ),
         destinationChainId: params.output.chainId,
-        destinationCurrency: toRelayNativeAddress(params.output.assetAddress),
+        destinationCurrency: withNativePlaceholder(
+            params.output.assetAddress,
+            "eip155",
+            NATIVE_ZERO_ADDRESS,
+        ),
         amount,
         tradeType: swapType === "exact-input" ? "EXACT_INPUT" : "EXPECTED_OUTPUT",
         recipient: params.output.recipient,

--- a/packages/cross-chain/src/protocols/relay/adapters/quoteRequestAdapter.ts
+++ b/packages/cross-chain/src/protocols/relay/adapters/quoteRequestAdapter.ts
@@ -1,7 +1,15 @@
 import type { QuoteRequest } from "../../../internal.js";
 import type { RelayQuoteRequest } from "../schemas.js";
-import { ProviderGetQuoteFailure } from "../../../internal.js";
+import { isNativeAddress, ProviderGetQuoteFailure } from "../../../internal.js";
 import { RelayQuoteRequestSchema } from "../schemas.js";
+
+/** Native placeholder the Relay API expects for EVM chains. */
+const RELAY_NATIVE_PLACEHOLDER = "0x0000000000000000000000000000000000000000";
+
+/** Map any native placeholder variant to the one Relay expects. */
+function toRelayNativeAddress(address: string): string {
+    return isNativeAddress(address, "eip155") ? RELAY_NATIVE_PLACEHOLDER : address;
+}
 
 /** Options forwarded from the provider to the quote request adapter. */
 export interface AdaptQuoteOptions {
@@ -32,9 +40,9 @@ export function adaptQuoteRequest(
     return RelayQuoteRequestSchema.parse({
         user: params.user,
         originChainId: params.input.chainId,
-        originCurrency: params.input.assetAddress,
+        originCurrency: toRelayNativeAddress(params.input.assetAddress),
         destinationChainId: params.output.chainId,
-        destinationCurrency: params.output.assetAddress,
+        destinationCurrency: toRelayNativeAddress(params.output.assetAddress),
         amount,
         tradeType: swapType === "exact-input" ? "EXACT_INPUT" : "EXPECTED_OUTPUT",
         recipient: params.output.recipient,

--- a/packages/cross-chain/test/adapters/lifiIntentsQuoteRequestAdapter.spec.ts
+++ b/packages/cross-chain/test/adapters/lifiIntentsQuoteRequestAdapter.spec.ts
@@ -106,4 +106,27 @@ describe("LI.FI Intents adaptQuoteRequest", () => {
         };
         expect(() => adaptQuoteRequest(request)).toThrow(/input\.amount/);
     });
+
+    describe("native token placeholder translation", () => {
+        const ZERO_NATIVE = "0x0000000000000000000000000000000000000000";
+        const EEE_NATIVE = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+        it("maps canonical 0xEEE… input asset to LI.FI's 0x000… placeholder", () => {
+            const request: QuoteRequest = {
+                ...baseRequest,
+                input: { chainId: INPUT_CHAIN_ID, assetAddress: EEE_NATIVE, amount: "10" },
+            };
+            const result = adaptQuoteRequest(request);
+            expect(result.intent.inputs[0]!.asset).toBe(ZERO_NATIVE);
+        });
+
+        it("maps canonical 0xEEE… output asset to LI.FI's 0x000… placeholder", () => {
+            const request: QuoteRequest = {
+                ...baseRequest,
+                output: { chainId: OUTPUT_CHAIN_ID, assetAddress: EEE_NATIVE },
+            };
+            const result = adaptQuoteRequest(request);
+            expect(result.intent.outputs[0]!.asset).toBe(ZERO_NATIVE);
+        });
+    });
 });

--- a/packages/cross-chain/test/adapters/quoteRequestAdapter.spec.ts
+++ b/packages/cross-chain/test/adapters/quoteRequestAdapter.spec.ts
@@ -185,4 +185,30 @@ describe("adaptQuoteRequest", () => {
             expect(result.supportedTypes).not.toContain("oif-escrow-v0");
         });
     });
+
+    describe("native token placeholder translation", () => {
+        const EEE_NATIVE = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" as Address;
+
+        function zeroAssetHex(chainId: number): string {
+            return toErc7930(chainId, "0x0000000000000000000000000000000000000000");
+        }
+
+        it("encodes canonical 0xEEE… input as 0x000… inside the ERC-7930 asset hex", () => {
+            const request: QuoteRequest = {
+                ...baseRequest,
+                input: { chainId: INPUT_CHAIN_ID, assetAddress: EEE_NATIVE, amount: "10" },
+            };
+            const result = adaptQuoteRequest(request);
+            expect(result.intent.inputs[0]!.asset).toBe(zeroAssetHex(INPUT_CHAIN_ID));
+        });
+
+        it("encodes canonical 0xEEE… output as 0x000… inside the ERC-7930 asset hex", () => {
+            const request: QuoteRequest = {
+                ...baseRequest,
+                output: { chainId: OUTPUT_CHAIN_ID, assetAddress: EEE_NATIVE },
+            };
+            const result = adaptQuoteRequest(request);
+            expect(result.intent.outputs[0]!.asset).toBe(zeroAssetHex(OUTPUT_CHAIN_ID));
+        });
+    });
 });

--- a/packages/cross-chain/test/protocols/bungee/adapters/quoteRequestAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/adapters/quoteRequestAdapter.spec.ts
@@ -109,4 +109,40 @@ describe("adaptQuoteRequest", () => {
         expect(result.slippage).toBeUndefined();
         expect(result.refuel).toBeUndefined();
     });
+
+    describe("native token placeholder translation", () => {
+        const BUNGEE_NATIVE = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        const ZERO_NATIVE = "0x0000000000000000000000000000000000000000";
+
+        it("maps 0x000… input to Bungee's 0xEEE… placeholder", () => {
+            const request = buildQuoteRequest({
+                input: { chainId: 1, assetAddress: ZERO_NATIVE, amount: "1000000" },
+            });
+            const result = adaptQuoteRequest(request);
+            expect(result.inputToken).toBe(BUNGEE_NATIVE);
+        });
+
+        it("maps 0x000… output to Bungee's 0xEEE… placeholder", () => {
+            const request = buildQuoteRequest({
+                output: { chainId: 10, assetAddress: ZERO_NATIVE, recipient: RECIPIENT_ADDRESS },
+            });
+            const result = adaptQuoteRequest(request);
+            expect(result.outputToken).toBe(BUNGEE_NATIVE);
+        });
+
+        it("keeps 0xEEE… unchanged when already Bungee's placeholder", () => {
+            const request = buildQuoteRequest({
+                input: { chainId: 1, assetAddress: BUNGEE_NATIVE, amount: "1000000" },
+            });
+            const result = adaptQuoteRequest(request);
+            expect(result.inputToken).toBe(BUNGEE_NATIVE);
+        });
+
+        it("leaves ERC-20 addresses untouched", () => {
+            const request = buildQuoteRequest();
+            const result = adaptQuoteRequest(request);
+            expect(result.inputToken).toBe(VALID_ADDRESS);
+            expect(result.outputToken).toBe(VALID_ADDRESS);
+        });
+    });
 });

--- a/packages/cross-chain/test/protocols/relay/adapters/quoteRequestAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/adapters/quoteRequestAdapter.spec.ts
@@ -92,4 +92,33 @@ describe("adaptQuoteRequest", () => {
             ),
         ).toThrow(ProviderGetQuoteFailure);
     });
+
+    describe("native token placeholder translation", () => {
+        const ZERO_NATIVE = "0x0000000000000000000000000000000000000000";
+        const EEE_NATIVE = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+        it("maps canonical 0xEEE… input to Relay's 0x000… placeholder", () => {
+            const result = adaptQuoteRequest(
+                makeQuoteRequest({
+                    input: { chainId: ORIGIN_CHAIN_ID, assetAddress: EEE_NATIVE, amount: "10" },
+                }),
+            );
+            expect(result.originCurrency).toBe(ZERO_NATIVE);
+        });
+
+        it("maps canonical 0xEEE… output to Relay's 0x000… placeholder", () => {
+            const result = adaptQuoteRequest(
+                makeQuoteRequest({
+                    output: { chainId: DESTINATION_CHAIN_ID, assetAddress: EEE_NATIVE },
+                }),
+            );
+            expect(result.destinationCurrency).toBe(ZERO_NATIVE);
+        });
+
+        it("leaves ERC-20 addresses untouched", () => {
+            const result = adaptQuoteRequest(makeQuoteRequest());
+            expect(result.originCurrency).toBe(VALID_ADDRESS);
+            expect(result.destinationCurrency).toBe(VALID_ADDRESS);
+        });
+    });
 });

--- a/packages/cross-chain/test/services/BaseAssetDiscoveryService.spec.ts
+++ b/packages/cross-chain/test/services/BaseAssetDiscoveryService.spec.ts
@@ -342,6 +342,36 @@ describe("BaseAssetDiscoveryService", () => {
 
                 expect(result).toBeNull();
             });
+
+            it("resolves native tokens regardless of which placeholder the caller passes", async () => {
+                const nativeOnlyService = new TestAssetDiscoveryService(
+                    { providerId: "bungee-like" },
+                    async () => [
+                        {
+                            chainId: 1,
+                            assets: [
+                                {
+                                    address: "0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE",
+                                    symbol: "ETH",
+                                    decimals: 18,
+                                },
+                            ],
+                        },
+                    ],
+                );
+
+                const viaZero = await nativeOnlyService.isAssetSupported(
+                    1,
+                    "0x0000000000000000000000000000000000000000",
+                );
+                const viaEee = await nativeOnlyService.isAssetSupported(
+                    1,
+                    "0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE",
+                );
+
+                expect(viaZero?.symbol).toBe("ETH");
+                expect(viaEee?.symbol).toBe("ETH");
+            });
         });
 
         describe("getSupportedChainIds", () => {

--- a/packages/cross-chain/test/services/aggregator.discovery.spec.ts
+++ b/packages/cross-chain/test/services/aggregator.discovery.spec.ts
@@ -6,6 +6,9 @@ import { createAggregator, CrossChainProvider } from "../../src/internal.js";
 const USDC_ETH = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const WETH_ETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 const USDC_ARB = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
+const NATIVE_ZERO = "0x0000000000000000000000000000000000000000";
+const NATIVE_EEE = "0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE";
+const NATIVE_EEE_LOWER = NATIVE_EEE.toLowerCase();
 
 function createMockProvider(
     providerId: string,
@@ -145,6 +148,43 @@ describe("Aggregator - Asset Discovery", () => {
 
             expect(result.tokensByChain[1]).toBeDefined();
             expect(result.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.providers).toEqual(["across"]);
+        });
+
+        it("collapses native placeholders across providers into one canonical entry", async () => {
+            const bungee = createMockProvider("bungee", {
+                type: "static",
+                config: {
+                    networks: [
+                        {
+                            chainId: 1,
+                            assets: [{ address: NATIVE_EEE, symbol: "ETH", decimals: 18 }],
+                        },
+                    ],
+                },
+            });
+
+            const across = createMockProvider("across", {
+                type: "static",
+                config: {
+                    networks: [
+                        {
+                            chainId: 1,
+                            assets: [{ address: NATIVE_ZERO, symbol: "ETH", decimals: 18 }],
+                        },
+                    ],
+                },
+            });
+
+            const executor = createAggregator({ providers: [bungee, across] });
+
+            const result = await executor.discoverAssets();
+
+            expect(result.tokensByChain[1]).toEqual([NATIVE_EEE_LOWER]);
+            expect(Object.keys(result.tokenMetadata[1]!)).toEqual([NATIVE_EEE_LOWER]);
+            expect(result.tokenMetadata[1]![NATIVE_EEE_LOWER]!.providers).toEqual([
+                "bungee",
+                "across",
+            ]);
         });
 
         it("should deduplicate same token from same provider", async () => {
@@ -299,6 +339,59 @@ describe("Aggregator - Asset Discovery", () => {
             });
 
             expect(providers).toEqual([]);
+        });
+
+        it("matches native tokens regardless of which placeholder the caller passes", async () => {
+            const bungee = createMockProvider("bungee", {
+                type: "static",
+                config: {
+                    networks: [
+                        {
+                            chainId: 1,
+                            assets: [{ address: NATIVE_EEE, symbol: "ETH", decimals: 18 }],
+                        },
+                        {
+                            chainId: 42161,
+                            assets: [{ address: NATIVE_EEE, symbol: "ETH", decimals: 18 }],
+                        },
+                    ],
+                },
+            });
+
+            const across = createMockProvider("across", {
+                type: "static",
+                config: {
+                    networks: [
+                        {
+                            chainId: 1,
+                            assets: [{ address: NATIVE_ZERO, symbol: "ETH", decimals: 18 }],
+                        },
+                        {
+                            chainId: 42161,
+                            assets: [{ address: NATIVE_ZERO, symbol: "ETH", decimals: 18 }],
+                        },
+                    ],
+                },
+            });
+
+            const executor = createAggregator({ providers: [bungee, across] });
+
+            const viaZero = await executor.getProvidersForRoute({
+                originChainId: 1,
+                originAsset: NATIVE_ZERO,
+                destinationChainId: 42161,
+                destinationAsset: NATIVE_ZERO,
+            });
+
+            const viaEee = await executor.getProvidersForRoute({
+                originChainId: 1,
+                originAsset: NATIVE_EEE,
+                destinationChainId: 42161,
+                destinationAsset: NATIVE_EEE,
+            });
+
+            expect(viaZero).toEqual(expect.arrayContaining(["bungee", "across"]));
+            expect(viaEee).toEqual(expect.arrayContaining(["bungee", "across"]));
         });
 
         it("should return multiple providers when both support the route", async () => {

--- a/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
+++ b/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
@@ -14,11 +14,16 @@ const USDC_ETH = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const WETH_ETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 const USDC_ARB = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
 const WETH_ARB = "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1";
+const NATIVE_ZERO = "0x0000000000000000000000000000000000000000";
+const NATIVE_EEE = "0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE";
+const NATIVE_EEE_LOWER = NATIVE_EEE.toLowerCase();
 
 const usdcEth: AssetInfo = { address: USDC_ETH, symbol: "USDC", decimals: 6 };
 const wethEth: AssetInfo = { address: WETH_ETH, symbol: "WETH", decimals: 18 };
 const usdcArb: AssetInfo = { address: USDC_ARB, symbol: "USDC", decimals: 6 };
 const wethArb: AssetInfo = { address: WETH_ARB, symbol: "WETH", decimals: 18 };
+const ethZero: AssetInfo = { address: NATIVE_ZERO, symbol: "ETH", decimals: 18 };
+const ethEee: AssetInfo = { address: NATIVE_EEE, symbol: "ETH", decimals: 18 };
 
 function result(providerId: string, ...networks: NetworkAssets[]): AssetDiscoveryResult {
     return { networks, providerId };
@@ -130,6 +135,32 @@ describe("toDiscoveredAssets", () => {
         });
     });
 
+    describe("native token placeholders", () => {
+        it("collapses 0xEEE… and 0x000… into a single canonical entry (NATIVE_ASSET_ADDRESS)", () => {
+            const out = toDiscoveredAssets([
+                result("bungee", { chainId: 1, assets: [ethEee] }),
+                result("across", { chainId: 1, assets: [ethZero] }),
+            ]);
+
+            expect(out.tokensByChain[1]).toEqual([NATIVE_EEE_LOWER]);
+            expect(Object.keys(out.tokenMetadata[1]!)).toEqual([NATIVE_EEE_LOWER]);
+            expect(out.tokenMetadata[1]![NATIVE_EEE_LOWER]!.providers).toEqual([
+                "bungee",
+                "across",
+            ]);
+            expect(out.tokenMetadata[1]![NATIVE_EEE_LOWER]!.address).toBe(NATIVE_EEE_LOWER);
+        });
+
+        it("leaves ERC-20 addresses lowercase, not canonicalized", () => {
+            const out = toDiscoveredAssets([
+                result("provider-a", { chainId: 1, assets: [usdcEth] }),
+            ]);
+
+            expect(out.tokensByChain[1]).toEqual([USDC_ETH.toLowerCase()]);
+            expect(out.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.address).toBe(USDC_ETH);
+        });
+    });
+
     describe("multiple chains", () => {
         it("have chain keys in tokensByChain", () => {
             const out = toDiscoveredAssets([
@@ -238,5 +269,38 @@ describe("mergeDiscoveredAssets", () => {
 
         expect(merged.tokensByChain).toEqual({});
         expect(merged.tokenMetadata).toEqual({});
+    });
+
+    it("collapses native placeholders across discovered sources", () => {
+        const sourceA = toDiscoveredAssets([result("bungee", { chainId: 1, assets: [ethEee] })]);
+        const sourceB = toDiscoveredAssets([result("across", { chainId: 1, assets: [ethZero] })]);
+
+        const merged = mergeDiscoveredAssets([sourceA, sourceB]);
+
+        expect(merged.tokensByChain[1]).toEqual([NATIVE_EEE_LOWER]);
+        expect(Object.keys(merged.tokenMetadata[1]!)).toEqual([NATIVE_EEE_LOWER]);
+        expect(merged.tokenMetadata[1]![NATIVE_EEE_LOWER]!.providers).toEqual(["bungee", "across"]);
+    });
+
+    it("canonicalizes native placeholders from raw input keys", () => {
+        const raw = {
+            tokensByChain: { 1: [NATIVE_ZERO] },
+            tokenMetadata: {
+                1: {
+                    [NATIVE_ZERO]: {
+                        address: NATIVE_ZERO,
+                        symbol: "ETH",
+                        decimals: 18,
+                        providers: ["legacy"],
+                    },
+                },
+            },
+        };
+
+        const merged = mergeDiscoveredAssets([raw]);
+
+        expect(merged.tokensByChain[1]).toEqual([NATIVE_EEE_LOWER]);
+        expect(merged.tokenMetadata[1]![NATIVE_EEE_LOWER]).toBeDefined();
+        expect(merged.tokenMetadata[1]![NATIVE_EEE_LOWER]!.address).toBe(NATIVE_EEE_LOWER);
     });
 });

--- a/packages/cross-chain/test/utils/token.spec.ts
+++ b/packages/cross-chain/test/utils/token.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    isNativeAddress,
+    NATIVE_ASSET_ADDRESS,
+    toCanonicalNativeAddress,
+} from "../../src/core/utils/token.js";
+
+const NATIVE_ZERO = "0x0000000000000000000000000000000000000000";
+const NATIVE_EEE_UPPER = "0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE";
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const SOLANA_SYSTEM = "11111111111111111111111111111111";
+const SOLANA_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+describe("isNativeAddress", () => {
+    it("recognizes 0x000… as native on eip155", () => {
+        expect(isNativeAddress(NATIVE_ZERO, "eip155")).toBe(true);
+    });
+
+    it("recognizes 0xEEE… as native on eip155 (case-insensitive)", () => {
+        expect(isNativeAddress(NATIVE_EEE_UPPER, "eip155")).toBe(true);
+        expect(isNativeAddress(NATIVE_EEE_UPPER.toLowerCase(), "eip155")).toBe(true);
+    });
+
+    it("returns false for ERC-20 addresses", () => {
+        expect(isNativeAddress(USDC, "eip155")).toBe(false);
+    });
+
+    it("recognizes Solana system program", () => {
+        expect(isNativeAddress(SOLANA_SYSTEM, "solana")).toBe(true);
+        expect(isNativeAddress(SOLANA_MINT, "solana")).toBe(false);
+    });
+});
+
+describe("toCanonicalNativeAddress", () => {
+    it("collapses 0x000… to NATIVE_ASSET_ADDRESS on eip155", () => {
+        expect(toCanonicalNativeAddress(NATIVE_ZERO, "eip155")).toBe(NATIVE_ASSET_ADDRESS);
+    });
+
+    it("leaves NATIVE_ASSET_ADDRESS unchanged (idempotent)", () => {
+        expect(toCanonicalNativeAddress(NATIVE_ASSET_ADDRESS, "eip155")).toBe(NATIVE_ASSET_ADDRESS);
+        expect(toCanonicalNativeAddress(NATIVE_EEE_UPPER, "eip155")).toBe(NATIVE_ASSET_ADDRESS);
+    });
+
+    it("lowercases ERC-20 addresses without rewriting them", () => {
+        expect(toCanonicalNativeAddress(USDC, "eip155")).toBe(USDC.toLowerCase());
+    });
+
+    it("maps the Solana system program to its canonical form", () => {
+        expect(toCanonicalNativeAddress(SOLANA_SYSTEM, "solana")).toBe(SOLANA_SYSTEM);
+    });
+});

--- a/packages/cross-chain/test/utils/token.spec.ts
+++ b/packages/cross-chain/test/utils/token.spec.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
     isNativeAddress,
     NATIVE_ASSET_ADDRESS,
+    NATIVE_ZERO_ADDRESS,
     toCanonicalNativeAddress,
+    withNativePlaceholder,
 } from "../../src/core/utils/token.js";
 
 const NATIVE_ZERO = "0x0000000000000000000000000000000000000000";
@@ -52,5 +54,44 @@ describe("toCanonicalNativeAddress", () => {
 
     it("preserves the casing of non-native Solana addresses (base58 is case-sensitive)", () => {
         expect(toCanonicalNativeAddress(SOLANA_MINT, "solana")).toBe(SOLANA_MINT);
+    });
+});
+
+describe("NATIVE_ZERO_ADDRESS", () => {
+    it("matches the 0x0000…0 sentinel", () => {
+        expect(NATIVE_ZERO_ADDRESS).toBe(NATIVE_ZERO);
+    });
+
+    it("is recognised as a native placeholder on eip155", () => {
+        expect(isNativeAddress(NATIVE_ZERO_ADDRESS, "eip155")).toBe(true);
+    });
+});
+
+describe("withNativePlaceholder", () => {
+    it("maps 0xEEE… to the provided placeholder on eip155", () => {
+        expect(withNativePlaceholder(NATIVE_EEE_UPPER, "eip155", NATIVE_ZERO_ADDRESS)).toBe(
+            NATIVE_ZERO_ADDRESS,
+        );
+    });
+
+    it("maps 0x000… to NATIVE_ASSET_ADDRESS when that is the provider placeholder", () => {
+        expect(withNativePlaceholder(NATIVE_ZERO, "eip155", NATIVE_ASSET_ADDRESS)).toBe(
+            NATIVE_ASSET_ADDRESS,
+        );
+    });
+
+    it("passes non-native addresses through unchanged (no lowercasing)", () => {
+        expect(withNativePlaceholder(USDC, "eip155", NATIVE_ZERO_ADDRESS)).toBe(USDC);
+    });
+
+    it("maps the Solana system program to a custom placeholder", () => {
+        const customPlaceholder = "SoL1111111111111111111111111111111111111111";
+        expect(withNativePlaceholder(SOLANA_SYSTEM, "solana", customPlaceholder)).toBe(
+            customPlaceholder,
+        );
+    });
+
+    it("passes non-native Solana addresses through unchanged", () => {
+        expect(withNativePlaceholder(SOLANA_MINT, "solana", SOLANA_SYSTEM)).toBe(SOLANA_MINT);
     });
 });

--- a/packages/cross-chain/test/utils/token.spec.ts
+++ b/packages/cross-chain/test/utils/token.spec.ts
@@ -49,4 +49,8 @@ describe("toCanonicalNativeAddress", () => {
     it("maps the Solana system program to its canonical form", () => {
         expect(toCanonicalNativeAddress(SOLANA_SYSTEM, "solana")).toBe(SOLANA_SYSTEM);
     });
+
+    it("preserves the casing of non-native Solana addresses (base58 is case-sensitive)", () => {
+        expect(toCanonicalNativeAddress(SOLANA_MINT, "solana")).toBe(SOLANA_MINT);
+    });
 });


### PR DESCRIPTION
Closes EFI-870

## Summary

In the cross-chain token picker (`examples/ui`), ETH appeared twice whenever quotes were aggregated from more than one provider. Each provider reports native tokens under a different sentinel: Bungee uses `0xEEE…E` (EIP-7528), and Across, Relay, LI.FI Intents and OIF use `0x000…0`. `DiscoveredAssets` only indexed by `toLowerCase()`, so the two variants landed in separate entries and `RouteQuery` / `isAssetSupported` lookups never matched across them.

- Both native placeholders now collapse to the canonical `NATIVE_ASSET_ADDRESS` inside `toDiscoveredAssets`, `mergeDiscoveredAssets`, `Aggregator.getProvidersForRoute`, `BaseAssetDiscoveryService.isAssetSupported`, and `buildQuoteValidator.resolveAssetRelationship`.
- Each provider's quote-request adapter translates the canonical address back to the placeholder its API expects: Bungee keeps `0xEEE…E`, and Across, Relay, LI.FI Intents and OIF get `0x000…0`.
- Adds a public `toCanonicalNativeAddress(address, chainType)` helper so consumers can normalize addresses the same way the SDK does.
- Callers can pass either variant in `QuoteRequest` / `RouteQuery` and every provider still works.

## Test plan

- [ ] `pnpm --filter @wonderland/interop-cross-chain build` passes
- [ ] `pnpm --filter @wonderland/interop-cross-chain test` passes
- [ ] `cd apps/docs && pnpm build` passes