### PR TITLE
docs: add beta disclaimer to docs site and package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # interop-sdk
 
+> **Beta — under active development.** APIs may change between releases. We're shipping quickly and welcome bug reports and feedback via [GitHub Issues](https://github.com/defi-wonderland/interop-sdk/issues).
+
 This repository is a monorepo consisting of the following packages:
 
 -   [`@wonderland/interop-addresses`](./packages/addresses/): A utility library for interoperable addresses based on ERC-7930.

--- a/apps/docs/docs/about.md
+++ b/apps/docs/docs/about.md
@@ -3,6 +3,10 @@ slug: "/"
 title: Interop SDK
 ---
 
+:::warning Beta — under active development
+APIs may change between releases. We're shipping quickly and welcome bug reports and feedback via [GitHub Issues](https://github.com/defi-wonderland/interop-sdk/issues).
+:::
+
 The _Interop SDK_ is a TypeScript library for cross-chain applications. It brings the latest interoperability standards to wallet and app developers who want to provide seamless multichain experiences.
 
 ## Modules

--- a/apps/docs/docs/addresses.md
+++ b/apps/docs/docs/addresses.md
@@ -2,6 +2,10 @@
 title: Addresses
 ---
 
+:::warning Beta — under active development
+APIs may change between releases. We're shipping quickly and welcome bug reports and feedback via [GitHub Issues](https://github.com/defi-wonderland/interop-sdk/issues).
+:::
+
 Ethereum is multichain. An address like `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045` doesn't tell you _which_ chain it's on — and sending to the right address on the wrong chain can mean lost funds.
 
 Interoperable addresses fix this by encoding the **address and the chain together**, so every recipient is unambiguous.

--- a/apps/docs/docs/cross-chain.md
+++ b/apps/docs/docs/cross-chain.md
@@ -2,6 +2,10 @@
 title: Cross-Chain
 ---
 
+:::warning Beta — under active development
+APIs may change between releases. We're shipping quickly and welcome bug reports and feedback via [GitHub Issues](https://github.com/defi-wonderland/interop-sdk/issues).
+:::
+
 The `cross-chain` package provides a standardized interface for cross-chain token transfers. It lets you fetch quotes from multiple bridge providers, execute transfers, and track orders through a unified API.
 
 It follows [EIP-7683](https://www.erc7683.org/) for cross-chain intent structures.

--- a/apps/docs/docs/installation.md
+++ b/apps/docs/docs/installation.md
@@ -2,6 +2,10 @@
 title: "Installation"
 ---
 
+:::warning Beta — under active development
+APIs may change between releases. We're shipping quickly and welcome bug reports and feedback via [GitHub Issues](https://github.com/defi-wonderland/interop-sdk/issues).
+:::
+
 ## Prerequisites
 
 -   **Node.js** v20.x or higher
@@ -24,8 +28,6 @@ pnpm add @wonderland/interop-addresses
 ```
 
 ### Cross-Chain Package
-
-> 🚧 This package is currently under development 🚧
 
 For cross-chain operations:
 

--- a/packages/addresses/README.md
+++ b/packages/addresses/README.md
@@ -1,5 +1,7 @@
 # @wonderland/interop-addresses
 
+> **Beta — under active development.** APIs may change between releases. We're shipping quickly and welcome bug reports and feedback via [GitHub Issues](https://github.com/defi-wonderland/interop-sdk/issues).
+
 A TypeScript library for handling interoperable blockchain addresses across different networks.
 
 This package provides methods to convert between interoperable names (ERC-7828), structured objects with CAIP-350 text-encoded fields, and binary addresses (EIP-7930), following a clean two-layer architecture.

--- a/packages/cross-chain/README.md
+++ b/packages/cross-chain/README.md
@@ -1,5 +1,7 @@
 # @wonderland/interop-cross-chain
 
+> **Beta — under active development.** APIs may change between releases. We're shipping quickly and welcome bug reports and feedback via [GitHub Issues](https://github.com/defi-wonderland/interop-sdk/issues).
+
 The cross-chain package provides a standardized interface for interacting with cross-chain bridges and protocols. It enables seamless token transfers and swaps between different blockchain networks through a unified API.
 
 Key features:


### PR DESCRIPTION
## Summary

- Adds a consistent "Beta — under active development" notice to the docs homepage, installation, and per-module landing pages (addresses, cross-chain) as a Docusaurus `:::warning` admonition.
- Adds the same notice as a blockquote to the repo README and the two published package READMEs (`@wonderland/interop-addresses`, `@wonderland/interop-cross-chain`).
- Removes the now-redundant `🚧 This package is currently under development 🚧` line on the cross-chain section of `installation.md`, since the top-level banner supersedes it.

The notice invites feedback via GitHub Issues rather than just warning about instability, to keep the tone inviting.

## Test plan

- [ ] Build the docs site (`pnpm --filter @apps/docs build`) and verify admonitions render correctly on `/`, `/installation`, `/addresses`, `/cross-chain`
- [ ] Eyeball the rendered README on GitHub for the root repo and both packages
- [ ] Confirm no broken links in the `GitHub Issues` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)