### PR TITLE
docs(cross-chain): troubleshooting section, provider chain matrix, package.json metadata

### DIFF
--- a/apps/docs/docs/cross-chain/advanced-usage.md
+++ b/apps/docs/docs/cross-chain/advanced-usage.md
@@ -170,6 +170,49 @@ try {
 6. Test your implementation on testnet before moving to production
 7. Provide custom RPC URLs for better reliability
 
+## Troubleshooting
+
+### No providers returned a quote
+
+If `response.quotes` is empty and `response.errors` contains failures, work through these checks:
+
+- **Verify the token pair is supported on the route.** Call `discoverAssets()` on the provider to confirm both the origin and destination tokens are available.
+- **Try a smaller input amount.** Most providers enforce minimum transfer sizes, and amounts below the threshold are rejected silently.
+- **Check route directionality.** Some routes are one-directional. If `A → B` fails, try `B → A` to confirm the route exists in the other direction.
+- **Confirm the provider is on the right network.** A provider configured with `isTestnet: true` will not return quotes for mainnet chain IDs and vice versa.
+- **Inspect per-provider failure reasons.** The `ProviderGetQuoteFailure` errors inside `response.errors` each carry a message explaining why that provider declined.
+
+```typescript
+response.errors.forEach((error) => {
+    console.error(error.errorMsg);
+});
+```
+
+### Simulation failure on submit
+
+A simulation failure usually means the transaction would revert on-chain before it is broadcast.
+
+- **Check allowances first.** Inspect `checks.allowances` on the quote and approve the input token before calling `submitOrder()` or sending the transaction.
+- **Retrieve the revert reason.** Catch the error thrown by `submitOrder()` — it may include a `cause` property with simulation failure details from viem.
+
+```typescript
+try {
+    await submitOrder(quote, signature);
+} catch (error) {
+    console.error("Simulation failure cause:", error?.cause);
+}
+```
+
+- **Across allowance note.** For Across, `checks.allowances` is not populated. You must manually approve the input token to the `transaction.to` address before submitting an ERC-20 transfer.
+
+### WalletConnect / web3modal 403 errors
+
+403 errors from WalletConnect infrastructure are unrelated to the interop SDK itself.
+
+- Ensure you have a valid WalletConnect project ID configured in your app.
+- These errors are typically rate-limit or project-ID rejections from the WalletConnect relay service.
+- If the errors appear only on initial page load and the app recovers, they can usually be safely ignored.
+
 ## Next steps
 
 -   [API Reference](./api.md) — complete function signatures and types

--- a/apps/docs/docs/cross-chain/providers.md
+++ b/apps/docs/docs/cross-chain/providers.md
@@ -108,6 +108,53 @@ class MyCustomProvider extends CrossChainProvider {
 
 See the [API Reference](./api.md) for the full `Quote`, `QuoteRequest`, and tracking config types.
 
+## Supported Chains
+
+The table below shows which chains each provider supports **as of April 2026**. Providers that discover chains dynamically via their API are noted separately — call `discoverAssets()` to get a live list for those providers.
+
+### Across
+
+Across has hardcoded origin-settler contract addresses for the following chains. Other chains may be available through the Across API at runtime.
+
+| Chain | Chain ID | Mainnet | Testnet |
+|-------|----------|---------|---------|
+| Base | 8453 | ✓ | — |
+| Arbitrum One | 42161 | ✓ | — |
+| Optimism | 10 | ✓ | — |
+| Sepolia | 11155111 | — | ✓ |
+| Base Sepolia | 84532 | — | ✓ |
+| Arbitrum Sepolia | 421614 | — | ✓ |
+
+### Relay, Bungee, and LI.FI Intents
+
+These providers discover supported chains and tokens dynamically via their respective APIs. There is no hardcoded chain list in the SDK.
+
+Call `discoverAssets()` on the provider to enumerate all chains and tokens currently available:
+
+```typescript
+const relayProvider = createCrossChainProvider("relay");
+const assets = await relayProvider.discoverAssets();
+// assets is an array of { chainId, assets: [...] }
+```
+
+### OIF
+
+OIF is a solver-specific integration. Supported chains depend entirely on the solver you configure. Contact your solver operator for the list of supported chains and assets.
+
+### Full Provider Comparison
+
+| Chain | Chain ID | Across | Relay | OIF | Bungee | LI.FI Intents |
+|-------|----------|--------|-------|-----|--------|---------------|
+| Ethereum | 1 | via API | ✓ | solver-dependent | ✓ | ✓ |
+| Base | 8453 | ✓ | ✓ | solver-dependent | ✓ | ✓ |
+| Arbitrum One | 42161 | ✓ | ✓ | solver-dependent | ✓ | ✓ |
+| Optimism | 10 | ✓ | ✓ | solver-dependent | ✓ | ✓ |
+| Others | varies | via API | via API | solver-dependent | via API | via API |
+
+:::tip
+For Relay, Bungee, and LI.FI Intents, the chain list grows as providers add support. Always call `discoverAssets()` at runtime rather than relying on a static list.
+:::
+
 ## References
 
 -   [API Reference](./api.md)

--- a/apps/docs/docs/cross-chain/providers.md
+++ b/apps/docs/docs/cross-chain/providers.md
@@ -139,20 +139,31 @@ const assets = await relayProvider.discoverAssets();
 
 ### OIF
 
-OIF is a solver-specific integration. Supported chains depend entirely on the solver you configure. Contact your solver operator for the list of supported chains and assets.
+OIF also supports `discoverAssets()` — the SDK queries the configured solver's API to enumerate the chains and tokens it supports:
+
+```typescript
+const oifProvider = createCrossChainProvider("oif", {
+  solverId: "my-solver",
+  url: "https://oif-api.example.com",
+});
+const assets = await oifProvider.discoverAssets();
+// assets is an array of { chainId, assets: [...] }
+```
+
+Supported chains and tokens depend entirely on the solver you configure.
 
 ### Full Provider Comparison
 
 | Chain | Chain ID | Across | Relay | OIF | Bungee | LI.FI Intents |
 |-------|----------|--------|-------|-----|--------|---------------|
-| Ethereum | 1 | via API | ✓ | solver-dependent | ✓ | ✓ |
-| Base | 8453 | ✓ | ✓ | solver-dependent | ✓ | ✓ |
-| Arbitrum One | 42161 | ✓ | ✓ | solver-dependent | ✓ | ✓ |
-| Optimism | 10 | ✓ | ✓ | solver-dependent | ✓ | ✓ |
-| Others | varies | via API | via API | solver-dependent | via API | via API |
+| Ethereum | 1 | via API | ✓ | via solver API | ✓ | ✓ |
+| Base | 8453 | ✓ | ✓ | via solver API | ✓ | ✓ |
+| Arbitrum One | 42161 | ✓ | ✓ | via solver API | ✓ | ✓ |
+| Optimism | 10 | ✓ | ✓ | via solver API | ✓ | ✓ |
+| Others | varies | via API | via API | via solver API | via API | via API |
 
 :::tip
-For Relay, Bungee, and LI.FI Intents, the chain list grows as providers add support. Always call `discoverAssets()` at runtime rather than relying on a static list.
+For Relay, Bungee, LI.FI Intents, and OIF, the chain list grows as providers add support. Always call `discoverAssets()` at runtime rather than relying on a static list.
 :::
 
 ## References

--- a/apps/docs/docs/cross-chain/providers.md
+++ b/apps/docs/docs/cross-chain/providers.md
@@ -114,7 +114,14 @@ The table below shows which chains each provider supports **as of April 2026**. 
 
 ### Across
 
-Across has hardcoded origin-settler contract addresses for the following chains. Other chains may be available through the Across API at runtime.
+**Asset discovery** behaves differently between mainnet and testnet:
+
+- **Mainnet**: `discoverAssets()` queries the Across API dynamically — the same as Relay and Bungee. No hardcoded token list is used.
+- **Testnet**: `discoverAssets()` uses a static hardcoded token list. The Across API returns mainnet chain IDs even for testnet queries, so a static list is the only reliable option for testnet.
+
+**Getting quotes** (`getQuotes()`) is fully API-driven for both mainnet and testnet — there is no hardcoded chain constraint.
+
+**Building quotes** (`buildQuote()`) requires a SpokePool contract address and a wrapped-native (WETH) address for the origin chain. The SDK has these hardcoded for the chains below. For any other chain, pass `escrowContractAddress` explicitly in the `buildQuote()` params as a fallback.
 
 | Chain | Chain ID | Mainnet | Testnet |
 |-------|----------|---------|---------|
@@ -154,16 +161,18 @@ Supported chains and tokens depend entirely on the solver you configure.
 
 ### Full Provider Comparison
 
-| Chain | Chain ID | Across | Relay | OIF | Bungee | LI.FI Intents |
-|-------|----------|--------|-------|-----|--------|---------------|
+| Chain | Chain ID | Across¹ | Relay | OIF | Bungee | LI.FI Intents |
+|-------|----------|---------|-------|-----|--------|---------------|
 | Ethereum | 1 | via API | ✓ | via solver API | ✓ | ✓ |
-| Base | 8453 | ✓ | ✓ | via solver API | ✓ | ✓ |
-| Arbitrum One | 42161 | ✓ | ✓ | via solver API | ✓ | ✓ |
-| Optimism | 10 | ✓ | ✓ | via solver API | ✓ | ✓ |
+| Base | 8453 | via API | ✓ | via solver API | ✓ | ✓ |
+| Arbitrum One | 42161 | via API | ✓ | via solver API | ✓ | ✓ |
+| Optimism | 10 | via API | ✓ | via solver API | ✓ | ✓ |
 | Others | varies | via API | via API | via solver API | via API | via API |
 
+¹ `getQuotes()` and `discoverAssets()` are fully API-driven for Across. `buildQuote()` additionally requires hardcoded SpokePool addresses, which the SDK provides for Base, Arbitrum One, Optimism (mainnet) and Sepolia, Base Sepolia, Arbitrum Sepolia (testnet). Pass `escrowContractAddress` in params for other chains.
+
 :::tip
-For Relay, Bungee, LI.FI Intents, and OIF, the chain list grows as providers add support. Always call `discoverAssets()` at runtime rather than relying on a static list.
+For all providers, the chain list grows as providers add support. Always call `discoverAssets()` at runtime rather than relying on a static list.
 :::
 
 ## References

--- a/apps/sdk/package.json
+++ b/apps/sdk/package.json
@@ -2,6 +2,7 @@
     "name": "@wonderland/interop",
     "version": "0.3.3",
     "description": "Complete SDK for blockchain interoperability with cross-chain operations and address utilities",
+    "homepage": "https://docs.interop.wonderland.xyz",
     "repository": {
         "type": "git",
         "url": "https://github.com/defi-wonderland/interop-sdk.git",

--- a/packages/cross-chain/package.json
+++ b/packages/cross-chain/package.json
@@ -2,6 +2,7 @@
     "name": "@wonderland/interop-cross-chain",
     "version": "0.5.0",
     "description": "Cross-chain interoperability library with standardized provider interface",
+    "homepage": "https://docs.interop.wonderland.xyz",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/defi-wonderland/interop-sdk.git",


### PR DESCRIPTION
## Summary

- Adds a **Troubleshooting** section to `advanced-usage.md` covering the three most common issues: no quotes returned, simulation failure (how to get the revert reason), and WalletConnect 403 noise
- Adds a **supported chains** static table to `providers.md` (as of April 2026), sourced from provider constants; fixes Across mainnet incorrectly showing Ethereum mainnet (only Base, Arbitrum, Optimism are in `ACROSS_ORIGIN_SETTLER_ADDRESSES`)
- Adds `homepage` field to `apps/sdk/package.json` and `packages/cross-chain/package.json` pointing at canonical docs URL

## Test plan

- [ ] `cd apps/docs && pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)