### PR TITLE
fix(ci): pass MAINNET_RPC_URL to build-lint job

### DIFF
--- a/.github/workflows/build-lint.yml
+++ b/.github/workflows/build-lint.yml
@@ -33,6 +33,8 @@ jobs:
 
             - name: Run Build
               run: pnpm build
+              env:
+                  MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
 
             - name: Check types
               run: pnpm check-types

--- a/.github/workflows/main-workflow.yml
+++ b/.github/workflows/main-workflow.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
     build-lint:
         uses: ./.github/workflows/build-lint.yml
+        secrets: inherit
 
     test:
         uses: ./.github/workflows/test.yml


### PR DESCRIPTION
## Summary

- Adds `secrets: inherit` to the build-lint job in main-workflow.yml
- Passes `MAINNET_RPC_URL` to the build step in build-lint.yml

The UI build generates `/addresses` statically via `getRegisteredChains`, which makes RPC calls to mainnet. Without the secret, it falls back to a public RPC that's rate-limited and times out after 60s on CI runners. The secret was already configured for the e2e job but missing from build-lint.

Unblocks #261 and any other PR that triggers a full build.