### PR TITLE
feat(ui): sync cross-chain mode toggle to URL param

### DIFF
--- a/examples/ui/app/cross-chain/stores/crossChainStore.ts
+++ b/examples/ui/app/cross-chain/stores/crossChainStore.ts
@@ -5,10 +5,18 @@ import type { Aggregator } from '@wonderland/interop-cross-chain';
 export type SwapFormMode = 'getQuotes' | 'buildQuote';
 
 const TESTNET_QUERY_PARAM = 'testnet';
+const MODE_QUERY_PARAM = 'mode';
+const MODE_BUILD_VALUE = 'build';
 
 function readIsTestnetFromUrl(): boolean {
   if (typeof window === 'undefined') return false;
   return new URLSearchParams(window.location.search).get(TESTNET_QUERY_PARAM) === 'true';
+}
+
+function readModeFromUrl(): SwapFormMode {
+  if (typeof window === 'undefined') return 'getQuotes';
+  const value = new URLSearchParams(window.location.search).get(MODE_QUERY_PARAM);
+  return value === MODE_BUILD_VALUE ? 'buildQuote' : 'getQuotes';
 }
 
 interface CrossChainState {
@@ -26,7 +34,7 @@ const initialIsTestnet = readIsTestnetFromUrl();
 export const useCrossChainStore = create<CrossChainState>((set, get) => ({
   isTestnet: initialIsTestnet,
   executor: buildExecutor(initialIsTestnet),
-  mode: 'getQuotes',
+  mode: readModeFromUrl(),
   buildQuoteProviderId: 'across',
 
   setIsTestnet: (isTestnet: boolean) => {
@@ -41,6 +49,20 @@ export const useCrossChainStore = create<CrossChainState>((set, get) => ({
     set({ isTestnet, executor: buildExecutor(isTestnet) });
   },
 
-  setMode: (mode: SwapFormMode) => set({ mode }),
+  setMode: (mode: SwapFormMode) => {
+    if (mode === get().mode) return;
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href);
+      if (mode === 'buildQuote') {
+        url.searchParams.set(MODE_QUERY_PARAM, MODE_BUILD_VALUE);
+      } else {
+        url.searchParams.delete(MODE_QUERY_PARAM);
+      }
+      if (url.search !== window.location.search) {
+        window.history.replaceState({}, '', url.toString());
+      }
+    }
+    set({ mode });
+  },
   setBuildQuoteProviderId: (providerId: string) => set({ buildQuoteProviderId: providerId }),
 }));


### PR DESCRIPTION
## Summary

- Deep-linkable mode selection on the cross-chain demo: reloading the page preserves the active mode.
- `?mode=build` → Build Quote; param absent (or any other value) → Get Quotes (default).
- Mirrors the existing `?testnet=true` URL-sync pattern already in `crossChainStore`.

Fixes [EFI-868](https://linear.app/defi-wonderland/issue/EFI-868/cross-chain-mode-should-be-in-the-url-params).

## Test plan

- [ ] Load `/cross-chain` → Get Quotes is the active tab.
- [ ] Load `/cross-chain?mode=build` → Build Quote is active on first paint (no flicker).
- [ ] Click Build Quote → URL gains `?mode=build` via `history.replaceState` (no navigation).
- [ ] Click Get Quotes → the `mode` param is removed.
- [ ] Refresh any state → selected mode persists.
- [ ] Existing route params (`fromChain`, `toChain`, `fromToken`, `toToken`, `testnet`) still sync correctly alongside `mode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)