### PR TITLE
docs(cross-chain): document ApprovalService, remove manual flow

### DIFF
--- a/apps/docs/docs/cross-chain/advanced-usage.md
+++ b/apps/docs/docs/cross-chain/advanced-usage.md
@@ -72,6 +72,83 @@ response.errors.forEach((error) => {
 
 For more details on the Aggregator configuration, see the [API Reference](./api.md#aggregator).
 
+## Automatic ERC-20 Approvals
+
+When ERC-20 inputs need an `approve` before the transfer, the aggregator can handle it for you. Pass an `approvalService` to `createAggregator` and every quote it returns already has the necessary `approve` `TransactionStep`s prepended to `order.steps`. If the user already holds sufficient allowance, nothing is prepended.
+
+```typescript
+import {
+    createAggregator,
+    createApprovalService,
+    createCrossChainProvider,
+} from "@wonderland/interop-cross-chain";
+
+const relayProvider = createCrossChainProvider("relay");
+
+const approvalService = createApprovalService({
+    rpcUrls: {
+        1: "https://mainnet.infura.io/v3/YOUR_API_KEY",
+        8453: "https://base-mainnet.g.alchemy.com/v2/YOUR_API_KEY",
+    },
+});
+
+const aggregator = createAggregator({
+    providers: [relayProvider],
+    approvalService,
+});
+
+// Every quote returned now has approval steps prepended when needed.
+const response = await aggregator.getQuotes({ /* ... */ });
+```
+
+Because approval steps live inside the normal `order.steps` array, your execution loop does not need a separate approval code path — iterate the steps in order and each `approve` fires before the transfer step that needs it:
+
+```typescript
+import { getTransactionSteps } from "@wonderland/interop-cross-chain";
+
+for (const step of getTransactionSteps(quote.order)) {
+    const hash = await walletClient.sendTransaction({
+        to: step.transaction.to,
+        data: step.transaction.data,
+        value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
+    });
+    await publicClient.waitForTransactionReceipt({ hash });
+}
+```
+
+### Choosing an amount strategy
+
+`ApprovalAmountStrategy` decides the amount encoded in each generated `approve`. Two implementations ship with the SDK:
+
+-   **`ExactAmountStrategy`** (default): approves exactly `required`. Smallest allowance footprint — one `approve` per order against the same `(token, spender)` pair.
+-   **`InfiniteAmountStrategy`**: approves `type(uint256).max`. The first order grants an unbounded allowance and later orders for the same pair skip the approval step entirely, at the cost of an unbounded allowance to the spender.
+
+```typescript
+import { createApprovalService, InfiniteAmountStrategy } from "@wonderland/interop-cross-chain";
+
+const approvalService = createApprovalService({
+    rpcUrls,
+    amountStrategy: new InfiniteAmountStrategy(),
+});
+```
+
+You can also supply your own strategy by implementing the `ApprovalAmountStrategy` interface — for example, a capped-allowance strategy that approves `min(required * 10, cap)`.
+
+### Failure handling
+
+The service is best-effort. If an allowance read fails for a chain, the affected quotes pass through unmodified rather than being dropped. Without an `approvalService`, aggregator output is unchanged.
+
+### Provider coverage
+
+The approval service can only enrich a quote whose provider declares its allowance requirements in `order.checks.allowances`. Coverage across shipped providers:
+
+-   **Across, LiFi Intents, OIF `oif-user-open-v0`** — always populated for ERC-20 inputs.
+-   **Relay, Bungee** — populated whenever the API flags an approve as needed (including the one-time Permit2 approval for Bungee's gasless path). Omitted when the API considers no approve required.
+-   **OIF `oif-escrow-v0`** (Permit2-based gasless) — **not populated**. The OIF wire format does not surface Permit2 approval state, so the adapter has no entry to forward. If your configuration accepts these quotes, the user's first transfer against a given token will fail when the solver cannot pull funds. Handle the one-time `approve(PERMIT2, ...)` yourself, or restrict the provider to `submissionModes: ["user-transaction"]` until the OIF adapter is updated.
+-   **OIF `oif-3009-v0`, `oif-resource-lock-v0`** — not populated, and correctly so: EIP-3009 and resource-lock flows don't use ERC-20 `approve`.
+
+For the full API reference see [Approval Service](./api.md#approval-service).
+
 ## Order Tracking
 
 The aggregator includes built-in order tracking when configured with a `trackerFactory`. After executing a transaction, use `aggregator.track()` to monitor the cross-chain transfer:

--- a/apps/docs/docs/cross-chain/advanced-usage.md
+++ b/apps/docs/docs/cross-chain/advanced-usage.md
@@ -101,12 +101,17 @@ const aggregator = createAggregator({
 const response = await aggregator.getQuotes({ /* ... */ });
 ```
 
-Because approval steps live inside the normal `order.steps` array, your execution loop does not need a separate approval code path — iterate the steps in order and each `approve` fires before the transfer step that needs it:
+Because approval steps live inside the normal `order.steps` array, your execution loop does not need a separate approval code path — iterate the steps in order and each `approve` fires before the transfer step that needs it.
+
+Each step carries an optional `description` field. Approval steps created by the SDK have `description: "Token approval"`, so you can surface different UI states:
 
 ```typescript
 import { getTransactionSteps } from "@wonderland/interop-cross-chain";
 
 for (const step of getTransactionSteps(quote.order)) {
+    const isApproval = step.description === "Token approval";
+    console.log(isApproval ? "Approving token…" : "Sending bridge tx…");
+
     const hash = await walletClient.sendTransaction({
         to: step.transaction.to,
         data: step.transaction.data,

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -132,6 +132,7 @@ A utility for managing multiple cross-chain providers and executing operations a
     import {
         AssetDiscoveryFactory,
         createAggregator,
+        createApprovalService,
         OrderTrackerFactory,
         SortingStrategyFactory,
     } from "@wonderland/interop-cross-chain";

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -142,8 +142,11 @@ A utility for managing multiple cross-chain providers and executing operations a
         timeoutMs: 15000, // optional
         trackerFactory: new OrderTrackerFactory({ rpcUrls }), // optional
         discoveryFactory: new AssetDiscoveryFactory(), // optional (default)
+        approvalService: createApprovalService({ rpcUrls }), // optional
     });
     ```
+
+    When `approvalService` is set, the aggregator reads on-chain ERC-20 allowances for every `order.checks.allowances` entry and prepends an `approve` `TransactionStep` to `order.steps` when the current allowance is below `required`. Without it, quotes pass through unchanged. See [Approval Service](#approval-service).
 
 #### Aggregator Class
 
@@ -266,6 +269,78 @@ A class that manages multiple cross-chain providers and coordinates their operat
         destinationAsset: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
     });
     ```
+
+### Approval Service
+
+An opt-in service that enriches aggregator quotes with ERC-20 approval steps. Pass one to `createAggregator({ approvalService })` and the aggregator will read on-chain allowances for every `order.checks.allowances` entry on the sorted quotes, then prepend an `approve` `TransactionStep` to `order.steps` when the current allowance is below `required`.
+
+Best-effort: on any read failure the affected quotes pass through unmodified. Quotes with sufficient existing allowance are not touched.
+
+#### Methods
+
+-   **createApprovalService**(config?: CreateApprovalServiceConfig): ApprovalService
+
+    Creates a `DefaultApprovalService` wired to a `MulticallAllowanceReader`.
+
+    ```typescript
+    import { createAggregator, createApprovalService } from "@wonderland/interop-cross-chain";
+
+    const approvalService = createApprovalService({
+        rpcUrls: {
+            1: "https://mainnet.infura.io/v3/YOUR_API_KEY",
+            8453: "https://base-mainnet.g.alchemy.com/v2/YOUR_API_KEY",
+        },
+    });
+
+    const aggregator = createAggregator({
+        providers: [acrossProvider],
+        approvalService,
+    });
+    ```
+
+#### CreateApprovalServiceConfig
+
+| Field              | Type                          | Required | Description                                                                                                              |
+| ------------------ | ----------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `rpcUrls`          | `Record<number, string>`      | No       | RPC URLs per chain ID. Used to build public clients for `allowance()` multicalls when `publicClient` is not supplied.    |
+| `publicClient`     | `PublicClient` (viem)         | No       | Pre-configured viem public client. Takes precedence over `rpcUrls`.                                                      |
+| `amountStrategy`   | `ApprovalAmountStrategy`      | No       | Strategy that decides the `amount` encoded in each `approve` call. Defaults to `ExactAmountStrategy`.                    |
+| `approvalGasLimit` | `bigint`                      | No       | Custom gas limit forwarded to every generated approval transaction. When omitted, the wallet or relayer estimates gas.   |
+
+#### Amount Strategies
+
+`ApprovalAmountStrategy` controls the amount encoded in each generated `approve` call.
+
+| Strategy                  | Approves            | Trade-off                                                                                                                       |
+| ------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `ExactAmountStrategy`     | exactly `required`  | Smallest allowance footprint. Next order against the same `(token, spender)` pair needs another `approve`.                      |
+| `InfiniteAmountStrategy`  | `type(uint256).max` | One `approve` per `(token, spender)` pair for its lifetime. Later orders skip the approval step, at the cost of unbounded allowance. |
+
+```typescript
+import { createApprovalService, InfiniteAmountStrategy } from "@wonderland/interop-cross-chain";
+
+const approvalService = createApprovalService({
+    rpcUrls,
+    amountStrategy: new InfiniteAmountStrategy(),
+});
+```
+
+Custom strategies implement the `ApprovalAmountStrategy` interface:
+
+```typescript
+interface ApprovalAmountStrategy {
+    resolve(required: bigint): bigint;
+}
+```
+
+#### Low-level classes
+
+Exported for advanced use cases (custom readers, custom service compositions):
+
+-   **DefaultApprovalService**(reader: AllowanceReader, amountStrategy: ApprovalAmountStrategy, gasLimit?: bigint) — implements `ApprovalService.enrichQuotes(quotes)`.
+-   **MulticallAllowanceReader**(clientManager: PublicClientManager) — batches ERC-20 `allowance()` calls into one `multicall` per chain. Failures on one chain do not affect others.
+
+Most consumers should use `createApprovalService(...)` rather than instantiating these directly.
 
 ### Sorting Strategies
 

--- a/apps/docs/docs/cross-chain/concepts.md
+++ b/apps/docs/docs/cross-chain/concepts.md
@@ -103,6 +103,8 @@ The `Aggregator` fetches quotes from multiple providers in parallel and returns 
 
 The aggregator also collects errors from individual providers, so you can show partial results even when some providers fail.
 
+Optionally, the aggregator can enrich sorted quotes with ERC-20 approval steps: configure an `approvalService` and every quote returned will already have any required `approve` `TransactionStep` prepended to `order.steps`. See [Automatic ERC-20 Approvals](./advanced-usage.md#automatic-erc-20-approvals).
+
 ## Order tracking
 
 After a transaction is submitted, the SDK can monitor the order through its lifecycle:

--- a/apps/docs/docs/cross-chain/example.md
+++ b/apps/docs/docs/cross-chain/example.md
@@ -173,7 +173,10 @@ if (isSignatureOnlyOrder(quote.order)) {
             maxPriorityFeePerGas: maxPriorityFeePerGas ? BigInt(maxPriorityFeePerGas) : undefined,
         });
         const receipt = await publicClient.waitForTransactionReceipt({ hash });
-        console.log("Confirmed:", receipt.status === "success" ? "Success" : "Failed");
+        if (receipt.status !== "success") {
+            throw new Error(`Step failed: ${step.description ?? "transaction"}`);
+        }
+        console.log("Confirmed: Success");
     }
 }
 ```

--- a/apps/docs/docs/cross-chain/example.md
+++ b/apps/docs/docs/cross-chain/example.md
@@ -13,11 +13,11 @@ First, import the required libraries and set up your environment variables, such
 ```typescript
 import {
     createAggregator,
+    createApprovalService,
     createCrossChainProvider,
     getSignatureSteps,
     getTransactionSteps,
     isSignatureOnlyOrder,
-    isNativeAddress,
 } from "@wonderland/interop-cross-chain";
 import { createPublicClient, createWalletClient, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
@@ -51,7 +51,7 @@ const walletClient = createWalletClient({
 
 ## 3. Set Up Cross-Chain Provider and Aggregator
 
-Initialize the cross-chain provider and aggregator, which will handle quoting and executing cross-chain transfers.
+Initialize the cross-chain provider and aggregator, which will handle quoting and executing cross-chain transfers. Wire an `approvalService` so the aggregator prepends any required ERC-20 `approve` steps to each quote automatically.
 
 ### Testnet (Sepolia → Base Sepolia)
 
@@ -59,21 +59,37 @@ Initialize the cross-chain provider and aggregator, which will handle quoting an
 const acrossProvider = createCrossChainProvider("across", { isTestnet: true });
 const relayProvider = createCrossChainProvider("relay", { isTestnet: true });
 
+const approvalService = createApprovalService({
+    rpcUrls: {
+        11155111: RPC_URL, // Sepolia
+        84532: "https://base-sepolia.g.alchemy.com/v2/YOUR_API_KEY",
+    },
+});
+
 const aggregator = createAggregator({
     providers: [acrossProvider, relayProvider],
+    approvalService,
 });
 ```
 
 ### Mainnet (Base → Arbitrum)
 
-For mainnet, omit `isTestnet` (or set it to `false`) and use the corresponding mainnet chain IDs when building your clients (step 2) and quote request (step 4).
+For mainnet, omit `isTestnet` (or set it to `false`) and use the corresponding mainnet chain IDs when building your clients (step 2), the approval service, and the quote request (step 4).
 
 ```typescript
 const acrossProvider = createCrossChainProvider("across");
 const relayProvider = createCrossChainProvider("relay");
 
+const approvalService = createApprovalService({
+    rpcUrls: {
+        8453: RPC_URL, // Base
+        42161: "https://arb-mainnet.g.alchemy.com/v2/YOUR_API_KEY",
+    },
+});
+
 const aggregator = createAggregator({
     providers: [acrossProvider, relayProvider],
+    approvalService,
 });
 ```
 
@@ -128,112 +144,45 @@ if (response.quotes.length === 0) {
 }
 ```
 
-## 5. Check and Handle ERC-20 Approvals
+## 5. Execute the Cross-Chain Transaction
 
-Before submitting the transaction, check whether the selected provider requires an ERC-20 token approval.
-
-Some providers (Relay, Bungee, OIF, LiFi Intents) populate `quote.order.checks.allowances` with the exact spender and amount. Others (e.g. Across) do not. The snippet below handles both cases: when checks are present it uses them directly, otherwise it derives the approval from the transaction step's `to` address.
+Because the aggregator was configured with an `approvalService` (step 3), each returned `quote.order.steps` already contains any ERC-20 `approve` step that the transfer needs, prepended before the transfer itself. Iterate the steps in order and each `approve` fires before the step that depends on it.
 
 ```typescript
-import { erc20Abi } from "viem";
-
 const quote = response.quotes[0];
-const request = { /* the QuoteRequest you passed to getQuotes */ };
 
-// Primary path: use checks.allowances when the provider populates it
-const allowances = quote.order.checks?.allowances ?? [];
-
-if (allowances.length > 0) {
-    for (const { tokenAddress, spender, required } of allowances) {
-        const token = tokenAddress as `0x${string}`;
-        const spenderAddr = spender as `0x${string}`;
-
-        const allowance = await publicClient.readContract({
-            address: token,
-            abi: erc20Abi,
-            functionName: "allowance",
-            args: [privateAccount.address, spenderAddr],
-        });
-        if (allowance < BigInt(required)) {
-            const hash = await walletClient.writeContract({
-                address: token,
-                abi: erc20Abi,
-                functionName: "approve",
-                args: [spenderAddr, BigInt(required)],
-            });
-            await publicClient.waitForTransactionReceipt({ hash });
-        }
-    }
-} else if (
-    !isSignatureOnlyOrder(quote.order) &&
-    !isNativeAddress(request.input.assetAddress, "eip155")
-) {
-    // Fallback: provider didn't supply checks (e.g. Across).
-    // Approve the transaction target for the quoted input amount.
-    const step = getTransactionSteps(quote.order)[0];
-    const spender = step.transaction.to as `0x${string}`;
-    const inputPreview = quote.preview.inputs[0];
-    const token = inputPreview.assetAddress as `0x${string}`;
-
-    const allowance = await publicClient.readContract({
-        address: token,
-        abi: erc20Abi,
-        functionName: "allowance",
-        args: [privateAccount.address, spender],
-    });
-    if (allowance < BigInt(inputPreview.amount)) {
-        const hash = await walletClient.writeContract({
-            address: token,
-            abi: erc20Abi,
-            functionName: "approve",
-            args: [spender, BigInt(inputPreview.amount)],
-        });
-        await publicClient.waitForTransactionReceipt({ hash });
-    }
-}
-```
-
-:::info Why two paths?
-
-Always honor `order.checks.allowances` when present — providers like Relay and LiFi Intents include required approvals there. Not all providers populate this field though (e.g. Across does not), so the fallback derives the spender from the transaction step's `to` address. The fallback only runs for transaction-based orders with ERC-20 inputs; signature-only orders without checks and native token inputs are skipped.
-
-:::
-
-## 6. Execute the Cross-Chain Transaction
-
-Execute the quote based on its order step type:
-
-```typescript
 if (isSignatureOnlyOrder(quote.order)) {
     // Protocol mode: sign and submit (gasless for user)
-    // Note: production code should handle all steps, not just the first
+    // Note: production code should handle all signature steps, not just the first
     const step = getSignatureSteps(quote.order)[0];
     const { signatureType, ...typedData } = step.signaturePayload;
     const signature = await walletClient.signTypedData(typedData);
     await aggregator.submitOrder(quote, signature);
     console.log("Order submitted via signature");
 } else {
-    // User mode: send transaction directly
-    // Note: production code should handle all steps, not just the first
-    const step = getTransactionSteps(quote.order)[0];
-    const { to, data, value, gas, maxFeePerGas, maxPriorityFeePerGas } = step.transaction;
-    console.log("Sending transaction...");
-    const hash = await walletClient.sendTransaction({
-        to,
-        data,
-        value: value ? BigInt(value) : undefined,
-        gas: gas ? BigInt(gas) : undefined,
-        maxFeePerGas: maxFeePerGas ? BigInt(maxFeePerGas) : undefined,
-        maxPriorityFeePerGas: maxPriorityFeePerGas ? BigInt(maxPriorityFeePerGas) : undefined,
-    });
-    console.log("Transaction sent:", hash);
-
-    const receipt = await publicClient.waitForTransactionReceipt({ hash });
-    console.log("Transaction confirmed:", receipt.status === "success" ? "Success" : "Failed");
+    // User mode: send each transaction step in order (approvals first, then transfer)
+    for (const step of getTransactionSteps(quote.order)) {
+        const { to, data, value, gas, maxFeePerGas, maxPriorityFeePerGas } = step.transaction;
+        console.log(`Sending step: ${step.description ?? "transaction"}`);
+        const hash = await walletClient.sendTransaction({
+            to,
+            data,
+            value: value ? BigInt(value) : undefined,
+            gas: gas ? BigInt(gas) : undefined,
+            maxFeePerGas: maxFeePerGas ? BigInt(maxFeePerGas) : undefined,
+            maxPriorityFeePerGas: maxPriorityFeePerGas ? BigInt(maxPriorityFeePerGas) : undefined,
+        });
+        const receipt = await publicClient.waitForTransactionReceipt({ hash });
+        console.log("Confirmed:", receipt.status === "success" ? "Success" : "Failed");
+    }
 }
 ```
 
-## 7. Run the Main Function
+:::info Native token inputs
+Native token inputs (ETH, MATIC, etc.) never require approval, so no `approve` step is prepended. The approval service only enriches quotes whose `order.checks.allowances` lists an ERC-20 allowance that is below `required` on-chain.
+:::
+
+## 6. Run the Main Function
 
 Finally, call the main function to execute the workflow.
 

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -136,10 +136,10 @@ if (isSignatureOnlyOrder(quote.order)) {
     console.log("Order submitted via signature");
 } else {
     // User pays gas: iterate every transaction step in order.
-    // Quotes from a single `provider` have one transaction step (the transfer).
-    // Quotes from an `Aggregator` configured with `approvalService` may have
-    // `approve` steps prepended before the transfer — this single loop handles
-    // both cases.
+    // A quote may contain one or more transaction steps depending on the provider.
+    // Quotes from an `Aggregator` configured with `approvalService` may also have
+    // `approve` steps prepended before the transfer. This single loop handles
+    // all cases.
     for (const step of getTransactionSteps(quote.order)) {
         const hash = await walletClient.sendTransaction({
             to: step.transaction.to,

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -136,8 +136,10 @@ if (isSignatureOnlyOrder(quote.order)) {
     console.log("Order submitted via signature");
 } else {
     // User pays gas: iterate every transaction step in order.
-    // With an aggregator + approvalService, any required approve steps are
-    // already prepended, so this single loop handles approvals and the transfer.
+    // Quotes from a single `provider` have one transaction step (the transfer).
+    // Quotes from an `Aggregator` configured with `approvalService` may have
+    // `approve` steps prepended before the transfer — this single loop handles
+    // both cases.
     for (const step of getTransactionSteps(quote.order)) {
         const hash = await walletClient.sendTransaction({
             to: step.transaction.to,

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -112,9 +112,9 @@ Both `0x0000000000000000000000000000000000000000` (zero address) and `0xeeeeeeee
 
 ## Handle ERC-20 approvals
 
-Always check `order.checks.allowances` first — some providers (Relay, Bungee, OIF, LiFi Intents) populate it with the exact spender and amount, even for signature-only orders. When checks are missing (e.g. Across), derive the spender from the transaction step's `to` address. Native token inputs never need an approval.
+ERC-20 inputs need an `approve` before the transfer step. The SDK can do this for you: wire an `approvalService` into the aggregator and every returned quote already has the necessary `approve` `TransactionStep`s prepended to `order.steps`. Iterate the steps in order and each `approve` fires before the step that needs it.
 
-See the [full approval pattern](./example.md#5-check-and-handle-erc-20-approvals) in the Execute Intent guide.
+See [Automatic ERC-20 Approvals](./advanced-usage.md#automatic-erc-20-approvals) for the setup, or the [Execute Intent guide](./example.md) for a full runnable example.
 
 ## Execute the transaction
 
@@ -174,13 +174,12 @@ response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`)
 
 ### Execution flow
 
-1. **Create provider** → `createCrossChainProvider("across")` (or use `createAggregator` for multiple)
+1. **Create provider** → `createCrossChainProvider("across")` (or use `createAggregator` for multiple — wire an `approvalService` to enrich quotes with ERC-20 `approve` steps automatically)
 2. **Get quotes** → `provider.getQuotes(request)` or `aggregator.getQuotes(request)`
-3. **Approve ERC-20 (if needed)** → check `order.checks?.allowances` and approve before submitting (see [approval guide](./example.md#5-check-and-handle-erc-20-approvals))
-4. **Check order type** → `isSignatureOnlyOrder(quote.order)`
+3. **Check order type** → `isSignatureOnlyOrder(quote.order)`
     - **Signature (gasless):** `signTypedData()` → `provider.submitOrder(quote, signature)`
-    - **Transaction (user pays gas):** `walletClient.sendTransaction(...)` (see [example above](#execute-the-transaction) — convert string `value` to `BigInt`)
-5. **Track** → `createOrderTracker(provider)` for single-provider or `aggregator.track({ txHash, providerId, originChainId, destinationChainId })` for aggregator
+    - **Transaction (user pays gas):** iterate `getTransactionSteps(quote.order)` and send each — approval steps (when present) come first (see [example above](#execute-the-transaction) — convert string `value` to `BigInt`)
+4. **Track** → `createOrderTracker(provider)` for single-provider or `aggregator.track({ txHash, providerId, originChainId, destinationChainId })` for aggregator
 
 ### Which function should I use?
 

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -135,17 +135,23 @@ if (isSignatureOnlyOrder(quote.order)) {
     await provider.submitOrder(quote, signature);
     console.log("Order submitted via signature");
 } else {
-    // User pays gas: send the transaction directly
-    const step = getTransactionSteps(quote.order)[0];
-    const hash = await walletClient.sendTransaction({
-        to: step.transaction.to,
-        data: step.transaction.data,
-        value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
-    });
-    console.log("Transaction sent:", hash);
+    // User pays gas: iterate every transaction step in order.
+    // With an aggregator + approvalService, any required approve steps are
+    // already prepended, so this single loop handles approvals and the transfer.
+    for (const step of getTransactionSteps(quote.order)) {
+        const hash = await walletClient.sendTransaction({
+            to: step.transaction.to,
+            data: step.transaction.data,
+            value: step.transaction.value ? BigInt(step.transaction.value) : undefined,
+        });
+        console.log("Transaction sent:", hash);
 
-    const receipt = await publicClient.waitForTransactionReceipt({ hash });
-    console.log("Confirmed:", receipt.status);
+        const receipt = await publicClient.waitForTransactionReceipt({ hash });
+        if (receipt.status !== "success") {
+            throw new Error(`Step failed: ${step.description ?? "transaction"}`);
+        }
+        console.log("Confirmed: Success");
+    }
 }
 ```
 

--- a/apps/docs/docs/cross-chain/getting-started.md
+++ b/apps/docs/docs/cross-chain/getting-started.md
@@ -135,11 +135,10 @@ if (isSignatureOnlyOrder(quote.order)) {
     await provider.submitOrder(quote, signature);
     console.log("Order submitted via signature");
 } else {
-    // User pays gas: iterate every transaction step in order.
+    // User pays gas: send every transaction step in order.
     // A quote may contain one or more transaction steps depending on the provider.
     // Quotes from an `Aggregator` configured with `approvalService` may also have
-    // `approve` steps prepended before the transfer. This single loop handles
-    // all cases.
+    // `approve` steps prepended before the transfer.
     for (const step of getTransactionSteps(quote.order)) {
         const hash = await walletClient.sendTransaction({
             to: step.transaction.to,

--- a/apps/docs/docs/cross-chain/oif-provider.md
+++ b/apps/docs/docs/cross-chain/oif-provider.md
@@ -45,6 +45,14 @@ The `supportedLocks` option controls which OIF order types the solver returns:
 
 `oif-user-open-v0` (user-pays-gas) is controlled by `submissionModes` independently.
 
+:::warning `oif-escrow-v0` Permit2 approval not auto-handled
+
+`oif-escrow-v0` quotes rely on Permit2 and require a one-time `approve(PERMIT2, ...)` per token before the solver can pull funds. The OIF wire format does not surface this in `order.checks.allowances`, so the [approval service](./advanced-usage.md#automatic-erc-20-approvals) cannot prepend the step automatically for these quotes.
+
+Workaround until the OIF adapter is updated: either handle the Permit2 approval yourself, or restrict the provider to `submissionModes: ["user-transaction"]` (which uses `oif-user-open-v0`, where approvals are declared correctly). `oif-3009-v0` and `oif-resource-lock-v0` do not need ERC-20 approvals and are unaffected.
+
+:::
+
 ## Creating the Provider
 
 ```typescript


### PR DESCRIPTION
## Summary

Documents the `ApprovalService` shipped in defi-wonderland/interop-sdk#251 and removes the manual ERC-20 `allowance()` → `approve()` dance from the guides, since the SDK now handles this when the aggregator is configured with an `approvalService`.

## Changes

- **`api.md`** — new **Approval Service** reference section (`createApprovalService`, `CreateApprovalServiceConfig`, strategies, low-level classes). Added `approvalService` to the `createAggregator` config example.
- **`advanced-usage.md`** — new **Automatic ERC-20 Approvals** how-to: wiring example, single-loop execution pattern, strategy trade-offs, failure handling, and a **Provider coverage** section.
- **`example.md`** — dropped the ~55-line manual allowance-check block; step 3 now wires `approvalService`, step 5 iterates all `TransactionStep`s so prepended approvals fire before the transfer. Renumbered.
- **`getting-started.md`** — "Handle ERC-20 approvals" now points at the aggregator path; Quick Reference updated.
- **`concepts.md`** — one-sentence mention under "Aggregation and sorting".
- **`oif-provider.md`** — `:::warning` callout right after the lock-mapping table flagging the `oif-escrow-v0` Permit2 gap in context.

## Provider coverage, as documented

- **Across, LiFi Intents, OIF `oif-user-open-v0`** — `checks.allowances` always populated for ERC-20 inputs (Across was updated in defi-wonderland/interop-sdk#251).
- **Relay, Bungee** — populated whenever the API flags an approve as needed, including the one-time Permit2 approval for Bungee's gasless path. Verified via live sandbox call against `public-backend.bungee.exchange`: gasless-path `spenderAddress` = `0x000000000022D473030F116dDEE9F6B43aC78BA3` (Permit2 canonical).
- **OIF `oif-escrow-v0`** — not populated; the OIF wire format doesn't surface Permit2 approval state. Documented as a known gap with a `submissionModes: ["user-transaction"]` workaround.
- **OIF `oif-3009-v0`, `oif-resource-lock-v0`** — not populated, and correctly so (those flows don't use ERC-20 `approve`).

## Follow-ups (not in this PR)

- `examples/ui` doesn't yet use the `ApprovalService` — it still rolls its own `handleTokenApproval` in `app/cross-chain/services/orderExecution/`. Wiring exists on `feat/efi-873-ui-approval-service` (commit `c8561db`, same author as defi-wonderland/interop-sdk#251) but is not yet on `dev`. Not a docs blocker — the SDK capability described here is shipped.
- Consider updating the OIF adapter to synthesize Permit2 allowance entries for `oif-escrow-v0` (tracked as the documented gap). Would remove the caveat in `oif-provider.md`.

## Test plan

- [ ] `pnpm --filter docs build` to verify Docusaurus builds.
- [ ] Visual check of rendered pages — particularly the cross-links (api ↔ advanced-usage ↔ oif-provider) and the new `:::warning` / `:::info` callouts.
- [ ] Copy-paste the wiring snippets into a scratch TS file to confirm type-check cleanly against the current `@wonderland/interop-cross-chain` exports.