### PR TITLE
chore(addresses): bump to 0.5.2 to unblock publish pipeline

### DIFF
--- a/.changeset/republish-addresses.md
+++ b/.changeset/republish-addresses.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-addresses": patch
+---
+
+Republish to unblock the release pipeline. The previous release did not bump `addresses`, so the publish job failed trying to re-publish 0.5.1 to npm.


### PR DESCRIPTION
The previous release (release-2026.04.16) had no changesets for `addresses`, so its version stayed at 0.5.1. The publish workflow still tried to republish it, npm rejected the duplicate, and the release pipeline died before `cross-chain` and `sdk` got published.

Adding a patch changeset for `addresses` so the next version-packages PR bumps it. Because `updateInternalDependencies` is set to `patch` and `cross-chain`/`sdk` depend on `addresses` via `workspace:*`, they will get cascade patch bumps too — which is what we want, since their previous bumps (cross-chain@0.6.0, sdk@0.3.4) never made it to npm.

Expected bumps after version-packages PR:
- `@wonderland/interop-addresses`: 0.5.1 → 0.5.2
- `@wonderland/interop-cross-chain`: 0.6.0 → 0.6.1
- `@wonderland/interop`: 0.3.4 → 0.3.5

Steps to release after this merges:
1. Merge the auto-generated version-packages PR on dev
2. Open dev → main PR, merge
3. Delete the stuck release on GitHub (release-2026.04.16)
4. Create a new release on the new main commit