### PR TITLE
fix(cross-chain): use in-repo TypedEventEmitter so OrderTracker runs in browser bundles

### DIFF
--- a/.changeset/fix-browser-event-emitter.md
+++ b/.changeset/fix-browser-event-emitter.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Fix `OrderTracker` breaking browser bundles. Replace the Node `EventEmitter` base with an in-repo `TypedEventEmitter` so importing `@wonderland/interop-cross-chain` no longer requires a `node:events` polyfill under Vite, Webpack, Rolldown, or any browser-targeting bundler. Public API (`on` / `once` / `off` / `emit`) is unchanged.

--- a/packages/cross-chain/src/core/services/OrderTracker.ts
+++ b/packages/cross-chain/src/core/services/OrderTracker.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from "events";
 import { Address, Hex } from "viem";
 
 import type { FillWatcher } from "../interfaces/fillWatcher.interface.js";
@@ -19,6 +18,7 @@ import { OrderTrackerEvent } from "../interfaces/orderTracker.interface.js";
 import { OrderFailureReason, OrderStatus, OrderTrackerYieldType } from "../types/orderTracking.js";
 import { getChainById } from "../utils/chainHelpers.js";
 import { PublicClientManager } from "../utils/publicClientManager.js";
+import { TypedEventEmitter } from "../utils/typedEventEmitter.js";
 
 const FillResultStatus = {
     Finalized: "finalized",
@@ -27,35 +27,7 @@ const FillResultStatus = {
     Timeout: "timeout",
 } as const;
 
-export class OrderTracker extends EventEmitter {
-    override on<K extends keyof OrderTrackerEvents>(
-        event: K,
-        listener: OrderTrackerEvents[K],
-    ): this {
-        return super.on(event, listener as (...args: unknown[]) => void);
-    }
-
-    override once<K extends keyof OrderTrackerEvents>(
-        event: K,
-        listener: OrderTrackerEvents[K],
-    ): this {
-        return super.once(event, listener as (...args: unknown[]) => void);
-    }
-
-    override off<K extends keyof OrderTrackerEvents>(
-        event: K,
-        listener: OrderTrackerEvents[K],
-    ): this {
-        return super.off(event, listener as (...args: unknown[]) => void);
-    }
-
-    override emit<K extends keyof OrderTrackerEvents>(
-        event: K,
-        ...args: Parameters<OrderTrackerEvents[K]>
-    ): boolean {
-        return super.emit(event, ...args);
-    }
-
+export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
     static readonly GRACE_PERIOD_SECONDS = 60;
     static readonly DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 

--- a/packages/cross-chain/src/core/utils/index.ts
+++ b/packages/cross-chain/src/core/utils/index.ts
@@ -5,5 +5,6 @@ export * from "./eventDataParser.js";
 export * from "./orderTypeHelpers.js";
 export * from "./publicClientManager.js";
 export * from "./token.js";
+export * from "./typedEventEmitter.js";
 export * from "./interopAccountId.js";
 export * from "./stepHelpers.js";

--- a/packages/cross-chain/src/core/utils/typedEventEmitter.ts
+++ b/packages/cross-chain/src/core/utils/typedEventEmitter.ts
@@ -1,20 +1,28 @@
 type EventListener = (...args: never[]) => void;
+type OnceWrapper = EventListener & { listener: EventListener };
 
 /**
  * Runtime-agnostic typed event emitter.
  *
  * Covers the subset of the Node `EventEmitter` API used inside the SDK
  * (`on` / `once` / `off` / `emit`). Keeps the SDK free of `node:events`
- * so it runs in any bundler without polyfills.
+ * so it runs in any bundler without polyfills, matching Node's semantics:
  *
- * Semantics match Node's defaults except that a listener registered
- * twice via {@link on} is deduplicated rather than fired twice.
+ * - Listeners fire in registration order.
+ * - {@link on} does not deduplicate: the same listener registered N times
+ *   fires N times per emit.
+ * - {@link off} removes one registration per call — the most recently
+ *   registered match for that event, scanning from the end, checking both
+ *   the listener itself and any `once` wrapper's original listener.
+ *
+ * Dispatch uses a snapshot of the listener list, so listeners added during
+ * an `emit` do not run in that same dispatch, and listeners captured by
+ * the snapshot still run even if another listener removes them mid-dispatch.
  *
  * @typeParam EventMap - Map of event name to listener signature.
  */
 export class TypedEventEmitter<EventMap extends Record<string, EventListener>> {
-    private readonly listenersByEvent: Map<keyof EventMap, Set<EventListener>> = new Map();
-    private readonly onceWrapperToListener: WeakMap<EventListener, EventListener> = new WeakMap();
+    private readonly listenersByEvent: Map<keyof EventMap, EventListener[]> = new Map();
 
     /**
      * Register `listener` to be called every time `event` is emitted.
@@ -22,12 +30,12 @@ export class TypedEventEmitter<EventMap extends Record<string, EventListener>> {
      * @returns The emitter instance, for chaining.
      */
     on<K extends keyof EventMap>(event: K, listener: EventMap[K]): this {
-        let set = this.listenersByEvent.get(event);
-        if (!set) {
-            set = new Set();
-            this.listenersByEvent.set(event, set);
+        let list = this.listenersByEvent.get(event);
+        if (!list) {
+            list = [];
+            this.listenersByEvent.set(event, list);
         }
-        set.add(listener as EventListener);
+        list.push(listener as EventListener);
         return this;
     }
 
@@ -35,42 +43,42 @@ export class TypedEventEmitter<EventMap extends Record<string, EventListener>> {
      * Register `listener` to be called the next time `event` is emitted, then removed.
      *
      * {@link off} called with the original `listener` after a `once` registration
-     * will remove it, even before it fires. Multiple `once` registrations of the
-     * same listener — on the same or different events — are tracked independently.
+     * will remove one pending wrapper, even before it fires. Multiple `once`
+     * registrations of the same listener — on the same or different events — are
+     * tracked independently.
      *
      * @returns The emitter instance, for chaining.
      */
     once<K extends keyof EventMap>(event: K, listener: EventMap[K]): this {
         const wrapper: EventListener = (...args) => {
-            const current = this.listenersByEvent.get(event);
-            if (current) {
-                current.delete(wrapper);
-                if (current.size === 0) this.listenersByEvent.delete(event);
-            }
+            this.off(event, wrapper as EventMap[K]);
             (listener as EventListener)(...args);
         };
-        this.onceWrapperToListener.set(wrapper, listener as EventListener);
+        (wrapper as OnceWrapper).listener = listener as EventListener;
         return this.on(event, wrapper as EventMap[K]);
     }
 
     /**
-     * Remove every registration of `listener` for `event`. Removes both direct
-     * {@link on} listeners and any pending {@link once} wrapper(s) for the pair
-     * `(event, listener)`, without touching registrations bound to other events.
+     * Remove one registration of `listener` for `event`. Scans from the most
+     * recently registered entry and removes the first match — either a direct
+     * {@link on} entry or a pending {@link once} wrapper whose original
+     * listener matches.
      *
      * @returns The emitter instance, for chaining.
      */
     off<K extends keyof EventMap>(event: K, listener: EventMap[K]): this {
-        const set = this.listenersByEvent.get(event);
-        if (!set) return this;
+        const list = this.listenersByEvent.get(event);
+        if (!list) return this;
 
         const target = listener as EventListener;
-        for (const registered of [...set]) {
-            if (registered === target || this.onceWrapperToListener.get(registered) === target) {
-                set.delete(registered);
+        for (let i = list.length - 1; i >= 0; i--) {
+            const entry = list[i];
+            if (entry === target || (entry as Partial<OnceWrapper>).listener === target) {
+                list.splice(i, 1);
+                break;
             }
         }
-        if (set.size === 0) this.listenersByEvent.delete(event);
+        if (list.length === 0) this.listenersByEvent.delete(event);
         return this;
     }
 
@@ -83,11 +91,10 @@ export class TypedEventEmitter<EventMap extends Record<string, EventListener>> {
      * @returns `true` when at least one listener was invoked, `false` otherwise.
      */
     emit<K extends keyof EventMap>(event: K, ...args: Parameters<EventMap[K]>): boolean {
-        const set = this.listenersByEvent.get(event);
-        if (!set || set.size === 0) return false;
+        const list = this.listenersByEvent.get(event);
+        if (!list || list.length === 0) return false;
 
-        const snapshot = [...set];
-        for (const listener of snapshot) {
+        for (const listener of [...list]) {
             (listener as (...callArgs: Parameters<EventMap[K]>) => void)(...args);
         }
         return true;

--- a/packages/cross-chain/src/core/utils/typedEventEmitter.ts
+++ b/packages/cross-chain/src/core/utils/typedEventEmitter.ts
@@ -1,0 +1,90 @@
+type EventListener = (...args: never[]) => void;
+
+/**
+ * Runtime-agnostic typed event emitter.
+ *
+ * Covers the subset of the Node `EventEmitter` API used inside the SDK
+ * (`on` / `once` / `off` / `emit`). Keeps the SDK free of `node:events`
+ * so it runs in any bundler without polyfills.
+ *
+ * Semantics match Node's defaults except that a listener registered
+ * twice via {@link on} is deduplicated rather than fired twice.
+ *
+ * @typeParam EventMap - Map of event name to listener signature.
+ */
+export class TypedEventEmitter<EventMap extends Record<string, EventListener>> {
+    private readonly listenersByEvent: Map<keyof EventMap, Set<EventListener>> = new Map();
+    private readonly onceWrappers: WeakMap<object, EventListener> = new WeakMap();
+
+    /**
+     * Register `listener` to be called every time `event` is emitted.
+     *
+     * @returns The emitter instance, for chaining.
+     */
+    on<K extends keyof EventMap>(event: K, listener: EventMap[K]): this {
+        let set = this.listenersByEvent.get(event);
+        if (!set) {
+            set = new Set();
+            this.listenersByEvent.set(event, set);
+        }
+        set.add(listener as EventListener);
+        return this;
+    }
+
+    /**
+     * Register `listener` to be called the next time `event` is emitted, then removed.
+     *
+     * {@link off} called with the original `listener` after a `once` registration
+     * will remove it, even before it fires.
+     *
+     * @returns The emitter instance, for chaining.
+     */
+    once<K extends keyof EventMap>(event: K, listener: EventMap[K]): this {
+        const wrapper: EventListener = (...args) => {
+            this.off(event, listener);
+            (listener as EventListener)(...args);
+        };
+        this.onceWrappers.set(listener as unknown as object, wrapper);
+        return this.on(event, wrapper as EventMap[K]);
+    }
+
+    /**
+     * Remove a previously registered listener. Works for listeners registered
+     * via {@link on} as well as {@link once}.
+     *
+     * @returns The emitter instance, for chaining.
+     */
+    off<K extends keyof EventMap>(event: K, listener: EventMap[K]): this {
+        const set = this.listenersByEvent.get(event);
+        if (!set) return this;
+
+        const wrapper = this.onceWrappers.get(listener as unknown as object);
+        set.delete((wrapper ?? listener) as EventListener);
+        if (wrapper) {
+            this.onceWrappers.delete(listener as unknown as object);
+        }
+        if (set.size === 0) {
+            this.listenersByEvent.delete(event);
+        }
+        return this;
+    }
+
+    /**
+     * Synchronously invoke all listeners registered for `event`.
+     *
+     * A throwing listener propagates the error synchronously and aborts
+     * the remaining listeners for that call — same as Node's default.
+     *
+     * @returns `true` when at least one listener was invoked, `false` otherwise.
+     */
+    emit<K extends keyof EventMap>(event: K, ...args: Parameters<EventMap[K]>): boolean {
+        const set = this.listenersByEvent.get(event);
+        if (!set || set.size === 0) return false;
+
+        const snapshot = [...set];
+        for (const listener of snapshot) {
+            (listener as (...callArgs: Parameters<EventMap[K]>) => void)(...args);
+        }
+        return true;
+    }
+}

--- a/packages/cross-chain/src/core/utils/typedEventEmitter.ts
+++ b/packages/cross-chain/src/core/utils/typedEventEmitter.ts
@@ -14,7 +14,7 @@ type EventListener = (...args: never[]) => void;
  */
 export class TypedEventEmitter<EventMap extends Record<string, EventListener>> {
     private readonly listenersByEvent: Map<keyof EventMap, Set<EventListener>> = new Map();
-    private readonly onceWrappers: WeakMap<object, EventListener> = new WeakMap();
+    private readonly onceWrapperToListener: WeakMap<EventListener, EventListener> = new WeakMap();
 
     /**
      * Register `listener` to be called every time `event` is emitted.
@@ -35,22 +35,28 @@ export class TypedEventEmitter<EventMap extends Record<string, EventListener>> {
      * Register `listener` to be called the next time `event` is emitted, then removed.
      *
      * {@link off} called with the original `listener` after a `once` registration
-     * will remove it, even before it fires.
+     * will remove it, even before it fires. Multiple `once` registrations of the
+     * same listener — on the same or different events — are tracked independently.
      *
      * @returns The emitter instance, for chaining.
      */
     once<K extends keyof EventMap>(event: K, listener: EventMap[K]): this {
         const wrapper: EventListener = (...args) => {
-            this.off(event, listener);
+            const current = this.listenersByEvent.get(event);
+            if (current) {
+                current.delete(wrapper);
+                if (current.size === 0) this.listenersByEvent.delete(event);
+            }
             (listener as EventListener)(...args);
         };
-        this.onceWrappers.set(listener as unknown as object, wrapper);
+        this.onceWrapperToListener.set(wrapper, listener as EventListener);
         return this.on(event, wrapper as EventMap[K]);
     }
 
     /**
-     * Remove a previously registered listener. Works for listeners registered
-     * via {@link on} as well as {@link once}.
+     * Remove every registration of `listener` for `event`. Removes both direct
+     * {@link on} listeners and any pending {@link once} wrapper(s) for the pair
+     * `(event, listener)`, without touching registrations bound to other events.
      *
      * @returns The emitter instance, for chaining.
      */
@@ -58,14 +64,13 @@ export class TypedEventEmitter<EventMap extends Record<string, EventListener>> {
         const set = this.listenersByEvent.get(event);
         if (!set) return this;
 
-        const wrapper = this.onceWrappers.get(listener as unknown as object);
-        set.delete((wrapper ?? listener) as EventListener);
-        if (wrapper) {
-            this.onceWrappers.delete(listener as unknown as object);
+        const target = listener as EventListener;
+        for (const registered of [...set]) {
+            if (registered === target || this.onceWrapperToListener.get(registered) === target) {
+                set.delete(registered);
+            }
         }
-        if (set.size === 0) {
-            this.listenersByEvent.delete(event);
-        }
+        if (set.size === 0) this.listenersByEvent.delete(event);
         return this;
     }
 

--- a/packages/cross-chain/test/utils/typedEventEmitter.spec.ts
+++ b/packages/cross-chain/test/utils/typedEventEmitter.spec.ts
@@ -38,7 +38,7 @@ describe("TypedEventEmitter", () => {
             expect(calls).toEqual(["a", "b", "c"]);
         });
 
-        it("deduplicates when the same listener is registered twice", () => {
+        it("invokes the same listener once per registration when added multiple times", () => {
             const emitter = createEmitter();
             const listener = vi.fn();
 
@@ -46,7 +46,7 @@ describe("TypedEventEmitter", () => {
             emitter.on("ping", listener);
             emitter.emit("ping", 42);
 
-            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledTimes(2);
         });
 
         it("returns the emitter instance for chaining", () => {
@@ -96,6 +96,57 @@ describe("TypedEventEmitter", () => {
             expect(() => emitter.emit("ping", 1)).toThrow("boom");
             expect(following).not.toHaveBeenCalled();
         });
+
+        it("forwards every positional argument to each listener", () => {
+            type MultiEvents = { multi: (a: number, b: string, c: boolean) => void };
+            const emitter = new TypedEventEmitter<MultiEvents>();
+            const listener = vi.fn();
+
+            emitter.on("multi", listener);
+            emitter.emit("multi", 7, "hi", true);
+
+            expect(listener).toHaveBeenCalledWith(7, "hi", true);
+        });
+
+        it("supports events with no arguments", () => {
+            type VoidEvents = { tick: () => void };
+            const emitter = new TypedEventEmitter<VoidEvents>();
+            const listener = vi.fn();
+
+            emitter.on("tick", listener);
+            emitter.emit("tick");
+
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledWith();
+        });
+
+        it("does not invoke listeners added during an emit in that same dispatch", () => {
+            const emitter = createEmitter();
+            const later = vi.fn();
+
+            emitter.on("ping", () => emitter.on("ping", later));
+            emitter.emit("ping", 1);
+            expect(later).not.toHaveBeenCalled();
+
+            emitter.emit("ping", 2);
+            expect(later).toHaveBeenCalledTimes(1);
+            expect(later).toHaveBeenCalledWith(2);
+        });
+
+        it("still invokes listeners captured by the snapshot when a prior listener removes them", () => {
+            const emitter = createEmitter();
+            const removable = vi.fn();
+
+            emitter.on("ping", () => emitter.off("ping", removable));
+            emitter.on("ping", removable);
+            emitter.emit("ping", 1);
+
+            expect(removable).toHaveBeenCalledTimes(1);
+            expect(removable).toHaveBeenCalledWith(1);
+
+            emitter.emit("ping", 2);
+            expect(removable).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe("off", () => {
@@ -114,6 +165,19 @@ describe("TypedEventEmitter", () => {
             const emitter = createEmitter();
 
             expect(() => emitter.off("ping", () => undefined)).not.toThrow();
+        });
+
+        it("is a no-op for an unregistered listener on a known event", () => {
+            const emitter = createEmitter();
+            const registered = vi.fn();
+            const unregistered = vi.fn();
+
+            emitter.on("ping", registered);
+            emitter.off("ping", unregistered);
+            emitter.emit("ping", 1);
+
+            expect(registered).toHaveBeenCalledTimes(1);
+            expect(unregistered).not.toHaveBeenCalled();
         });
     });
 
@@ -190,6 +254,38 @@ describe("TypedEventEmitter", () => {
             emitter.emit("ping", 42);
             expect(shared).toHaveBeenCalledTimes(1);
             expect(shared).toHaveBeenCalledWith(42);
+        });
+
+        it("keeps the on-listener when the same function is also once-registered on the same event", () => {
+            const emitter = createEmitter();
+            const listener = vi.fn();
+
+            emitter.on("ping", listener);
+            emitter.once("ping", listener);
+            emitter.emit("ping", 1);
+            expect(listener).toHaveBeenCalledTimes(2);
+
+            listener.mockClear();
+            emitter.emit("ping", 2);
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledWith(2);
+        });
+
+        it("removes a single once wrapper per off call when multiple share the same listener", () => {
+            const emitter = createEmitter();
+            const listener = vi.fn();
+
+            emitter.once("ping", listener);
+            emitter.once("ping", listener);
+            emitter.off("ping", listener);
+            emitter.emit("ping", 1);
+
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledWith(1);
+
+            listener.mockClear();
+            emitter.emit("ping", 2);
+            expect(listener).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/cross-chain/test/utils/typedEventEmitter.spec.ts
+++ b/packages/cross-chain/test/utils/typedEventEmitter.spec.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { TypedEventEmitter } from "../../src/core/utils/typedEventEmitter.js";
+
+type TestEvents = {
+    ping: (value: number) => void;
+    error: (err: Error) => void;
+};
+
+function createEmitter(): TypedEventEmitter<TestEvents> {
+    return new TypedEventEmitter<TestEvents>();
+}
+
+describe("TypedEventEmitter", () => {
+    describe("on", () => {
+        it("invokes the listener every time the event is emitted", () => {
+            const emitter = createEmitter();
+            const listener = vi.fn();
+
+            emitter.on("ping", listener);
+            emitter.emit("ping", 1);
+            emitter.emit("ping", 2);
+
+            expect(listener).toHaveBeenCalledTimes(2);
+            expect(listener).toHaveBeenNthCalledWith(1, 1);
+            expect(listener).toHaveBeenNthCalledWith(2, 2);
+        });
+
+        it("invokes multiple listeners in registration order", () => {
+            const emitter = createEmitter();
+            const calls: string[] = [];
+
+            emitter.on("ping", () => calls.push("a"));
+            emitter.on("ping", () => calls.push("b"));
+            emitter.on("ping", () => calls.push("c"));
+            emitter.emit("ping", 0);
+
+            expect(calls).toEqual(["a", "b", "c"]);
+        });
+
+        it("deduplicates when the same listener is registered twice", () => {
+            const emitter = createEmitter();
+            const listener = vi.fn();
+
+            emitter.on("ping", listener);
+            emitter.on("ping", listener);
+            emitter.emit("ping", 42);
+
+            expect(listener).toHaveBeenCalledTimes(1);
+        });
+
+        it("returns the emitter instance for chaining", () => {
+            const emitter = createEmitter();
+
+            const result = emitter.on("ping", () => undefined).on("error", () => undefined);
+
+            expect(result).toBe(emitter);
+        });
+    });
+
+    describe("emit", () => {
+        it("returns true when at least one listener was invoked", () => {
+            const emitter = createEmitter();
+            emitter.on("ping", () => undefined);
+
+            expect(emitter.emit("ping", 1)).toBe(true);
+        });
+
+        it("returns false when no listeners are registered", () => {
+            const emitter = createEmitter();
+
+            expect(emitter.emit("ping", 1)).toBe(false);
+        });
+
+        it("returns false after the last listener is removed", () => {
+            const emitter = createEmitter();
+            const listener = vi.fn();
+
+            emitter.on("ping", listener);
+            emitter.off("ping", listener);
+
+            expect(emitter.emit("ping", 1)).toBe(false);
+            expect(listener).not.toHaveBeenCalled();
+        });
+
+        it("propagates listener errors synchronously and aborts remaining listeners", () => {
+            const emitter = createEmitter();
+            const failing = (): never => {
+                throw new Error("boom");
+            };
+            const following = vi.fn();
+
+            emitter.on("ping", failing);
+            emitter.on("ping", following);
+
+            expect(() => emitter.emit("ping", 1)).toThrow("boom");
+            expect(following).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("off", () => {
+        it("removes a listener registered via on", () => {
+            const emitter = createEmitter();
+            const listener = vi.fn();
+
+            emitter.on("ping", listener);
+            emitter.off("ping", listener);
+            emitter.emit("ping", 1);
+
+            expect(listener).not.toHaveBeenCalled();
+        });
+
+        it("is a no-op for an unknown event", () => {
+            const emitter = createEmitter();
+
+            expect(() => emitter.off("ping", () => undefined)).not.toThrow();
+        });
+    });
+
+    describe("once", () => {
+        it("fires exactly once and then auto-removes", () => {
+            const emitter = createEmitter();
+            const listener = vi.fn();
+
+            emitter.once("ping", listener);
+            emitter.emit("ping", 1);
+            emitter.emit("ping", 2);
+
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledWith(1);
+        });
+
+        it("removes the listener when off is called with the original reference before firing", () => {
+            const emitter = createEmitter();
+            const listener = vi.fn();
+
+            emitter.once("ping", listener);
+            emitter.off("ping", listener);
+            emitter.emit("ping", 1);
+
+            expect(listener).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/cross-chain/test/utils/typedEventEmitter.spec.ts
+++ b/packages/cross-chain/test/utils/typedEventEmitter.spec.ts
@@ -140,5 +140,56 @@ describe("TypedEventEmitter", () => {
 
             expect(listener).not.toHaveBeenCalled();
         });
+
+        it("fires each wrapper when once is registered twice with the same listener on the same event", () => {
+            const emitter = createEmitter();
+            const listener = vi.fn();
+
+            emitter.once("ping", listener);
+            emitter.once("ping", listener);
+            emitter.emit("ping", 1);
+
+            expect(listener).toHaveBeenCalledTimes(2);
+            expect(listener).toHaveBeenNthCalledWith(1, 1);
+            expect(listener).toHaveBeenNthCalledWith(2, 1);
+
+            listener.mockClear();
+            emitter.emit("ping", 2);
+            expect(listener).not.toHaveBeenCalled();
+        });
+
+        it("tracks once registrations independently across events", () => {
+            const emitter = createEmitter();
+            const listener = vi.fn();
+
+            emitter.once("ping", listener as TestEvents["ping"]);
+            emitter.once("error", listener as TestEvents["error"]);
+
+            emitter.emit("ping", 1);
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenLastCalledWith(1);
+
+            const err = new Error("boom");
+            emitter.emit("error", err);
+            expect(listener).toHaveBeenCalledTimes(2);
+            expect(listener).toHaveBeenLastCalledWith(err);
+        });
+
+        it("removes the on-listener of a different event when the same function is also once-registered", () => {
+            const emitter = createEmitter();
+            const shared = vi.fn();
+
+            emitter.once("ping", shared as TestEvents["ping"]);
+            emitter.on("error", shared as TestEvents["error"]);
+            emitter.off("error", shared as TestEvents["error"]);
+
+            const err = new Error("boom");
+            emitter.emit("error", err);
+            expect(shared).not.toHaveBeenCalled();
+
+            emitter.emit("ping", 42);
+            expect(shared).toHaveBeenCalledTimes(1);
+            expect(shared).toHaveBeenCalledWith(42);
+        });
     });
 });


### PR DESCRIPTION
Closes EFI-878

## Summary
- Replaced the Node `EventEmitter` base in `OrderTracker` with an in-repo `TypedEventEmitter`. Same `on` / `once` / `off` / `emit` API, no `node:events` polyfill required.
- Patch changeset included.

## Test plan
- [x] `pnpm --filter @wonderland/interop-cross-chain check-types`
- [x] `pnpm --filter @wonderland/interop-cross-chain test` (926 passed, 9 skipped)
- [x] `pnpm --filter @wonderland/interop-cross-chain build`, `dist/` has no references to `"events"`