### PR TITLE
fix(ui): cap on.eth registry fetch with 10s timeout (EFI-876)

### DIFF
--- a/examples/ui/app/lib/getChains.ts
+++ b/examples/ui/app/lib/getChains.ts
@@ -1,12 +1,23 @@
 import { getRegisteredChains } from '@wonderland/interop-addresses';
 import { REGISTRY_CHAINS, type RegistryChainWithStatus } from './registry-chains';
 
+/**
+ * Max time we wait for the on.eth registry before falling back to the curated list.
+ * Kept well under Next's 60s per-page prerender budget so a flaky RPC cannot block the build.
+ */
+const ONCHAIN_FETCH_TIMEOUT_MS = 10_000;
+
+const timeout = (ms: number): Promise<never> =>
+  new Promise((_, reject) => setTimeout(() => reject(new Error('on.eth registry fetch timed out')), ms));
+
 /** Merges the on.eth onchain registry with the curated list. */
 export async function getChains(): Promise<RegistryChainWithStatus[]> {
   let onchainEntries: Awaited<ReturnType<typeof getRegisteredChains>>;
 
+  const fetchRegistry = getRegisteredChains({ rpcUrl: process.env.MAINNET_RPC_URL });
+
   try {
-    onchainEntries = await getRegisteredChains({ rpcUrl: process.env.MAINNET_RPC_URL });
+    onchainEntries = await Promise.race([fetchRegistry, timeout(ONCHAIN_FETCH_TIMEOUT_MS)]);
   } catch {
     onchainEntries = [];
   }

--- a/examples/ui/app/lib/getChains.ts
+++ b/examples/ui/app/lib/getChains.ts
@@ -7,17 +7,23 @@ import { REGISTRY_CHAINS, type RegistryChainWithStatus } from './registry-chains
  */
 const ONCHAIN_FETCH_TIMEOUT_MS = 10_000;
 
-const timeout = (ms: number): Promise<never> =>
-  new Promise((_, reject) => setTimeout(() => reject(new Error('on.eth registry fetch timed out')), ms));
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('on.eth registry fetch timed out')), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
 
 /** Merges the on.eth onchain registry with the curated list. */
 export async function getChains(): Promise<RegistryChainWithStatus[]> {
   let onchainEntries: Awaited<ReturnType<typeof getRegisteredChains>>;
 
-  const fetchRegistry = getRegisteredChains({ rpcUrl: process.env.MAINNET_RPC_URL });
-
   try {
-    onchainEntries = await Promise.race([fetchRegistry, timeout(ONCHAIN_FETCH_TIMEOUT_MS)]);
+    onchainEntries = await withTimeout(
+      getRegisteredChains({ rpcUrl: process.env.MAINNET_RPC_URL }),
+      ONCHAIN_FETCH_TIMEOUT_MS,
+    );
   } catch {
     onchainEntries = [];
   }


### PR DESCRIPTION
## Summary

- `examples/ui` `/addresses` page fetches the on.eth registry at build time with no timeout. When the mainnet RPC is slow, the fetch can stretch past Next's 60s per-page prerender budget, blocking the build. This has tripped unrelated PRs (changeset-only hotfixes).
- Wrap `getRegisteredChains()` in `Promise.race` against a 10s timer. On timeout, fall back to the curated `REGISTRY_CHAINS` list, same as the existing error path.

Resolves [EFI-876](https://linear.app/defi-wonderland/issue/EFI-876).

## Test plan

Reproduced locally with a stub RPC that delays each request 70s:

- Before: static pre-render exceeds 60s, Next retries 3× and fails the build (matches the CI logs from run 24533860680 and 3 subsequent flakes).
- After: build finishes in ~19s; the timeout path yields `[]` and the page renders from the curated list.
- Normal build (default RPC) unchanged, ~9s.
- `pnpm lint` clean.