### PR TITLE
docs(cross-chain): add LiFi Intents provider documentation

### DIFF
--- a/apps/docs/docs/about.md
+++ b/apps/docs/docs/about.md
@@ -17,7 +17,7 @@ Implements [EIP-7930](https://eips.ethereum.org/EIPS/eip-7930), [ERC-7828](https
 
 Fetch quotes, execute transfers, and track orders across chains through a unified provider interface.
 
-Implements [EIP-7683](https://www.erc7683.org/) for cross-chain intents. Supports Across, Relay, and OIF providers.
+Supports Open Intents Framework (OIF), Across, Relay, Bungee, and LiFi Intents providers.
 
 ## Where to start
 

--- a/apps/docs/docs/cross-chain.md
+++ b/apps/docs/docs/cross-chain.md
@@ -20,7 +20,7 @@ It follows [EIP-7683](https://www.erc7683.org/) for cross-chain intent structure
 | Try it out                   | [Getting Started](./cross-chain/getting-started.md)                                                                        |
 | Understand the design        | [Concepts](./cross-chain/concepts.md)                                                                                      |
 | See the transfer flow        | [Flow](./cross-chain/flow.md)                                                                                              |
-| Set up a specific provider   | [Across](./cross-chain/across-provider.md), [Relay](./cross-chain/relay-provider.md), [OIF](./cross-chain/oif-provider.md) |
+| Set up a specific provider   | [Across](./cross-chain/across-provider.md), [Relay](./cross-chain/relay-provider.md), [OIF](./cross-chain/oif-provider.md), [Bungee](./cross-chain/bungee-provider.md), [LiFi Intents](./cross-chain/lifi-intents-provider.md) |
 | Monitor a transfer           | [Order Tracking](./cross-chain/intent-tracking.md)                                                                         |
 | Learn advanced patterns      | [Advanced Usage](./cross-chain/advanced-usage.md)                                                                          |
 | Look up a function signature | [API Reference](./cross-chain/api.md)                                                                                      |

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -10,10 +10,13 @@ A set of classes and utilities for handling cross-chain operations through vario
 
 -   **createCrossChainProvider**(protocolName: string, config?: ProviderConfig): CrossChainProvider
 
-    Creates a provider instance for a supported cross-chain protocol. Config is optional for Across (uses mainnet defaults), required for OIF.
+    Creates a provider instance for a supported cross-chain protocol. Config is optional for Across (uses mainnet defaults), required for OIF and LiFi Intents.
 
     ```typescript
-    import { createCrossChainProvider } from "@wonderland/interop-cross-chain";
+    import {
+        createCrossChainProvider,
+        LIFI_INTENTS_ORDER_SERVER_URL,
+    } from "@wonderland/interop-cross-chain";
 
     // Across - config optional (defaults to mainnet)
     const provider = createCrossChainProvider("across");
@@ -33,6 +36,11 @@ A set of classes and utilities for handling cross-chain operations through vario
     const oifProvider = createCrossChainProvider("oif", {
         solverId: "my-solver",
         url: "https://solver.example.com",
+    });
+
+    // LiFi Intents - orderServerUrl required
+    const lifiProvider = createCrossChainProvider("lifi-intents", {
+        orderServerUrl: LIFI_INTENTS_ORDER_SERVER_URL,
     });
     ```
 
@@ -623,6 +631,20 @@ Payload validation:
 | `oif-resource-lock-v0` | token, amount, sponsor, expiration        |
 | `oif-3009-v0`          | from, value, token address, expiration    |
 | `oif-user-open-v0`     | allowances (token, user, spender, amount) |
+
+#### LiFi Intents
+
+| Field            | Type   | Required | Description                                                   |
+| ---------------- | ------ | -------- | ------------------------------------------------------------- |
+| `orderServerUrl` | string | Yes      | LI.FI order server URL (e.g. `https://order.li.fi`)          |
+| `providerId`     | string | No       | Custom provider identifier (default: `"lifi-intents"`)        |
+| `headers`        | object | No       | Custom HTTP headers sent with all requests to the order server |
+
+Constraints:
+
+-   Only supports **exact-input** swaps
+-   Only supports **ERC-20** token inputs (no native tokens)
+-   All quotes return **transaction steps** (no gasless/signature-based execution)
 
 ## References
 

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -638,7 +638,7 @@ Payload validation:
 | ---------------- | ------ | -------- | ------------------------------------------------------------- |
 | `orderServerUrl` | string | Yes      | LI.FI order server URL (e.g. `https://order.li.fi`)          |
 | `providerId`     | string | No       | Custom provider identifier (default: `"lifi-intents"`)        |
-| `headers`        | object | No       | Custom HTTP headers sent with all requests to the order server |
+| `headers`        | Record&lt;string, string&gt; | No       | Custom HTTP headers sent with all requests to the order server |
 
 Constraints:
 

--- a/apps/docs/docs/cross-chain/concepts.md
+++ b/apps/docs/docs/cross-chain/concepts.md
@@ -83,10 +83,11 @@ A provider is an adapter that translates the SDK's standardized `QuoteRequest` i
 
 | Provider                       | Status | Execution Modes                         | Tracking                        |
 | ------------------------------ | ------ | --------------------------------------- | ------------------------------- |
-| [Across](./across-provider.md) | Active | User (transaction)                      | API (mainnet), Events (testnet) |
-| [Relay](./relay-provider.md)   | Active | User (transaction)                      | API-based                       |
-| [OIF](./oif-provider.md)       | Active | Protocol + User                         | Event-based                     |
-| [Bungee](./bungee-provider.md) | Active | User (transaction) + Protocol (permit2) | API-based                       |
+| [Across](./across-provider.md)                | Active | User (transaction)                      | API (mainnet), Events (testnet) |
+| [Relay](./relay-provider.md)                  | Active | User (transaction)                      | API-based                       |
+| [OIF](./oif-provider.md)                      | Active | Protocol + User                         | Event-based                     |
+| [Bungee](./bungee-provider.md)                | Active | User (transaction) + Protocol (permit2) | API-based                       |
+| [LiFi Intents](./lifi-intents-provider.md)    | Active | User (transaction)                      | Custom event + API              |
 
 ### Choosing a provider
 
@@ -94,6 +95,7 @@ A provider is an adapter that translates the SDK's standardized `QuoteRequest` i
 -   **Across** is well-established and active on both mainnet and testnet. Mainnet uses API tracking; testnet requires RPC URLs for event-based tracking.
 -   **OIF** offers the most flexibility — supports both gasless (protocol) and user-pays-gas execution modes. Requires access to an OIF-compliant solver endpoint.
 -   **Bungee** supports both gasless (permit2 signatures) and user-pays-gas (onchain transactions, default). The onchain flow works for native tokens and ERC20s. API-based tracking, no extra RPC URLs needed.
+-   **LiFi Intents** routes through the LI.FI intent solver marketplace. Transaction-based only (ERC-20 inputs, exact-input swaps). Requires an `orderServerUrl`. Uses custom event parsing on the origin chain plus API-based fill tracking — origin-chain RPC URL required.
 
 ## Aggregation and sorting
 

--- a/apps/docs/docs/cross-chain/example.md
+++ b/apps/docs/docs/cross-chain/example.md
@@ -132,7 +132,7 @@ if (response.quotes.length === 0) {
 
 Before submitting the transaction, check whether the selected provider requires an ERC-20 token approval.
 
-Some providers (Relay, Bungee, OIF) populate `quote.order.checks.allowances` with the exact spender and amount. Others (e.g. Across) do not. The snippet below handles both cases: when checks are present it uses them directly, otherwise it derives the approval from the transaction step's `to` address.
+Some providers (Relay, Bungee, OIF, LiFi Intents) populate `quote.order.checks.allowances` with the exact spender and amount. Others (e.g. Across) do not. The snippet below handles both cases: when checks are present it uses them directly, otherwise it derives the approval from the transaction step's `to` address.
 
 ```typescript
 import { erc20Abi } from "viem";
@@ -195,7 +195,7 @@ if (allowances.length > 0) {
 
 :::info Why two paths?
 
-Always honor `order.checks.allowances` when present — some providers (e.g. Relay) include required approvals there even for signature-only orders. Not all providers populate this field though (e.g. Across does not), so the fallback derives the spender from the transaction step's `to` address. The fallback only runs for transaction-based orders with ERC-20 inputs; signature-only orders without checks and native token inputs are skipped.
+Always honor `order.checks.allowances` when present — providers like Relay and LiFi Intents include required approvals there. Not all providers populate this field though (e.g. Across does not), so the fallback derives the spender from the transaction step's `to` address. The fallback only runs for transaction-based orders with ERC-20 inputs; signature-only orders without checks and native token inputs are skipped.
 
 :::
 

--- a/apps/docs/docs/cross-chain/frontend-integration.md
+++ b/apps/docs/docs/cross-chain/frontend-integration.md
@@ -171,7 +171,7 @@ export function useCrossChainSwap() {
 
         // ── 3. ERC-20 approvals ──────────────────────────────────────────────
         //
-        // Some providers (Relay, Bungee, OIF) populate quote.order.checks.allowances
+        // Some providers (Relay, Bungee, OIF, LiFi Intents) populate quote.order.checks.allowances
         // with the exact spender and amount. Others (e.g. Across) do not.
         // When checks are missing, derive the approval from the transaction step:
         // the `to` address is the contract that will pull tokens from the user.

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -112,7 +112,7 @@ Both `0x0000000000000000000000000000000000000000` (zero address) and `0xeeeeeeee
 
 ## Handle ERC-20 approvals
 
-Always check `order.checks.allowances` first — some providers (Relay, Bungee, OIF) populate it with the exact spender and amount, even for signature-only orders. When checks are missing (e.g. Across), derive the spender from the transaction step's `to` address. Native token inputs never need an approval.
+Always check `order.checks.allowances` first — some providers (Relay, Bungee, OIF, LiFi Intents) populate it with the exact spender and amount, even for signature-only orders. When checks are missing (e.g. Across), derive the spender from the transaction step's `to` address. Native token inputs never need an approval.
 
 See the [full approval pattern](./example.md#5-check-and-handle-erc-20-approvals) in the Execute Intent guide.
 

--- a/apps/docs/docs/cross-chain/intent-tracking.md
+++ b/apps/docs/docs/cross-chain/intent-tracking.md
@@ -13,17 +13,17 @@ Tracking supports **two ways of observing the same lifecycle**, depending on the
 
 The `OrderTracker` streams updates using the full OIF `OrderStatus` set (from `@openintentsframework/oif-specs`). Not every provider emits every status — the table below shows which statuses each provider actually produces:
 
-| Status | Description | Across | Relay | OIF | Bungee |
-|--------|-------------|--------|-------|-----|--------|
-| `Created` | Order created on-chain | — | — | ✓ | — |
-| `Pending` | Awaiting execution | ✓ | ✓ | ✓ | ✓ |
-| `Executing` | Filler is processing the order | — | ✓ | ✓ | ✓ |
-| `Executed` | Fill transaction submitted | — | — | ✓ | — |
-| `Settling` | Settlement in progress | — | ✓ | — | — |
-| `Settled` | Settlement complete (reserved) | — | — | — | — |
-| `Finalized` | Order fully complete | ✓ | ✓ | ✓ | ✓ |
-| `Failed` | Order failed | ✓ | ✓ | ✓ | ✓ |
-| `Refunded` | Funds returned to sender | ✓ | ✓ | ✓ | ✓ |
+| Status | Description | Across | Relay | OIF | Bungee | LiFi Intents |
+|--------|-------------|--------|-------|-----|--------|--------------|
+| `Created` | Order created on-chain | — | — | ✓ | — | — |
+| `Pending` | Awaiting execution | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `Executing` | Filler is processing the order | — | ✓ | ✓ | ✓ | — |
+| `Executed` | Fill transaction submitted | — | — | ✓ | — | — |
+| `Settling` | Settlement in progress | — | ✓ | — | — | ✓ |
+| `Settled` | Settlement complete (reserved) | — | — | — | — | — |
+| `Finalized` | Order fully complete | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `Failed` | Order failed | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `Refunded` | Funds returned to sender | ✓ | ✓ | ✓ | ✓ | — |
 
 You can subscribe to **any** `OrderStatus` via `tracker.on(OrderStatus.<status>, ...)` — the examples below show the most common ones.
 

--- a/apps/docs/docs/cross-chain/lifi-intents-provider.md
+++ b/apps/docs/docs/cross-chain/lifi-intents-provider.md
@@ -23,7 +23,7 @@ All quotes return **transaction steps** (user-pays-gas). The provider does not s
 | ---------------- | ------ | -------- | ------------------------------------------------------------- |
 | `orderServerUrl` | string | Yes      | LI.FI order server URL                                        |
 | `providerId`     | string | No       | Custom provider identifier (default: `"lifi-intents"`)        |
-| `headers`        | object | No       | Custom HTTP headers sent with all requests to the order server |
+| `headers`        | Record&lt;string, string&gt; | No       | Custom HTTP headers sent with all requests to the order server |
 
 ## Creating the Provider
 

--- a/apps/docs/docs/cross-chain/lifi-intents-provider.md
+++ b/apps/docs/docs/cross-chain/lifi-intents-provider.md
@@ -1,0 +1,153 @@
+---
+title: LiFi Intents Provider
+---
+
+The [LiFi Intents](https://docs.li.fi/lifi-intents/introduction) provider enables cross-chain token transfers through the LI.FI intent solver marketplace, where solvers compete to fulfill users' transfer requests at the best rates.
+
+**Status**: Active (mainnet)
+
+## How It Works
+
+LiFi Intents uses an intent-based architecture:
+
+1. The user deposits tokens into a resource lock (escrow contract) via an onchain transaction
+2. The LI.FI order server broadcasts the deposit proof to competing solvers
+3. The winning solver delivers the destination-chain assets
+4. Settlement verification releases the locked funds to the solver
+
+All quotes return **transaction steps** (user-pays-gas). The provider does not support gasless/signature-based execution.
+
+## Configuration
+
+| Field            | Type   | Required | Description                                                   |
+| ---------------- | ------ | -------- | ------------------------------------------------------------- |
+| `orderServerUrl` | string | Yes      | LI.FI order server URL                                        |
+| `providerId`     | string | No       | Custom provider identifier (default: `"lifi-intents"`)        |
+| `headers`        | object | No       | Custom HTTP headers sent with all requests to the order server |
+
+## Creating the Provider
+
+### Mainnet
+
+```typescript
+import {
+    createCrossChainProvider,
+    LIFI_INTENTS_ORDER_SERVER_URL,
+} from "@wonderland/interop-cross-chain";
+
+const lifiProvider = createCrossChainProvider("lifi-intents", {
+    orderServerUrl: LIFI_INTENTS_ORDER_SERVER_URL, // https://order.li.fi
+});
+```
+
+### Dev Environment
+
+```typescript
+import {
+    createCrossChainProvider,
+    LIFI_INTENTS_ORDER_SERVER_DEV_URL,
+} from "@wonderland/interop-cross-chain";
+
+const lifiProvider = createCrossChainProvider("lifi-intents", {
+    orderServerUrl: LIFI_INTENTS_ORDER_SERVER_DEV_URL, // https://order-dev.li.fi
+});
+```
+
+### With Custom Headers
+
+```typescript
+import {
+    createCrossChainProvider,
+    LIFI_INTENTS_ORDER_SERVER_URL,
+} from "@wonderland/interop-cross-chain";
+
+const lifiProvider = createCrossChainProvider("lifi-intents", {
+    orderServerUrl: LIFI_INTENTS_ORDER_SERVER_URL,
+    headers: { "x-api-key": "your-api-key" },
+});
+```
+
+## Getting Quotes
+
+LiFi Intents only supports **exact-input** swaps with **ERC-20 tokens** (native token inputs are not supported):
+
+```typescript
+const quotes = await lifiProvider.getQuotes({
+    user: "0xYourAddress",
+    input: {
+        chainId: 1, // Ethereum
+        assetAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+        amount: "1000000", // 1 USDC
+    },
+    output: {
+        chainId: 42161, // Arbitrum
+        assetAddress: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831", // USDC
+    },
+    swapType: "exact-input",
+});
+
+const quote = quotes[0];
+```
+
+## Executing Transactions
+
+LiFi Intents quotes contain transaction steps. The user sends the transaction directly — the order server detects the deposit via the onchain Open event:
+
+```typescript
+import { getTransactionSteps } from "@wonderland/interop-cross-chain";
+
+const step = getTransactionSteps(quote.order)[0];
+const hash = await walletClient.sendTransaction({
+    to: step.transaction.to,
+    data: step.transaction.data,
+    value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
+});
+console.log("Transaction sent:", hash);
+```
+
+## Approvals
+
+Access approval information from the order checks:
+
+```typescript
+const allowances = quote.order.checks?.allowances ?? [];
+for (const { spender, tokenAddress, required } of allowances) {
+    // Approve token spend if needed
+}
+```
+
+## Tracking
+
+LiFi Intents uses a custom Open event parser on the origin chain combined with API-based fill tracking. The SDK polls the order server status endpoint at 5-second intervals:
+
+```
+GET /orders/status?onChainOrderId=<orderId>
+```
+
+The origin chain requires an RPC URL for parsing the Open event. Fill tracking is handled entirely through the LI.FI order server API.
+
+### Order Statuses
+
+The LI.FI order server reports the following statuses, mapped to SDK statuses:
+
+| LI.FI Status | SDK Status   | Description                               |
+| ------------ | ------------ | ----------------------------------------- |
+| `Signed`     | Pending      | Order registered, awaiting solver pickup   |
+| `Delivered`  | Settling     | Solver delivered assets, awaiting settlement |
+| `Settled`    | Finalized    | Settlement complete, funds released         |
+| `Expired`    | Failed       | Order deadline exceeded                    |
+| `Failed`     | Failed       | Order failed for another reason            |
+
+## Asset Discovery
+
+The provider supports asset discovery via the LI.FI `/routes` endpoint, which returns the supported chains and tokens for cross-chain transfers.
+
+## Next Step
+
+See a complete working example: [Execute Intent](./example.md)
+
+## References
+
+-   [LI.FI Intents Documentation](https://docs.li.fi/lifi-intents/introduction)
+-   [API Reference](./api.md) — full type definitions for quotes, fees, and orders
+-   [Concepts](./concepts.md) — how intent-based transfers work

--- a/apps/docs/docs/cross-chain/providers.md
+++ b/apps/docs/docs/cross-chain/providers.md
@@ -12,7 +12,7 @@ This document lists all cross-chain providers supported by the Interop SDK.
 | [Relay Protocol](./relay-provider.md)   | Active | Cross-chain token transfers using Relay bridge            |
 | [OIF](./oif-provider.md)                | Active | Direct integration with OIF-compliant solvers             |
 | [Bungee Protocol](./bungee-provider.md) | Active | Cross-chain transfers via onchain or gasless permit2 flow |
-| LiFi Intents                            | Active | Cross-chain via LiFi intent solver                        |
+| [LiFi Intents](./lifi-intents-provider.md) | Active | Cross-chain via LiFi intent solver marketplace         |
 
 ## Provider Configuration
 
@@ -47,7 +47,7 @@ createCrossChainProvider("bungee", {
 | `across`       | (none)            | `isTestnet`                                                                                           |
 | `relay`        | (none)            | `apiKey`, `isTestnet`                                                                                 |
 | `oif`          | `solverId`, `url` | —                                                                                                     |
-| `lifi-intents` | `orderServerUrl`  | —                                                                                                     |
+| `lifi-intents` | `orderServerUrl`  | `providerId`, `headers`                                                                               |
 | `bungee`       | (none)            | `tier`, `apiKey`, `affiliateId`, `feeBps`, `feeTakerAddress`, `submissionModes`, `slippage`, `refuel` |
 
 ## Order Tracking Requirements
@@ -61,6 +61,7 @@ Different providers use different tracking mechanisms. Some need RPC URLs, other
 | Relay            | API-based            | API-based    | None                        |
 | OIF              | OIF event-based      | Event-based  | Origin + destination chains |
 | Bungee           | API-based            | API-based    | None                        |
+| LiFi Intents     | Custom event-based   | API-based    | Origin chain only           |
 
 ## Creating Custom Providers
 

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -49,6 +49,7 @@ const sidebars: SidebarsConfig = {
                 "cross-chain/relay-provider",
                 "cross-chain/oif-provider",
                 "cross-chain/bungee-provider",
+                "cross-chain/lifi-intents-provider",
                 "cross-chain/example",
                 "cross-chain/frontend-integration",
                 "cross-chain/intent-tracking",


### PR DESCRIPTION
## Summary

- Add dedicated LiFi Intents provider page (`lifi-intents-provider.md`) covering configuration, quotes, execution, approvals, tracking, and asset discovery
- Reference LiFi Intents across all existing docs where providers are listed: about, concepts, getting-started, example, frontend-integration, intent-tracking, API reference, and providers overview
- Add Bungee to the provider links table in `cross-chain.md` (was previously missing)

## Test plan

- [ ] Verify docs site builds without errors (`pnpm --filter docs build`)
- [ ] Check all new internal links resolve (sidebar entry, cross-references)
- [ ] Review LiFi Intents provider page renders correctly
- [ ] Spot-check updated tables (concepts, intent-tracking, providers) for alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)