### PR TITLE
feat(ui): add reverse-direction button to cross-chain swap form

### DIFF
--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -19,6 +19,7 @@ import {
 } from '../utils/amountValidation';
 import { TokenSelect } from './TokenSelect';
 import { WalletConnect } from './WalletConnect';
+import { SwapIcon } from './icons';
 
 export type { SwapFormMode } from '../stores/crossChainStore';
 
@@ -66,6 +67,7 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
     setOutputChain,
     setInputToken,
     setOutputToken,
+    reverseDirection,
   } = useRouteSelection(chainConfig.DEFAULT_INPUT_CHAIN_ID, chainConfig.DEFAULT_OUTPUT_CHAIN_ID);
 
   const [recipient, setRecipient] = useState('');
@@ -205,6 +207,11 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
     onInputChange?.();
   };
 
+  const handleReverseDirection = () => {
+    reverseDirection();
+    onInputChange?.();
+  };
+
   const handleInputTokenChange = (address: string) => {
     setInputToken(address);
     onInputChange?.();
@@ -335,7 +342,7 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
           <p className='text-xs text-text-tertiary mt-1'>Leave empty to use your wallet address.</p>
         </div>
 
-        <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+        <div className='grid grid-cols-1 md:grid-cols-[1fr_auto_1fr] gap-4 md:gap-3'>
           <div className='flex flex-col gap-3'>
             <label htmlFor='input-chain-select' className='text-sm font-medium text-text-secondary'>
               From
@@ -362,6 +369,20 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
               disabled={isDisabled}
               dataTestId='input-token-select'
             />
+          </div>
+
+          <div className='flex items-center justify-center'>
+            <button
+              type='button'
+              onClick={handleReverseDirection}
+              disabled={isDisabled}
+              aria-label='Reverse direction'
+              title='Reverse direction'
+              data-testid='reverse-direction-button'
+              className={`p-2 rounded-lg border border-border/50 bg-background/50 text-text-secondary hover:text-accent hover:border-accent/60 transition-colors focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:ring-offset-1 ${isDisabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+            >
+              <SwapIcon className='w-4 h-4' />
+            </button>
           </div>
 
           <div className='flex flex-col gap-3'>

--- a/examples/ui/app/cross-chain/hooks/useRouteSelection.ts
+++ b/examples/ui/app/cross-chain/hooks/useRouteSelection.ts
@@ -45,6 +45,8 @@ export function useRouteSelection(defaultInputChainId: number, defaultOutputChai
     setSelection((prev) => ({ ...prev, outputToken: address }));
   }, []);
 
+  const reverseDirection = useCallback(() => setSelection((prev) => selector.reverseDirection(prev)), [selector]);
+
   useEffect(() => {
     const configLoaded = Object.keys(byChain).length > 0;
     if (!configLoaded) return;
@@ -62,5 +64,6 @@ export function useRouteSelection(defaultInputChainId: number, defaultOutputChai
     setOutputChain,
     setInputToken,
     setOutputToken,
+    reverseDirection,
   };
 }

--- a/examples/ui/app/cross-chain/utils/routeSelection.spec.ts
+++ b/examples/ui/app/cross-chain/utils/routeSelection.spec.ts
@@ -159,6 +159,30 @@ describe('cascading', () => {
   });
 });
 
+describe('reverseDirection', () => {
+  const selector = createRouteSelector(config);
+
+  it('swaps chainIds and tokens so each token stays on its original chain', () => {
+    const next = selector.reverseDirection(
+      sel({ inputChainId: 1, outputChainId: 10, inputToken: USDC, outputToken: DAI }),
+    );
+    expect(next.inputChainId).toBe(10);
+    expect(next.outputChainId).toBe(1);
+    expect(next.inputToken).toBe(DAI);
+    expect(next.outputToken).toBe(USDC);
+  });
+
+  it('resolve preserves the reversed selection when tokens remain compatible', () => {
+    // USDC (across+sample) ↔ DAI (sample) share the `sample` provider on both chains,
+    // so the reversed route still resolves cleanly.
+    const resolved = selector.resolve(selector.reverseDirection(sel({ inputToken: USDC, outputToken: DAI })));
+    expect(resolved.inputChainId).toBe(10);
+    expect(resolved.outputChainId).toBe(1);
+    expect(resolved.inputToken).toBe(DAI);
+    expect(resolved.outputToken).toBe(USDC);
+  });
+});
+
 describe('edge cases', () => {
   it('empty config or unknown chain yields empty results', () => {
     const empty = createRouteSelector({

--- a/examples/ui/app/cross-chain/utils/routeSelection.spec.ts
+++ b/examples/ui/app/cross-chain/utils/routeSelection.spec.ts
@@ -181,6 +181,20 @@ describe('reverseDirection', () => {
     expect(resolved.inputToken).toBe(DAI);
     expect(resolved.outputToken).toBe(USDC);
   });
+
+  it('resolves empty tokens before reversing so the swap reflects the displayed selection', () => {
+    // Initial-load scenario: URL omits fromToken/toToken, so the raw selection has empty strings.
+    // The UI renders the resolved selection. A reverse at that moment must swap what's being
+    // displayed, not the empty underlying state — otherwise the post-reverse tokens could differ
+    // from just flipping what the user saw.
+    const emptyTokens = sel({ inputToken: '', outputToken: '' });
+    const displayed = selector.resolve(emptyTokens);
+    const reversed = selector.reverseDirection(emptyTokens);
+    expect(reversed.inputChainId).toBe(displayed.outputChainId);
+    expect(reversed.outputChainId).toBe(displayed.inputChainId);
+    expect(reversed.inputToken).toBe(displayed.outputToken);
+    expect(reversed.outputToken).toBe(displayed.inputToken);
+  });
 });
 
 describe('edge cases', () => {

--- a/examples/ui/app/cross-chain/utils/routeSelection.ts
+++ b/examples/ui/app/cross-chain/utils/routeSelection.ts
@@ -173,5 +173,19 @@ export function createRouteSelector(config: RouteConfig) {
     return { ...prev, inputToken: address, outputToken };
   }
 
-  return { selectionFromUrl, resolve, setInputChain, setOutputChain, setInputToken };
+  /**
+   * Reverse the direction of the route: origin ↔ destination.
+   * Each token moves with its chain, so the post-swap state stays valid
+   * (what was the destination token/chain becomes the new origin, and vice versa).
+   */
+  function reverseDirection(prev: Selection): Selection {
+    return {
+      inputChainId: prev.outputChainId,
+      outputChainId: prev.inputChainId,
+      inputToken: prev.outputToken,
+      outputToken: prev.inputToken,
+    };
+  }
+
+  return { selectionFromUrl, resolve, setInputChain, setOutputChain, setInputToken, reverseDirection };
 }

--- a/examples/ui/app/cross-chain/utils/routeSelection.ts
+++ b/examples/ui/app/cross-chain/utils/routeSelection.ts
@@ -175,15 +175,19 @@ export function createRouteSelector(config: RouteConfig) {
 
   /**
    * Reverse the direction of the route: origin ↔ destination.
-   * Each token moves with its chain, so the post-swap state stays valid
-   * (what was the destination token/chain becomes the new origin, and vice versa).
+   * Resolves `prev` first so the swap always reflects the tokens the user is
+   * actually seeing (on initial load when the URL omits token params, the raw
+   * selection has empty token strings but `resolve` fills them with the
+   * first-available tokens that the UI is rendering). Each token then moves
+   * with its chain, so the post-swap state stays valid.
    */
   function reverseDirection(prev: Selection): Selection {
+    const { inputChainId, outputChainId, inputToken, outputToken } = resolve(prev);
     return {
-      inputChainId: prev.outputChainId,
-      outputChainId: prev.inputChainId,
-      inputToken: prev.outputToken,
-      outputToken: prev.inputToken,
+      inputChainId: outputChainId,
+      outputChainId: inputChainId,
+      inputToken: outputToken,
+      outputToken: inputToken,
     };
   }
 


### PR DESCRIPTION
## Summary

- Adds a `<>` button between the From/To selectors that reverses the route in a single click. Swaps both chainIds and tokens so each token stays on its original chain — the post-swap state is always valid.
- Previously there was no one-click way to flip a cross-chain route; users had to change destination first before they could use that chain as origin.
- Three-column grid `1fr | auto | 1fr`; button sits vertically centered against the From/To columns on desktop, and stacks in between on mobile. Reuses the existing `SwapIcon`, a11y via `aria-label="Reverse direction"` + matching `title`.

Net scope:
- `routeSelection.ts` — new `reverseDirection(prev)` on the selector (swaps chainIds + tokens).
- `useRouteSelection.ts` — exposes `reverseDirection`.
- `SwapForm.tsx` — three-column layout with the centered button.
- `routeSelection.spec.ts` — covers `reverseDirection` + `resolve` cascade.

## Test plan

- [ ] Default route (Base → OP, USDC/USDC): click `<>` — origin becomes OP/USDC, destination becomes Base/USDC.
- [ ] Asymmetric route (Base/USDC → OP/ETH): click `<>` — origin becomes OP/ETH, destination becomes Base/USDC.
- [ ] Rapid double-click cleanly round-trips back to the starting route.
- [ ] Button is keyboard-accessible (tab + enter/space).
- [ ] Screen reader announces "Reverse direction".
- [ ] Desktop (md+): button vertically centered across the full From/To column height.
- [ ] Mobile: layout stacks `From → button → To` without overflow.
- [ ] `data-testid="reverse-direction-button"` available for future e2e coverage.
- [ ] `pnpm vitest run app/cross-chain/utils/routeSelection.spec.ts` (19/19 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)