### PR TITLE
feat(cross-chain): add OIF buildQuote with on-chain fill tracking

### DIFF
--- a/.changeset/oif-buildquote.md
+++ b/.changeset/oif-buildquote.md
@@ -1,0 +1,12 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Add buildQuote support for OIF provider
+
+-   OIF provider now supports `buildQuote()` using the InputSettlerEscrow `open(StandardOrder)` function
+-   Fill tracking uses on-chain `OutputFilled` events from the OutputSettler contract
+-   Dual fill watcher: API-based for getQuotes flow, event-based for buildQuote flow (available to all providers via `onChainFillWatcherConfig`)
+-   Fixed OIFOpenedIntentParser to parse the actual OIF `Open(bytes32, StandardOrder)` event instead of the ERC-7683 standard event
+-   Removed dead code: unused ERC-7683 ABIs and types that didn't match the real OIF contracts
+-   Shared `addressToBytes32` utility extracted from Across and OIF providers

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -114,7 +114,8 @@ An abstract class that defines the interface for cross-chain protocol providers.
     ```typescript
     const config = provider.getTrackingConfig();
     // config.openedIntentParserConfig — how to parse opened intents from origin chain
-    // config.fillWatcherConfig — how to watch for fills on destination chain
+    // config.fillWatcherConfig — how to watch for fills on destination chain (API-based, used for orderId tracking)
+    // config.onChainFillWatcherConfig — optional on-chain fill watcher (event-based, used for txHash tracking)
     // config.preTrackerConfig — optional pre-tracking step (e.g., notify provider API)
     ```
 

--- a/apps/docs/docs/cross-chain/intent-tracking.md
+++ b/apps/docs/docs/cross-chain/intent-tracking.md
@@ -48,7 +48,8 @@ The SDK exposes three ways to track an order. Choose based on your use case:
 -   `WatchOrderByTxHash` — pass `txHash` only. Uses on-chain event tracking.
 -   `WatchOrderByOrderId` — pass `orderId` only. Uses API-based tracking. Required for signature-based/gasless orders that don't have a `txHash` at open time.
 -   `WatchOrderExplicit` — pass both `txHash` and `orderId`, plus an optional `tracking: 'on-chain' | 'api'` field. Defaults to `'api'` when not specified.
-    :::
+
+:::
 
 :::info Mixed-step orders
 Mixed-step orders (containing both transaction steps and signature steps) are not currently emitted by any supported provider. Consumers can safely handle either `isSignatureOnlyOrder()` or `isTransactionOnlyOrder()` without defensive mixed-order handling.

--- a/apps/docs/docs/cross-chain/intent-tracking.md
+++ b/apps/docs/docs/cross-chain/intent-tracking.md
@@ -13,17 +13,17 @@ Tracking supports **two ways of observing the same lifecycle**, depending on the
 
 The `OrderTracker` streams updates using the full OIF `OrderStatus` set (from `@openintentsframework/oif-specs`). Not every provider emits every status — the table below shows which statuses each provider actually produces:
 
-| Status | Description | Across | Relay | OIF | Bungee | LiFi Intents |
-|--------|-------------|--------|-------|-----|--------|--------------|
-| `Created` | Order created on-chain | — | — | ✓ | — | — |
-| `Pending` | Awaiting execution | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `Executing` | Filler is processing the order | — | ✓ | ✓ | ✓ | — |
-| `Executed` | Fill transaction submitted | — | — | ✓ | — | — |
-| `Settling` | Settlement in progress | — | ✓ | — | — | ✓ |
-| `Settled` | Settlement complete (reserved) | — | — | — | — | — |
-| `Finalized` | Order fully complete | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `Failed` | Order failed | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `Refunded` | Funds returned to sender | ✓ | ✓ | ✓ | ✓ | — |
+| Status      | Description                    | Across | Relay | OIF | Bungee | LiFi Intents |
+| ----------- | ------------------------------ | ------ | ----- | --- | ------ | ------------ |
+| `Created`   | Order created on-chain         | —      | —     | ✓   | —      | —            |
+| `Pending`   | Awaiting execution             | ✓      | ✓     | ✓   | ✓      | ✓            |
+| `Executing` | Filler is processing the order | —      | ✓     | ✓   | ✓      | —            |
+| `Executed`  | Fill transaction submitted     | —      | —     | ✓   | —      | —            |
+| `Settling`  | Settlement in progress         | —      | ✓     | —   | —      | ✓            |
+| `Settled`   | Settlement complete (reserved) | —      | —     | —   | —      | —            |
+| `Finalized` | Order fully complete           | ✓      | ✓     | ✓   | ✓      | ✓            |
+| `Failed`    | Order failed                   | ✓      | ✓     | ✓   | ✓      | ✓            |
+| `Refunded`  | Funds returned to sender       | ✓      | ✓     | ✓   | ✓      | —            |
 
 You can subscribe to **any** `OrderStatus` via `tracker.on(OrderStatus.<status>, ...)` — the examples below show the most common ones.
 
@@ -36,15 +36,19 @@ In addition, the tracker can emit:
 
 The SDK exposes three ways to track an order. Choose based on your use case:
 
-| API | How to call | Input | Use when |
-|-----|-------------|-------|----------|
-| `aggregator.track()` | Event-emitter | `txHash` + `providerId` + `originChainId` + `destinationChainId` | You have a tx hash and want real-time events |
-| `tracker.watchOrder()` | Async generator | (`txHash` + `originChainId`) or (`orderId` + `originChainId` + `destinationChainId`) | You need `orderId`-based tracking (required for signature-based/gasless orders), or prefer async iteration |
-| `aggregator.getOrderStatus()` | One-shot promise | `txHash` + `providerId` + `originChainId` | You only need the current status without streaming |
+| API                           | How to call      | Input                                                                                                                    | Use when                                                                                                                                              |
+| ----------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aggregator.track()`          | Event-emitter    | `txHash` + `providerId` + `originChainId` + `destinationChainId`                                                         | You have a tx hash and want real-time events                                                                                                          |
+| `tracker.watchOrder()`        | Async generator  | (`txHash` + `originChainId`) or (`orderId` + `originChainId` + `destinationChainId`) or (both, with optional `tracking`) | You need `orderId`-based tracking (required for signature-based/gasless orders), want to choose tracking method explicitly, or prefer async iteration |
+| `aggregator.getOrderStatus()` | One-shot promise | `txHash` + `providerId` + `originChainId`                                                                                | You only need the current status without streaming                                                                                                    |
 
 :::warning
-`watchOrder` is currently the only path that supports tracking by `orderId`. Signature-based (gasless) orders may not have a `txHash` at open time — for those, `orderId` tracking is required. Pass a `WatchOrderByOrderId` param (with `orderId`, `originChainId`, and `destinationChainId`) instead of `WatchOrderByTxHash`.
-:::
+`watchOrder` supports three param shapes:
+
+-   `WatchOrderByTxHash` — pass `txHash` only. Uses on-chain event tracking.
+-   `WatchOrderByOrderId` — pass `orderId` only. Uses API-based tracking. Required for signature-based/gasless orders that don't have a `txHash` at open time.
+-   `WatchOrderExplicit` — pass both `txHash` and `orderId`, plus an optional `tracking: 'on-chain' | 'api'` field. Defaults to `'api'` when not specified.
+    :::
 
 :::info Mixed-step orders
 Mixed-step orders (containing both transaction steps and signature steps) are not currently emitted by any supported provider. Consumers can safely handle either `isSignatureOnlyOrder()` or `isTransactionOnlyOrder()` without defensive mixed-order handling.

--- a/apps/docs/docs/cross-chain/providers.md
+++ b/apps/docs/docs/cross-chain/providers.md
@@ -65,14 +65,14 @@ Only `across` and `relay` accept `isTestnet`. What it changes:
 
 Different providers use different tracking mechanisms. Some need RPC URLs, others are fully API-based:
 
-| Provider         | Opened Intent Parser | Fill Watcher | RPC URLs Needed?            |
-| ---------------- | -------------------- | ------------ | --------------------------- |
-| Across (mainnet) | OIF event-based      | API-based    | Origin chain only           |
-| Across (testnet) | OIF event-based      | Event-based  | Origin + destination chains |
-| Relay            | API-based            | API-based    | None                        |
-| OIF              | OIF event-based      | Event-based  | Origin + destination chains |
-| Bungee           | API-based            | API-based    | None                        |
-| LiFi Intents     | Custom event-based   | API-based    | Origin chain only           |
+| Provider         | Opened Intent Parser | Fill Watcher                   | RPC URLs Needed?                                   |
+| ---------------- | -------------------- | ------------------------------ | -------------------------------------------------- |
+| Across (mainnet) | OIF event-based      | API-based                      | Origin chain only                                  |
+| Across (testnet) | OIF event-based      | Event-based                    | Origin + destination chains                        |
+| Relay            | API-based            | API-based                      | None                                               |
+| OIF              | OIF event-based      | API-based + Event-based (dual) | Origin always; destination when tracking by txHash |
+| Bungee           | API-based            | API-based                      | None                                               |
+| LiFi Intents     | Custom event-based   | API-based                      | Origin chain only                                  |
 
 ## Creating Custom Providers
 
@@ -104,10 +104,13 @@ class MyCustomProvider extends CrossChainProvider {
     getTrackingConfig(): {
         openedIntentParserConfig: OpenedIntentParserConfig;
         fillWatcherConfig: FillWatcherConfig;
+        onChainFillWatcherConfig?: FillWatcherConfig; // optional, for on-chain fill detection
         preTrackerConfig?: PreTrackerConfig;
     } {
         // Return protocol-specific tracking configuration
-        // See Relay or Across providers for examples
+        // fillWatcherConfig is used for orderId/API tracking
+        // onChainFillWatcherConfig (if set) is used for txHash/on-chain tracking
+        // See OIF provider for a dual-watcher example, Across for single-watcher
     }
 
     // Optional: override to support gasless (signature-based) order submission

--- a/examples/ui/app/components/Select.tsx
+++ b/examples/ui/app/components/Select.tsx
@@ -19,6 +19,7 @@ interface SelectProps {
   id?: string;
   className?: string;
   emptyMessage?: string;
+  disabled?: boolean;
   renderOption?: (option: SelectOption) => ReactNode;
   renderSelected?: (option: SelectOption) => ReactNode;
 }
@@ -32,6 +33,7 @@ export function Select({
   id,
   className,
   emptyMessage = 'No results found',
+  disabled = false,
   renderOption,
   renderSelected,
 }: SelectProps) {
@@ -77,13 +79,14 @@ export function Select({
   );
 
   return (
-    <Popover.Root open={isOpen} onOpenChange={handleOpenChange}>
+    <Popover.Root open={isOpen && !disabled} onOpenChange={handleOpenChange}>
       <Popover.Trigger asChild>
         <button
           id={id}
           type='button'
+          disabled={disabled}
           className={cn(
-            'w-full px-4 py-3 bg-background/50 border border-border/50 rounded-xl font-mono text-sm focus:border-accent focus:ring-2 focus:ring-accent/20 text-left flex items-center justify-between',
+            'w-full px-4 py-3 bg-background/50 border border-border/50 rounded-xl font-mono text-sm focus:border-accent focus:ring-2 focus:ring-accent/20 text-left flex items-center justify-between disabled:opacity-50 disabled:cursor-not-allowed',
             className,
           )}
         >

--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -293,35 +293,27 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
         </div>
 
         {mode === 'buildQuote' && (
-          <fieldset>
-            <legend className='text-sm font-medium text-text-secondary mb-2'>Provider</legend>
-            <div className='flex gap-2'>
+          <div>
+            <label htmlFor='buildQuoteProvider' className='text-sm font-medium text-text-secondary mb-2 block'>
+              Provider
+            </label>
+            <select
+              id='buildQuoteProvider'
+              value={buildQuoteProviderId}
+              onChange={(e) => {
+                setBuildQuoteProviderId(e.target.value);
+                onInputChange?.();
+              }}
+              disabled={isDisabled}
+              className='w-full px-3 py-2 rounded-lg text-sm font-medium bg-background/50 border border-border/50 text-text-primary focus:outline-none focus:ring-2 focus:ring-accent/50 disabled:opacity-50 disabled:cursor-not-allowed'
+            >
               {BUILD_QUOTE_PROVIDERS.map((p) => (
-                <label
-                  key={p.providerId}
-                  className={`flex-1 text-center px-3 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-accent/50 has-[:focus-visible]:ring-offset-1 ${
-                    buildQuoteProviderId === p.providerId
-                      ? 'bg-accent text-white'
-                      : 'bg-background/50 border border-border/50 text-text-secondary hover:text-text-primary hover:border-border-focus/60'
-                  } ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-                >
-                  <input
-                    type='radio'
-                    name='buildQuoteProvider'
-                    value={p.providerId}
-                    checked={buildQuoteProviderId === p.providerId}
-                    onChange={() => {
-                      setBuildQuoteProviderId(p.providerId);
-                      onInputChange?.();
-                    }}
-                    disabled={isDisabled}
-                    className='sr-only peer'
-                  />
+                <option key={p.providerId} value={p.providerId}>
                   {p.displayName}
-                </label>
+                </option>
               ))}
-            </div>
-          </fieldset>
+            </select>
+          </div>
         )}
 
         <div>

--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { isNativeAddress } from '@wonderland/interop-cross-chain';
 import { formatUnits, parseUnits } from 'viem';
 import { useAccount } from 'wagmi';
+import { Select } from '../../components';
 import { MINT_AMOUNT, useMintToken } from '../hooks/useMintToken';
 import { useChainConfig, useTokenConfig } from '../hooks/useNetworkConfig';
 import { useRouteSelection } from '../hooks/useRouteSelection';
@@ -297,22 +298,16 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
             <label htmlFor='buildQuoteProvider' className='text-sm font-medium text-text-secondary mb-2 block'>
               Provider
             </label>
-            <select
+            <Select
               id='buildQuoteProvider'
               value={buildQuoteProviderId}
-              onChange={(e) => {
-                setBuildQuoteProviderId(e.target.value);
+              options={BUILD_QUOTE_PROVIDERS.map((p) => ({ value: p.providerId, label: p.displayName }))}
+              onChange={(value) => {
+                setBuildQuoteProviderId(value);
                 onInputChange?.();
               }}
               disabled={isDisabled}
-              className='w-full px-3 py-2 rounded-lg text-sm font-medium bg-background/50 border border-border/50 text-text-primary focus:outline-none focus:ring-2 focus:ring-accent/50 disabled:opacity-50 disabled:cursor-not-allowed'
-            >
-              {BUILD_QUOTE_PROVIDERS.map((p) => (
-                <option key={p.providerId} value={p.providerId}>
-                  {p.displayName}
-                </option>
-              ))}
-            </select>
+            />
           </div>
         )}
 

--- a/examples/ui/app/cross-chain/services/orderExecution/flows.ts
+++ b/examples/ui/app/cross-chain/services/orderExecution/flows.ts
@@ -1,10 +1,15 @@
-import { isNativeAddress, getTransactionSteps, type ExecutableQuote } from '@wonderland/interop-cross-chain';
+import {
+  isNativeAddress,
+  getTransactionSteps,
+  type ExecutableQuote,
+  type TrackingIdentifier,
+} from '@wonderland/interop-cross-chain';
 import { useCrossChainStore } from '../../stores/crossChainStore';
 import { handleTokenApproval } from './approval';
 import { submitBridgeTransaction } from './bridge';
 import { signAndSubmitOrder } from './signing';
 import type { ConfiguredWalletClient } from './chainSetup';
-import type { BridgeState, ChainContext, TrackingIdentifier } from '../../types/execution';
+import type { BridgeState, ChainContext } from '../../types/execution';
 import type { Address, Hex, PublicClient } from 'viem';
 
 interface FlowParams {

--- a/examples/ui/app/cross-chain/services/orderExecution/tracking.ts
+++ b/examples/ui/app/cross-chain/services/orderExecution/tracking.ts
@@ -1,7 +1,12 @@
-import { OrderStatus, OrderTrackerYieldType } from '@wonderland/interop-cross-chain';
+import {
+  OrderStatus,
+  OrderTrackerYieldType,
+  type TrackingIdentifier,
+  type WatchOrderParams,
+} from '@wonderland/interop-cross-chain';
 import { TIMEOUT_MS } from '../../constants';
 import { useCrossChainStore } from '../../stores/crossChainStore';
-import { STEP, type BridgeState, type ChainContext, type TrackingIdentifier } from '../../types/execution';
+import { STEP, type BridgeState, type ChainContext } from '../../types/execution';
 import type { Hex } from 'viem';
 
 export class TrackingError extends Error {
@@ -17,8 +22,8 @@ export class TrackingError extends Error {
 }
 
 /**
- * Track an order by txHash (Across) or orderId (OIF escrow/3009).
- * The SDK's watchOrder accepts either identifier.
+ * Track an order using the SDK's watchOrder.
+ * Tracking method is determined by the identifier fields.
  */
 export async function trackOrder(
   providerId: string,
@@ -28,15 +33,16 @@ export async function trackOrder(
   onStateChange: (state: BridgeState) => void,
 ): Promise<void> {
   const tracker = useCrossChainStore.getState().executor.prepareTracking(providerId);
-  const { txHash, orderId } = identifier;
+  const { txHash, orderId, tracking } = identifier;
 
-  const baseParams = {
+  const watchParams = {
+    txHash,
+    orderId,
+    tracking,
     originChainId: chainContext.originChainId,
     destinationChainId: chainContext.destinationChainId,
     timeout: TIMEOUT_MS.INTENT_TRACKING_TIMEOUT,
-  };
-
-  const watchParams = orderId ? { ...baseParams, orderId, openTxHash: txHash } : { ...baseParams, txHash: txHash! };
+  } as WatchOrderParams;
 
   try {
     for await (const item of tracker.watchOrder(watchParams)) {

--- a/examples/ui/app/cross-chain/services/sdk.ts
+++ b/examples/ui/app/cross-chain/services/sdk.ts
@@ -32,9 +32,7 @@ const PROVIDER_CONFIGS: ProviderConfig[] = [
   {
     providerId: 'oif',
     displayName: 'OIF Sample Solver',
-    // TODO: re-enable once OZ confirms on-chain discovery is active on the production solver.
-    // SDK-side implementation is done (StandardOrder encoding, settler addresses, event-based tracking).
-    supportsBuildQuote: false,
+    supportsBuildQuote: true,
   },
   {
     providerId: 'relay',

--- a/examples/ui/app/cross-chain/types/execution.ts
+++ b/examples/ui/app/cross-chain/types/execution.ts
@@ -91,12 +91,3 @@ export interface ExecuteResult {
   success: boolean;
   userRejected?: boolean;
 }
-
-/**
- * Identifier used to track an order after submission.
- * Across uses txHash, OIF uses orderId, Relay uses both.
- */
-export interface TrackingIdentifier {
-  txHash?: Hex;
-  orderId?: Hex;
-}

--- a/packages/cross-chain/src/core/interfaces/crossChainProvider.interface.ts
+++ b/packages/cross-chain/src/core/interfaces/crossChainProvider.interface.ts
@@ -91,8 +91,10 @@ export abstract class CrossChainProvider {
     abstract getTrackingConfig(): {
         /** Configuration for parsing opened intent data */
         openedIntentParserConfig: OpenedIntentParserConfig;
-        /** Configuration for watching fill events */
+        /** Fill watcher for API-based tracking (orderId path, used by getQuotes flow) */
         fillWatcherConfig: FillWatcherConfig;
+        /** Fill watcher for on-chain tracking (txHash path, used by buildQuote flow). Falls back to fillWatcherConfig if not set. */
+        onChainFillWatcherConfig?: FillWatcherConfig;
         /** Optional config for the pre-tracker that runs before tracking begins */
         preTrackerConfig?: PreTrackerConfig;
     };

--- a/packages/cross-chain/src/core/services/OrderTracker.ts
+++ b/packages/cross-chain/src/core/services/OrderTracker.ts
@@ -36,6 +36,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
         private readonly fillWatcher: FillWatcher,
         private readonly clientManager?: PublicClientManager,
         private readonly preTracker?: PreTracker,
+        private readonly onChainFillWatcher?: FillWatcher,
     ) {
         super();
     }
@@ -247,7 +248,9 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
             throw new Error("Order has no destination chain in fillInstructions");
         }
 
+        const watcher = this.onChainFillWatcher ?? this.fillWatcher;
         const fillResult = await this.waitForFillWithTimeout(
+            watcher,
             {
                 orderId: openedIntent.orderId,
                 openTxHash: txHash,
@@ -570,6 +573,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
     }
 
     private async waitForFillWithTimeout(
+        watcher: FillWatcher,
         fillParams: {
             orderId: Hex;
             openTxHash?: Hex;
@@ -591,7 +595,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
         | { status: typeof FillResultStatus.Timeout }
     > {
         try {
-            const fillEvent = await this.fillWatcher.waitForFill(fillParams, timeout);
+            const fillEvent = await watcher.waitForFill(fillParams, timeout);
             return {
                 status: FillResultStatus.Finalized,
                 fillTxHash: fillEvent.fillTxHash,

--- a/packages/cross-chain/src/core/services/OrderTracker.ts
+++ b/packages/cross-chain/src/core/services/OrderTracker.ts
@@ -31,14 +31,36 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
     static readonly GRACE_PERIOD_SECONDS = 60;
     static readonly DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 
+    /** Watcher for API-based tracking (orderId path). */
+    private readonly apiFillWatcher: FillWatcher;
+    /** Watcher for on-chain tracking (txHash path). */
+    private readonly txFillWatcher: FillWatcher;
+
     constructor(
         private readonly openedIntentParser: OpenedIntentParser,
-        private readonly fillWatcher: FillWatcher,
+        fillWatcher: FillWatcher,
         private readonly clientManager?: PublicClientManager,
         private readonly preTracker?: PreTracker,
-        private readonly onChainFillWatcher?: FillWatcher,
+        onChainFillWatcher?: FillWatcher,
     ) {
         super();
+        this.apiFillWatcher = fillWatcher;
+        this.txFillWatcher = onChainFillWatcher ?? fillWatcher;
+    }
+
+    /**
+     * Determine tracking path from params.
+     * Explicit `tracking` field wins. Otherwise: txHash-only → on-chain, anything with orderId → api.
+     */
+    private shouldTrackOnChain(params: WatchOrderParams): boolean {
+        if ("tracking" in params && params.tracking) {
+            return params.tracking === "on-chain";
+        }
+
+        const hasTxHash = "txHash" in params && !!params.txHash;
+        const hasOrderId = "orderId" in params && !!params.orderId;
+
+        return hasTxHash && !hasOrderId;
     }
 
     async getOrderStatus(txHash: Hex, originChainId: number): Promise<OrderTrackingInfo> {
@@ -68,7 +90,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
             fillEvent,
             status,
             failureReason: watcherFailureReason,
-        } = await this.fillWatcher.getFill({
+        } = await this.txFillWatcher.getFill({
             orderId: openedIntent.orderId,
             openTxHash: txHash,
             originChainId,
@@ -141,8 +163,10 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
 
         await this.invokePreTracker(params);
 
-        if ("txHash" in params && params.txHash) {
-            yield* this.watchOrderByTxHash({ ...params, timeout });
+        if (this.shouldTrackOnChain(params)) {
+            yield* this.watchOrderByTxHash({ ...params, timeout } as WatchOrderByTxHash & {
+                timeout: number;
+            });
         } else {
             yield* this.watchOrderByOrderId({ ...(params as WatchOrderByOrderId), timeout });
         }
@@ -248,9 +272,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
             throw new Error("Order has no destination chain in fillInstructions");
         }
 
-        const watcher = this.onChainFillWatcher ?? this.fillWatcher;
         const fillResult = await this.waitForFillWithTimeout(
-            watcher,
+            this.txFillWatcher,
             {
                 orderId: openedIntent.orderId,
                 openTxHash: txHash,
@@ -314,7 +337,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
 
         while (Date.now() - startTime < timeout) {
             const { fillEvent, status, failureReason, fillTxHash } =
-                await this.fillWatcher.getFill(fillParams);
+                await this.apiFillWatcher.getFill(fillParams);
 
             if (fillEvent) {
                 const hasWarnings = fillEvent.warnings && fillEvent.warnings.length > 0;

--- a/packages/cross-chain/src/core/services/OrderTracker.ts
+++ b/packages/cross-chain/src/core/services/OrderTracker.ts
@@ -53,14 +53,10 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
      * Explicit `tracking` field wins. Otherwise: txHash-only → on-chain, anything with orderId → api.
      */
     private shouldTrackOnChain(params: WatchOrderParams): boolean {
-        if ("tracking" in params && params.tracking) {
-            return params.tracking === "on-chain";
-        }
+        if (params.tracking === "on-chain") return true;
+        if (params.tracking === "api") return false;
 
-        const hasTxHash = "txHash" in params && !!params.txHash;
-        const hasOrderId = "orderId" in params && !!params.orderId;
-
-        return hasTxHash && !hasOrderId;
+        return !!params.txHash && !params.orderId;
     }
 
     async getOrderStatus(txHash: Hex, originChainId: number): Promise<OrderTrackingInfo> {

--- a/packages/cross-chain/src/core/services/aggregator.ts
+++ b/packages/cross-chain/src/core/services/aggregator.ts
@@ -252,7 +252,18 @@ class Aggregator {
         validateAssetSupport(params, providerId, isSupported);
 
         const quote = await provider.buildQuote(params);
-        return { ...quote, _providerId: providerId };
+        let executable: ExecutableQuote = { ...quote, _providerId: providerId };
+
+        if (this.approvalService) {
+            try {
+                const [enriched] = await this.approvalService.enrichQuotes([executable]);
+                if (enriched) executable = enriched;
+            } catch (error) {
+                console.warn("[Aggregator] Approval enrichment failed:", error);
+            }
+        }
+
+        return executable;
     }
 
     /**

--- a/packages/cross-chain/src/core/types/orderTracking.ts
+++ b/packages/cross-chain/src/core/types/orderTracking.ts
@@ -186,6 +186,9 @@ export type OrderTrackerYield =
     | { type: typeof OrderTrackerYieldType.Update; update: OrderTrackingUpdate }
     | { type: typeof OrderTrackerYieldType.Timeout; payload: OrderTrackerTimeoutPayload };
 
+/** Strategy for tracking an order's fill: on-chain events or solver API. */
+export type OrderTrackingStrategy = "on-chain" | "api";
+
 interface WatchOrderBase {
     /** Origin chain ID */
     originChainId: number;
@@ -216,7 +219,7 @@ export interface WatchOrderByOrderId extends WatchOrderBase {
 export interface WatchOrderExplicit extends WatchOrderBase {
     txHash: Hex;
     orderId: Hex;
-    tracking?: "on-chain" | "api";
+    tracking?: OrderTrackingStrategy;
     destinationChainId?: number;
 }
 

--- a/packages/cross-chain/src/core/types/orderTracking.ts
+++ b/packages/cross-chain/src/core/types/orderTracking.ts
@@ -195,28 +195,35 @@ interface WatchOrderBase {
     pollingInterval?: number;
 }
 
-/** Watch by txHash (user-open orders) */
+/** Watch by txHash only - tracks on-chain (event-based). */
 export interface WatchOrderByTxHash extends WatchOrderBase {
-    /** Transaction hash where the order was opened */
     txHash: Hex;
     orderId?: never;
-    /** Optional - extracted from parsed order's fillInstructions */
+    tracking?: never;
     destinationChainId?: number;
 }
 
-/** Watch by order identifier instead of transaction hash */
+/** Watch by orderId only - tracks via API. */
 export interface WatchOrderByOrderId extends WatchOrderBase {
     txHash?: never;
-    /** Order or request identifier returned by the protocol */
     orderId: Hex;
-    /** Required when no origin transaction is available to parse */
+    tracking?: never;
     destinationChainId: number;
-    /** Origin transaction hash, passed to the pre-tracker when provided */
     openTxHash?: Hex;
 }
 
-/** Pass txHash for user-open orders, orderId for escrow orders */
-export type WatchOrderParams = WatchOrderByTxHash | WatchOrderByOrderId;
+/** Watch with both identifiers. Defaults to API tracking if not specified. */
+export interface WatchOrderExplicit extends WatchOrderBase {
+    txHash: Hex;
+    orderId: Hex;
+    tracking?: "on-chain" | "api";
+    destinationChainId?: number;
+}
+
+export type WatchOrderParams = WatchOrderByTxHash | WatchOrderByOrderId | WatchOrderExplicit;
+
+/** Tracking identifiers returned by execution flows, used to start order tracking. */
+export type TrackingIdentifier = Pick<WatchOrderParams, "txHash" | "orderId" | "tracking">;
 
 /**
  * Parameters for getting fill status on destination chain

--- a/packages/cross-chain/src/core/utils/addressHelpers.ts
+++ b/packages/cross-chain/src/core/utils/addressHelpers.ts
@@ -1,5 +1,18 @@
 import type { Address } from "viem";
-import { Hex } from "viem";
+import { Hex, pad } from "viem";
+
+/**
+ * Left-pad a 20-byte address to a bytes32 hex string.
+ *
+ * @example
+ * ```typescript
+ * addressToBytes32("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+ * // Returns: "0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+ * ```
+ */
+export function addressToBytes32(addr: string): Hex {
+    return pad(addr as Hex, { size: 32 });
+}
 
 /**
  * Convert a bytes32 value to an Ethereum address

--- a/packages/cross-chain/src/factories/orderTrackerFactory.ts
+++ b/packages/cross-chain/src/factories/orderTrackerFactory.ts
@@ -59,7 +59,17 @@ export class OrderTrackerFactory {
                 ? this.preTrackerFactory.create(trackingConfig.preTrackerConfig)
                 : undefined);
 
-        return new OrderTracker(openedIntentParser, fillWatcher, this.clientManager, preTracker);
+        const onChainFillWatcher = trackingConfig.onChainFillWatcherConfig
+            ? this.createFillWatcher(trackingConfig.onChainFillWatcherConfig as FillWatcherConfig)
+            : undefined;
+
+        return new OrderTracker(
+            openedIntentParser,
+            fillWatcher,
+            this.clientManager,
+            preTracker,
+            onChainFillWatcher,
+        );
     }
 
     /**

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -13,6 +13,7 @@ import { ZodError } from "zod";
 
 import type { Quote, QuoteFeeEntry } from "../../core/schemas/quote.js";
 import type { BuildQuoteRequest, QuoteRequest } from "../../core/schemas/quoteRequest.js";
+import { addressToBytes32 } from "../../core/utils/addressHelpers.js";
 import {
     ACROSS_FILLED_RELAY_EVENT_ABI,
     ACROSS_SPOKE_POOL_ADDRESSES,
@@ -59,10 +60,6 @@ import { decodeAcrossCalldata } from "./utils.js";
 
 const ZERO_BYTES32 = pad("0x00" as Hex, { size: 32 });
 const ACROSS_DEFAULT_MESSAGE: Hex = "0x";
-
-function addressToBytes32(address: string): Hex {
-    return pad(address as Address, { size: 32 });
-}
 
 /**
  * An implementation of the CrossChainProvider interface for the Across protocol

--- a/packages/cross-chain/src/protocols/oif/constants.ts
+++ b/packages/cross-chain/src/protocols/oif/constants.ts
@@ -5,7 +5,7 @@
 // Canonical EIP-712 type definitions for OIF order signing
 // =============================================================================
 import type { EIP712Types, Order } from "@openintentsframework/oif-specs";
-import type { Address, Hex } from "viem";
+import type { Address } from "viem";
 
 export type OifOrderType = Order["type"];
 
@@ -18,16 +18,69 @@ const OIF_ORDER_TYPE_SET: Record<OifOrderType, true> = {
 
 export const OIF_ORDER_TYPES = Object.keys(OIF_ORDER_TYPE_SET) as OifOrderType[];
 
-export const OPEN_ABI = [
+// =============================================================================
+// OIF deployed contract addresses (current solver deployment)
+// =============================================================================
+
+/** InputSettlerEscrow addresses per chain. */
+export const OIF_INPUT_SETTLER_ESCROW_BY_CHAIN: Record<number, Address> = {
+    42161: "0x79750615FD0c3DBE3bBCD7e8E7BDdCbB554b10a8", // Arbitrum
+    8453: "0x2778258002a69a0cB1DfD29b360a0bB1654C8652", // Base
+    10: "0x2778258002a69a0cB1DfD29b360a0bB1654C8652", // Optimism
+};
+
+/** OutputSettler addresses per chain. */
+export const OIF_OUTPUT_SETTLER_BY_CHAIN: Record<number, Address> = {
+    42161: "0x28E8D349d76bf9d553452bF6f02279196E7c5929", // Arbitrum
+    8453: "0x2404F8e3c37c002c89bA78086a119e68E3fF8824", // Base
+    10: "0x2404F8e3c37c002c89bA78086a119e68E3fF8824", // Optimism
+};
+
+/** Hyperlane BroadcasterOracle, same on all mainnet chains. */
+export const OIF_BROADCASTER_ORACLE: Address = "0x0b88D54A39F330Dd7e773af4806BDC490c79cAB6";
+
+// =============================================================================
+// Shared ABI components
+// =============================================================================
+
+const MANDATE_OUTPUT_COMPONENTS = [
+    { internalType: "bytes32", name: "oracle", type: "bytes32" },
+    { internalType: "bytes32", name: "settler", type: "bytes32" },
+    { internalType: "uint256", name: "chainId", type: "uint256" },
+    { internalType: "bytes32", name: "token", type: "bytes32" },
+    { internalType: "uint256", name: "amount", type: "uint256" },
+    { internalType: "bytes32", name: "recipient", type: "bytes32" },
+    { internalType: "bytes", name: "callbackData", type: "bytes" },
+    { internalType: "bytes", name: "context", type: "bytes" },
+] as const;
+
+const STANDARD_ORDER_COMPONENTS = [
+    { internalType: "address", name: "user", type: "address" },
+    { internalType: "uint256", name: "nonce", type: "uint256" },
+    { internalType: "uint256", name: "originChainId", type: "uint256" },
+    { internalType: "uint32", name: "expires", type: "uint32" },
+    { internalType: "uint32", name: "fillDeadline", type: "uint32" },
+    { internalType: "address", name: "inputOracle", type: "address" },
+    { internalType: "uint256[2][]", name: "inputs", type: "uint256[2][]" },
+    {
+        internalType: "struct MandateOutput[]",
+        name: "outputs",
+        type: "tuple[]",
+        components: MANDATE_OUTPUT_COMPONENTS,
+    },
+] as const;
+
+// =============================================================================
+// InputSettlerEscrow ABIs
+// =============================================================================
+
+/** ABI for InputSettlerEscrow.open(StandardOrder). */
+export const STANDARD_ORDER_OPEN_ABI = [
     {
         inputs: [
             {
-                components: [
-                    { internalType: "uint32", name: "fillDeadline", type: "uint32" },
-                    { internalType: "bytes32", name: "orderDataType", type: "bytes32" },
-                    { internalType: "bytes", name: "orderData", type: "bytes" },
-                ],
-                internalType: "struct OnchainCrossChainOrder",
+                components: STANDARD_ORDER_COMPONENTS,
+                internalType: "struct StandardOrder",
                 name: "order",
                 type: "tuple",
             },
@@ -37,119 +90,52 @@ export const OPEN_ABI = [
         stateMutability: "nonpayable",
         type: "function",
     },
-];
-
-/**
- * EIP-7683 Output struct
- * Represents token amounts in maxSpent/minReceived arrays
- */
-const OUTPUT_STRUCT_COMPONENTS = [
-    { internalType: "bytes32", name: "token", type: "bytes32" },
-    { internalType: "uint256", name: "amount", type: "uint256" },
-    { internalType: "bytes32", name: "recipient", type: "bytes32" },
-    { internalType: "uint256", name: "chainId", type: "uint256" },
 ] as const;
 
-/**
- * EIP-7683 FillInstruction struct
- * Contains destination chain info and settlement data
- */
-const FILL_INSTRUCTION_STRUCT_COMPONENTS = [
-    { internalType: "uint256", name: "destinationChainId", type: "uint256" },
-    { internalType: "bytes32", name: "destinationSettler", type: "bytes32" },
-    { internalType: "bytes", name: "originData", type: "bytes" },
-] as const;
-
-/**
- * EIP-7683 Open event ABI
- * Emitted when a cross-chain order is opened on a settlement contract
- *
- * Contains the full ResolvedCrossChainOrder struct including:
- * - maxSpent: Maximum outputs the filler will send (user's input)
- * - minReceived: Minimum outputs user must receive
- * - fillInstructions: Destination chain and settlement info
- *
- * @see https://eips.ethereum.org/EIPS/eip-7683
- */
-export const OPEN_EVENT_ABI = [
+/** Open event emitted by InputSettlerEscrow: Open(bytes32 indexed orderId, StandardOrder order). */
+export const OIF_OPEN_EVENT_ABI = [
     {
         type: "event",
         name: "Open",
         inputs: [
-            {
-                indexed: true,
-                internalType: "bytes32",
-                name: "orderId",
-                type: "bytes32",
-            },
+            { indexed: true, internalType: "bytes32", name: "orderId", type: "bytes32" },
             {
                 indexed: false,
-                internalType: "struct ResolvedCrossChainOrder",
-                name: "resolvedOrder",
+                internalType: "struct StandardOrder",
+                name: "order",
                 type: "tuple",
-                components: [
-                    { internalType: "address", name: "user", type: "address" },
-                    { internalType: "uint256", name: "originChainId", type: "uint256" },
-                    { internalType: "uint32", name: "openDeadline", type: "uint32" },
-                    { internalType: "uint32", name: "fillDeadline", type: "uint32" },
-                    { internalType: "bytes32", name: "orderId", type: "bytes32" },
-                    {
-                        internalType: "struct Output[]",
-                        name: "maxSpent",
-                        type: "tuple[]",
-                        components: OUTPUT_STRUCT_COMPONENTS,
-                    },
-                    {
-                        internalType: "struct Output[]",
-                        name: "minReceived",
-                        type: "tuple[]",
-                        components: OUTPUT_STRUCT_COMPONENTS,
-                    },
-                    {
-                        internalType: "struct FillInstruction[]",
-                        name: "fillInstructions",
-                        type: "tuple[]",
-                        components: FILL_INSTRUCTION_STRUCT_COMPONENTS,
-                    },
-                ],
+                components: STANDARD_ORDER_COMPONENTS,
             },
         ],
     },
 ] as const;
 
-/**
- * Event signature for the EIP-7683 Open event
- * Used to identify Open events in transaction receipts
- */
-export const OPEN_EVENT_SIGNATURE =
-    "0xa576d0af275d0c6207ef43ceee8c498a5d7a26b8157a32d3fdf361e64371628c" as const;
+export const OIF_OPEN_EVENT_SIGNATURE =
+    "0x9ff74bd56d00785b881ef9fa3f03d7b598686a39a9bcff89a6008db588b18a7b" as const;
 
-/** EIP-7683 Output struct (decoded) */
-export interface EIP7683Output {
-    token: Hex;
-    amount: bigint;
-    recipient: Hex;
-    chainId: bigint;
-}
+// =============================================================================
+// OutputSettler ABI
+// =============================================================================
 
-/** EIP-7683 FillInstruction struct (decoded) */
-export interface EIP7683FillInstruction {
-    destinationChainId: bigint;
-    destinationSettler: Hex;
-    originData: Hex;
-}
-
-/** EIP-7683 ResolvedCrossChainOrder struct (decoded) */
-export interface EIP7683ResolvedOrder {
-    user: Address;
-    originChainId: bigint;
-    openDeadline: number;
-    fillDeadline: number;
-    orderId: Hex;
-    maxSpent: readonly EIP7683Output[];
-    minReceived: readonly EIP7683Output[];
-    fillInstructions: readonly EIP7683FillInstruction[];
-}
+/** OutputFilled event emitted by the OutputSettler when a solver fills an order. */
+export const OUTPUT_FILLED_EVENT_ABI = [
+    {
+        type: "event",
+        name: "OutputFilled",
+        inputs: [
+            { indexed: true, internalType: "bytes32", name: "orderId", type: "bytes32" },
+            { indexed: false, internalType: "bytes32", name: "solver", type: "bytes32" },
+            { indexed: false, internalType: "uint32", name: "timestamp", type: "uint32" },
+            {
+                internalType: "struct MandateOutput",
+                name: "output",
+                type: "tuple",
+                components: MANDATE_OUTPUT_COMPONENTS,
+            },
+            { indexed: false, internalType: "uint256", name: "fillAmount", type: "uint256" },
+        ],
+    },
+] as const;
 
 /**
  * Canonical EIP-712 types for oif-escrow-v0 and oif-3009-v0 orders.

--- a/packages/cross-chain/src/protocols/oif/provider.ts
+++ b/packages/cross-chain/src/protocols/oif/provider.ts
@@ -5,7 +5,7 @@ import {
     PostOrderResponse,
 } from "@openintentsframework/oif-specs";
 import axios, { AxiosError } from "axios";
-import { encodeFunctionData, Hex, hexToBytes, pad } from "viem";
+import { encodeFunctionData, Hex, hexToBytes } from "viem";
 import { ZodError } from "zod";
 
 import type {
@@ -14,10 +14,12 @@ import type {
 } from "../../core/interfaces/quotes.interface.js";
 import type { Quote, SubmitOrderResponse } from "../../core/schemas/quote.js";
 import type { BuildQuoteRequest, QuoteRequest } from "../../core/schemas/quoteRequest.js";
+import { addressToBytes32 } from "../../core/utils/addressHelpers.js";
 import { isSignableOifOrder } from "../../core/utils/orderTypeHelpers.js";
 import {
     APIBasedFillWatcherConfig,
     CrossChainProvider,
+    EventBasedFillWatcherConfig,
     FillEvent,
     FillWatcherConfig,
     GetFillParams,
@@ -42,9 +44,13 @@ import {
     adaptQuoteRequest,
     adaptTypedDataPayload,
 } from "./adapters/index.js";
-import { OPEN_ABI } from "./constants.js";
-
-const DEFAULT_ORDER_DATA_TYPE = pad("0x00" as Hex, { size: 32 });
+import {
+    OIF_BROADCASTER_ORACLE,
+    OIF_INPUT_SETTLER_ESCROW_BY_CHAIN,
+    OIF_OUTPUT_SETTLER_BY_CHAIN,
+    OUTPUT_FILLED_EVENT_ABI,
+    STANDARD_ORDER_OPEN_ABI,
+} from "./constants.js";
 
 /**
  * OIF Provider implementation
@@ -278,25 +284,52 @@ export class OifProvider extends CrossChainProvider {
             );
         }
 
-        const orderDataType = params.orderDataType
-            ? (pad(params.orderDataType as Hex, { size: 32 }) as Hex)
-            : DEFAULT_ORDER_DATA_TYPE;
+        const escrowAddress = OIF_INPUT_SETTLER_ESCROW_BY_CHAIN[params.input.chainId];
 
-        const orderData = (params.orderData ?? "0x") as Hex;
+        if (!escrowAddress) {
+            throw new ProviderExecuteNotImplemented(
+                `OIF has no input settler on chain ${params.input.chainId}`,
+            );
+        }
+
+        const outputSettler = OIF_OUTPUT_SETTLER_BY_CHAIN[params.output.chainId];
+        if (!outputSettler) {
+            throw new ProviderExecuteNotImplemented(
+                `OIF has no output settler on chain ${params.output.chainId}`,
+            );
+        }
+
+        // Nonce only needs to be unique per user. Millisecond timestamp avoids collisions.
+        const nonce = BigInt(Date.now());
+        const recipient = params.output.recipient ?? params.user;
 
         const calldata = encodeFunctionData({
-            abi: OPEN_ABI,
+            abi: STANDARD_ORDER_OPEN_ABI,
             functionName: "open",
             args: [
                 {
+                    user: params.user as Hex,
+                    nonce,
+                    originChainId: BigInt(params.input.chainId),
+                    expires: params.fillDeadline,
                     fillDeadline: params.fillDeadline,
-                    orderDataType,
-                    orderData,
+                    inputOracle: OIF_BROADCASTER_ORACLE,
+                    inputs: [[BigInt(params.input.assetAddress), BigInt(params.input.amount)]],
+                    outputs: [
+                        {
+                            oracle: addressToBytes32(OIF_BROADCASTER_ORACLE),
+                            settler: addressToBytes32(outputSettler),
+                            chainId: BigInt(params.output.chainId),
+                            token: addressToBytes32(params.output.assetAddress),
+                            amount: BigInt(params.output.amount),
+                            recipient: addressToBytes32(recipient),
+                            callbackData: "0x" as Hex,
+                            context: "0x" as Hex,
+                        },
+                    ],
                 },
             ],
         });
-
-        const recipient = params.output.recipient ?? params.user;
 
         return {
             provider: this.providerId,
@@ -306,7 +339,7 @@ export class OifProvider extends CrossChainProvider {
                         kind: "transaction" as const,
                         chainId: params.input.chainId,
                         transaction: {
-                            to: params.escrowContractAddress,
+                            to: escrowAddress,
                             data: calldata,
                         },
                     },
@@ -317,7 +350,7 @@ export class OifProvider extends CrossChainProvider {
                             chainId: params.input.chainId,
                             tokenAddress: params.input.assetAddress,
                             owner: params.user,
-                            spender: params.escrowContractAddress,
+                            spender: escrowAddress,
                             required: params.input.amount,
                         },
                     ],
@@ -344,12 +377,13 @@ export class OifProvider extends CrossChainProvider {
             metadata: {
                 buildQuote: true,
                 fillDeadline: params.fillDeadline,
-                escrowContractAddress: params.escrowContractAddress,
+                escrowContractAddress: escrowAddress,
+                nonce: nonce.toString(),
             },
         };
     }
 
-    static getFillWatcherConfig(baseUrl: string): APIBasedFillWatcherConfig<unknown> {
+    static getApiFillWatcherConfig(baseUrl: string): APIBasedFillWatcherConfig<unknown> {
         return {
             type: "api-based",
             baseUrl,
@@ -387,17 +421,41 @@ export class OifProvider extends CrossChainProvider {
                     return { event: null, status, failureReason, fillTxHash };
                 }
 
-                const event: FillEvent = {
-                    fillTxHash,
-                    timestamp:
-                        validatedResponse.updatedAt ??
-                        validatedResponse.createdAt ??
-                        Math.floor(Date.now() / 1000),
+                return {
+                    event: {
+                        fillTxHash,
+                        timestamp:
+                            validatedResponse.updatedAt ??
+                            validatedResponse.createdAt ??
+                            Math.floor(Date.now() / 1000),
+                        originChainId: params.originChainId,
+                        orderId: params.orderId,
+                    },
+                    status,
+                    failureReason,
+                };
+            },
+        };
+    }
+
+    static getOnChainFillWatcherConfig(): EventBasedFillWatcherConfig {
+        return {
+            type: "event-based",
+            contractAddresses: OIF_OUTPUT_SETTLER_BY_CHAIN,
+            eventAbi: OUTPUT_FILLED_EVENT_ABI,
+            buildLogsArgs: (params: GetFillParams, contractAddress) => ({
+                address: contractAddress,
+                event: OUTPUT_FILLED_EVENT_ABI[0],
+                args: { orderId: params.orderId },
+            }),
+            extractFillEvent: (log, params): FillEvent | null => {
+                if (!log.transactionHash) return null;
+                return {
+                    fillTxHash: log.transactionHash,
+                    timestamp: 0,
                     originChainId: params.originChainId,
                     orderId: params.orderId,
                 };
-
-                return { event, status, failureReason };
             },
         };
     }
@@ -405,10 +463,12 @@ export class OifProvider extends CrossChainProvider {
     getTrackingConfig(): {
         openedIntentParserConfig: OpenedIntentParserConfig;
         fillWatcherConfig: FillWatcherConfig;
+        onChainFillWatcherConfig?: FillWatcherConfig;
     } {
         return {
             openedIntentParserConfig: { type: "oif" },
-            fillWatcherConfig: OifProvider.getFillWatcherConfig(this.url),
+            fillWatcherConfig: OifProvider.getApiFillWatcherConfig(this.url),
+            onChainFillWatcherConfig: OifProvider.getOnChainFillWatcherConfig(),
         };
     }
 

--- a/packages/cross-chain/src/protocols/oif/services/OIFOpenedIntentParser.ts
+++ b/packages/cross-chain/src/protocols/oif/services/OIFOpenedIntentParser.ts
@@ -1,29 +1,22 @@
-import { Chain, decodeEventLog, Hex, PublicClient } from "viem";
+import { Chain, decodeEventLog, Hex, numberToHex, PublicClient } from "viem";
 
+import { addressToBytes32 } from "../../../core/utils/addressHelpers.js";
 import {
-    EIP7683ResolvedOrder,
     getChainById,
     InvalidOpenEventError,
     OIFOpenEventNotFoundError,
-    OPEN_EVENT_ABI,
-    OPEN_EVENT_SIGNATURE,
     OpenedIntent,
     OpenedIntentParser,
     OpenedIntentParserDependencies,
 } from "../../../internal.js";
+import { OIF_OPEN_EVENT_ABI, OIF_OPEN_EVENT_SIGNATURE } from "../constants.js";
 
 /**
- * Parser for OIF (Open Intent Framework) standard Open events.
- * For protocols that emit the standard ERC-7683 Open event.
+ * Parser for OIF InputSettlerEscrow Open events.
  *
- * Extracts the complete ERC-7683 ResolvedCrossChainOrder struct including:
- * - All fields from the spec (user, originChainId, openDeadline, fillDeadline, orderId)
- * - Full arrays: maxSpent[], minReceived[], fillInstructions[]
- * - SDK metadata: txHash, blockNumber, originContract
- *
- * Fully supports multi-token and multi-chain intents as defined in ERC-7683.
- *
- * @see https://www.erc7683.org/spec
+ * The OIF settler emits `Open(bytes32 orderId, StandardOrder order)` which
+ * differs from the ERC-7683 standard event. This parser extracts the
+ * StandardOrder fields and maps them to the SDK's OpenedIntent interface.
  */
 export class OIFOpenedIntentParser implements OpenedIntentParser {
     constructor(private readonly dependencies: OpenedIntentParserDependencies) {}
@@ -32,26 +25,13 @@ export class OIFOpenedIntentParser implements OpenedIntentParser {
         return this.dependencies.clientManager.getClient(chain);
     }
 
-    /**
-     * Parse OIF Open event from a transaction and return OpenedIntent.
-     *
-     * Extracts the complete ERC-7683 ResolvedCrossChainOrder struct from the Open event,
-     * including all arrays (maxSpent, minReceived, fillInstructions) for full multi-token
-     * and multi-chain support.
-     *
-     * @param txHash - Transaction hash to parse
-     * @param chainId - Chain ID where the transaction occurred
-     * @returns Complete opened intent data matching ERC-7683 spec
-     * @throws {OIFOpenEventNotFoundError} If Open event is not found
-     * @throws {InvalidOpenEventError} If Open event data is malformed
-     */
     async getOpenedIntent(txHash: Hex, chainId: number): Promise<OpenedIntent> {
         const chain = getChainById(chainId);
         const publicClient = this.getPublicClient({ chain });
 
         const receipt = await publicClient.getTransactionReceipt({ hash: txHash });
 
-        const openLog = receipt.logs.find((log) => log.topics[0] === OPEN_EVENT_SIGNATURE);
+        const openLog = receipt.logs.find((log) => log.topics[0] === OIF_OPEN_EVENT_SIGNATURE);
 
         if (!openLog) {
             throw new OIFOpenEventNotFoundError(txHash);
@@ -59,54 +39,57 @@ export class OIFOpenedIntentParser implements OpenedIntentParser {
 
         try {
             const decoded = decodeEventLog({
-                abi: OPEN_EVENT_ABI,
+                abi: OIF_OPEN_EVENT_ABI,
                 data: openLog.data,
                 topics: openLog.topics,
             });
 
-            const { orderId, resolvedOrder } = decoded.args as {
-                orderId: Hex;
-                resolvedOrder: EIP7683ResolvedOrder;
-            };
+            const { orderId, order } = decoded.args;
 
-            if (!orderId || !resolvedOrder) {
-                throw new InvalidOpenEventError("Missing orderId or resolvedOrder");
+            if (!orderId || !order) {
+                throw new InvalidOpenEventError("Missing orderId or order");
             }
 
-            if (!resolvedOrder.maxSpent || resolvedOrder.maxSpent.length === 0) {
-                throw new InvalidOpenEventError("Missing maxSpent in Open event");
+            if (!order.inputs || order.inputs.length === 0) {
+                throw new InvalidOpenEventError("Missing inputs in Open event");
             }
-            if (!resolvedOrder.minReceived || resolvedOrder.minReceived.length === 0) {
-                throw new InvalidOpenEventError("Missing minReceived in Open event");
-            }
-            if (!resolvedOrder.fillInstructions || resolvedOrder.fillInstructions.length === 0) {
-                throw new InvalidOpenEventError("Missing fillInstructions in Open event");
+            if (!order.outputs || order.outputs.length === 0) {
+                throw new InvalidOpenEventError("Missing outputs in Open event");
             }
 
-            const maxSpent = resolvedOrder.maxSpent.map((output) => ({
-                ...output,
+            // Map StandardOrder inputs to TokenTransfer (maxSpent).
+            // inputs is uint256[2][] where [0] is token address and [1] is amount.
+            const maxSpent = order.inputs.map((input) => ({
+                token: numberToHex(input[0], { size: 32 }),
+                amount: input[1],
+                recipient: addressToBytes32(openLog.address),
+                chainId: Number(order.originChainId),
+            }));
+
+            // Map MandateOutput to TokenTransfer (minReceived).
+            const minReceived = order.outputs.map((output) => ({
+                token: output.token,
+                amount: output.amount,
+                recipient: output.recipient,
                 chainId: Number(output.chainId),
             }));
-            const minReceived = resolvedOrder.minReceived.map((output) => ({
-                ...output,
-                chainId: Number(output.chainId),
-            }));
-            const fillInstructions = resolvedOrder.fillInstructions.map((instruction) => ({
-                ...instruction,
-                destinationChainId: Number(instruction.destinationChainId),
+
+            // Map MandateOutput to FillInstruction.
+            const fillInstructions = order.outputs.map((output) => ({
+                destinationChainId: Number(output.chainId),
+                destinationSettler: output.settler,
+                originData: "0x" as Hex,
             }));
 
             return {
-                // ERC-7683 ResolvedCrossChainOrder fields
-                user: resolvedOrder.user,
-                originChainId: Number(resolvedOrder.originChainId),
-                openDeadline: resolvedOrder.openDeadline,
-                fillDeadline: resolvedOrder.fillDeadline,
+                user: order.user,
+                originChainId: Number(order.originChainId),
+                openDeadline: order.expires,
+                fillDeadline: order.fillDeadline,
                 orderId,
                 maxSpent,
                 minReceived,
                 fillInstructions,
-                // SDK metadata fields
                 txHash,
                 blockNumber: receipt.blockNumber,
                 originContract: openLog.address,

--- a/packages/cross-chain/test/adapters/buildQuoteAdapter.spec.ts
+++ b/packages/cross-chain/test/adapters/buildQuoteAdapter.spec.ts
@@ -4,14 +4,19 @@ import { describe, expect, it } from "vitest";
 
 import type { BuildQuoteRequest } from "../../src/core/schemas/quoteRequest.js";
 import { BuildQuoteRequestSchema } from "../../src/core/schemas/quoteRequest.js";
-import { OPEN_ABI } from "../../src/protocols/oif/constants.js";
+import {
+    OIF_INPUT_SETTLER_ESCROW_BY_CHAIN,
+    STANDARD_ORDER_OPEN_ABI,
+} from "../../src/protocols/oif/constants.js";
 import { OifProvider } from "../../src/protocols/oif/provider.js";
 
 const USER = "0x742D35cC6634C0532925A3b844bc9E7595f0BEb8" as Address;
-const ESCROW = "0x95AD61B0A150D79219dcf64E1e6cC01f0C0c8A4A" as Address;
-const INPUT_TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as Address;
-const OUTPUT_TOKEN = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as Address;
+const INPUT_TOKEN = "0x7e13e59a15e4703a54a0976ddd970f8fe52d3a76" as Address;
+const OUTPUT_TOKEN = "0xc0b782920b2de8b55f08fc98004eb5c7d4fbf287" as Address;
 const RECIPIENT = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" as Address;
+// Use a supported chain (ARB) so buildQuote doesn't reject
+const INPUT_CHAIN = 42161;
+const OUTPUT_CHAIN = 8453;
 
 const PROVIDER_ID = "test-oif-provider";
 
@@ -25,16 +30,16 @@ function createBuildQuoteRequest(overrides?: Partial<BuildQuoteRequest>): BuildQ
     return {
         user: USER,
         input: {
-            chainId: 1,
+            chainId: INPUT_CHAIN,
             assetAddress: INPUT_TOKEN,
             amount: "1000000",
         },
         output: {
-            chainId: 8453,
+            chainId: OUTPUT_CHAIN,
             assetAddress: OUTPUT_TOKEN,
             amount: "990000",
         },
-        escrowContractAddress: ESCROW,
+        escrowContractAddress: OIF_INPUT_SETTLER_ESCROW_BY_CHAIN[INPUT_CHAIN]!,
         fillDeadline: 4102444800,
         ...overrides,
     };
@@ -60,12 +65,6 @@ describe("BuildQuoteRequestSchema", () => {
         expect(result.success).toBe(false);
     });
 
-    it("rejects when escrowContractAddress is missing", () => {
-        const { escrowContractAddress: _, ...noEscrow } = createBuildQuoteRequest();
-        const result = BuildQuoteRequestSchema.safeParse(noEscrow);
-        expect(result.success).toBe(false);
-    });
-
     it("rejects when fillDeadline is missing", () => {
         const { fillDeadline: _, ...noDeadline } = createBuildQuoteRequest();
         const result = BuildQuoteRequestSchema.safeParse(noDeadline);
@@ -82,7 +81,7 @@ describe("BuildQuoteRequestSchema", () => {
     it("rejects non-numeric amount", () => {
         const result = BuildQuoteRequestSchema.safeParse(
             createBuildQuoteRequest({
-                input: { chainId: 1, assetAddress: INPUT_TOKEN, amount: "1.5" },
+                input: { chainId: INPUT_CHAIN, assetAddress: INPUT_TOKEN, amount: "1.5" },
             }),
         );
         expect(result.success).toBe(false);
@@ -92,40 +91,12 @@ describe("BuildQuoteRequestSchema", () => {
         const result = BuildQuoteRequestSchema.safeParse(
             createBuildQuoteRequest({
                 output: {
-                    chainId: 8453,
+                    chainId: OUTPUT_CHAIN,
                     assetAddress: OUTPUT_TOKEN,
                     amount: "990000",
                     recipient: RECIPIENT,
                 },
             }),
-        );
-        expect(result.success).toBe(true);
-    });
-
-    it("rejects invalid orderDataType hex", () => {
-        const result = BuildQuoteRequestSchema.safeParse(
-            createBuildQuoteRequest({ orderDataType: "not-hex" }),
-        );
-        expect(result.success).toBe(false);
-    });
-
-    it("rejects invalid orderData hex", () => {
-        const result = BuildQuoteRequestSchema.safeParse(
-            createBuildQuoteRequest({ orderData: "not-hex" }),
-        );
-        expect(result.success).toBe(false);
-    });
-
-    it("accepts valid orderDataType hex", () => {
-        const result = BuildQuoteRequestSchema.safeParse(
-            createBuildQuoteRequest({ orderDataType: "0xabcdef" }),
-        );
-        expect(result.success).toBe(true);
-    });
-
-    it("accepts valid orderData hex", () => {
-        const result = BuildQuoteRequestSchema.safeParse(
-            createBuildQuoteRequest({ orderData: "0x1234" }),
         );
         expect(result.success).toBe(true);
     });
@@ -139,23 +110,25 @@ describe("OifProvider.buildQuote", () => {
         expect(quote.order.steps[0]!.kind).toBe("transaction");
     });
 
-    it("targets the escrow contract address", async () => {
+    it("targets the input settler for the origin chain", async () => {
         const quote = await provider.buildQuote(createBuildQuoteRequest());
 
         const step = quote.order.steps[0]!;
         expect(step.kind).toBe("transaction");
         if (step.kind === "transaction") {
-            expect(step.transaction.to).toBe(ESCROW);
+            // ARB input settler
+            expect(step.transaction.to!.toLowerCase()).toBe(
+                OIF_INPUT_SETTLER_ESCROW_BY_CHAIN[INPUT_CHAIN]!.toLowerCase(),
+            );
         }
     });
 
     it("sets the correct origin chainId on the step", async () => {
         const quote = await provider.buildQuote(createBuildQuoteRequest());
-
-        expect(quote.order.steps[0]!.chainId).toBe(1);
+        expect(quote.order.steps[0]!.chainId).toBe(INPUT_CHAIN);
     });
 
-    it("encodes valid open() calldata", async () => {
+    it("encodes valid StandardOrder open() calldata", async () => {
         const params = createBuildQuoteRequest();
         const quote = await provider.buildQuote(params);
 
@@ -163,15 +136,14 @@ describe("OifProvider.buildQuote", () => {
         expect(step.kind).toBe("transaction");
         if (step.kind === "transaction") {
             const decoded = decodeFunctionData({
-                abi: OPEN_ABI,
+                abi: STANDARD_ORDER_OPEN_ABI,
                 data: step.transaction.data as Hex,
             });
 
             expect(decoded.functionName).toBe("open");
-            const args = decoded.args as [
-                { fillDeadline: number; orderDataType: Hex; orderData: Hex },
-            ];
-            expect(args[0].fillDeadline).toBe(params.fillDeadline);
+            const order = decoded.args[0];
+            expect(order.fillDeadline).toBe(params.fillDeadline);
+            expect(order.user.toLowerCase()).toBe(USER.toLowerCase());
         }
     });
 
@@ -180,7 +152,7 @@ describe("OifProvider.buildQuote", () => {
         const quote = await provider.buildQuote(params);
 
         expect(quote.preview.inputs).toHaveLength(1);
-        expect(quote.preview.inputs[0]!.chainId).toBe(1);
+        expect(quote.preview.inputs[0]!.chainId).toBe(INPUT_CHAIN);
         expect(quote.preview.inputs[0]!.accountAddress).toBe(USER);
         expect(quote.preview.inputs[0]!.assetAddress).toBe(INPUT_TOKEN);
         expect(quote.preview.inputs[0]!.amount).toBe("1000000");
@@ -191,7 +163,7 @@ describe("OifProvider.buildQuote", () => {
         const quote = await provider.buildQuote(params);
 
         expect(quote.preview.outputs).toHaveLength(1);
-        expect(quote.preview.outputs[0]!.chainId).toBe(8453);
+        expect(quote.preview.outputs[0]!.chainId).toBe(OUTPUT_CHAIN);
         expect(quote.preview.outputs[0]!.assetAddress).toBe(OUTPUT_TOKEN);
         expect(quote.preview.outputs[0]!.amount).toBe("990000");
     });
@@ -199,21 +171,19 @@ describe("OifProvider.buildQuote", () => {
     it("uses user address as recipient when no explicit recipient", async () => {
         const params = createBuildQuoteRequest();
         const quote = await provider.buildQuote(params);
-
         expect(quote.preview.outputs[0]!.accountAddress).toBe(USER);
     });
 
     it("uses explicit recipient when provided", async () => {
         const params = createBuildQuoteRequest({
             output: {
-                chainId: 8453,
+                chainId: OUTPUT_CHAIN,
                 assetAddress: OUTPUT_TOKEN,
                 amount: "990000",
                 recipient: RECIPIENT,
             },
         });
         const quote = await provider.buildQuote(params);
-
         expect(quote.preview.outputs[0]!.accountAddress).toBe(RECIPIENT);
     });
 
@@ -222,7 +192,7 @@ describe("OifProvider.buildQuote", () => {
         expect(quote.provider).toBe(PROVIDER_ID);
     });
 
-    it("populates order.checks.allowances", async () => {
+    it("populates order.checks.allowances targeting the settler", async () => {
         const params = createBuildQuoteRequest();
         const quote = await provider.buildQuote(params);
 
@@ -230,10 +200,13 @@ describe("OifProvider.buildQuote", () => {
         expect(quote.order.checks!.allowances).toHaveLength(1);
 
         const allowance = quote.order.checks!.allowances![0]!;
-        expect(allowance.chainId).toBe(1);
+        expect(allowance.chainId).toBe(INPUT_CHAIN);
         expect(allowance.tokenAddress).toBe(INPUT_TOKEN);
         expect(allowance.owner).toBe(USER);
-        expect(allowance.spender).toBe(ESCROW);
+        // spender should be the settler, not a user-provided address
+        expect(allowance.spender.toLowerCase()).toBe(
+            OIF_INPUT_SETTLER_ESCROW_BY_CHAIN[INPUT_CHAIN]!.toLowerCase(),
+        );
         expect(allowance.required).toBe("1000000");
     });
 
@@ -244,26 +217,19 @@ describe("OifProvider.buildQuote", () => {
         expect(quote.metadata).toBeDefined();
         expect(quote.metadata!.buildQuote).toBe(true);
         expect(quote.metadata!.fillDeadline).toBe(params.fillDeadline);
-        expect(quote.metadata!.escrowContractAddress).toBe(ESCROW);
     });
 
-    it("accepts optional orderDataType override", async () => {
-        const customOrderDataType =
-            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
-        const params = createBuildQuoteRequest({ orderDataType: customOrderDataType });
-        const quote = await provider.buildQuote(params);
+    it("rejects unsupported origin chain", async () => {
+        const params = createBuildQuoteRequest({
+            input: { chainId: 1, assetAddress: INPUT_TOKEN, amount: "1000000" },
+        });
+        await expect(provider.buildQuote(params)).rejects.toThrow("no input settler on chain 1");
+    });
 
-        const step = quote.order.steps[0]!;
-        expect(step.kind).toBe("transaction");
-        if (step.kind === "transaction") {
-            const decoded = decodeFunctionData({
-                abi: OPEN_ABI,
-                data: step.transaction.data as Hex,
-            });
-            const args = decoded.args as [
-                { fillDeadline: number; orderDataType: Hex; orderData: Hex },
-            ];
-            expect(args[0].orderDataType).toBe(customOrderDataType);
-        }
+    it("rejects unsupported destination chain", async () => {
+        const params = createBuildQuoteRequest({
+            output: { chainId: 999, assetAddress: OUTPUT_TOKEN, amount: "990000" },
+        });
+        await expect(provider.buildQuote(params)).rejects.toThrow("no output settler on chain 999");
     });
 });

--- a/packages/cross-chain/test/services/OIFOpenedIntentParser.spec.ts
+++ b/packages/cross-chain/test/services/OIFOpenedIntentParser.spec.ts
@@ -1,65 +1,64 @@
-import { Address, encodeAbiParameters, Hex, Log, PublicClient } from "viem";
+import type { Address, Hex, Log, PublicClient } from "viem";
+import { encodeAbiParameters } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
     InvalidOpenEventError,
     OIFOpenedIntentParser,
     OIFOpenEventNotFoundError,
-    OPEN_EVENT_SIGNATURE,
     PublicClientManager,
 } from "../../src/internal.js";
+import {
+    OIF_INPUT_SETTLER_ESCROW_BY_CHAIN,
+    OIF_OPEN_EVENT_SIGNATURE,
+} from "../../src/protocols/oif/constants.js";
 
 /**
- * Create mock Open event log with full EIP-7683 ResolvedCrossChainOrder data
+ * Create a mock Open event log with OIF StandardOrder data.
  */
 const createMockOpenEventLog = (overrides?: Partial<Log>): Log => {
     const orderId = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" as Hex;
     const user = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" as Address;
-    const originChainId = 11155111n;
-    const openDeadline = 1700000000;
+    const originChainId = 42161n;
+    const nonce = 1700000000000n;
+    const expires = 1700003900;
     const fillDeadline = 1700003600;
-    const destinationChainId = 84532n; // Base Sepolia
-    const inputAmount = 1000000000000000000n; // 1 ETH
-    const outputAmount = 990000000000000000n; // 0.99 ETH
+    const inputOracle = "0x0b88D54A39F330Dd7e773af4806BDC490c79cAB6" as Address;
+    const inputToken = BigInt("0x7e13e59a15e4703a54a0976ddd970f8fe52d3a76");
+    const inputAmount = 1000000n;
+    const outputOracle =
+        "0x0000000000000000000000000b88D54A39F330Dd7e773af4806BDC490c79cAB6" as Hex;
+    const outputSettler =
+        "0x0000000000000000000000002404F8e3c37c002c89bA78086a119e68E3fF8824" as Hex;
+    const outputChainId = 8453n;
+    const outputToken = "0x000000000000000000000000c0b782920b2de8b55f08fc98004eb5c7d4fbf287" as Hex;
+    const outputAmount = 960000n;
+    const recipient = "0x000000000000000000000000d8dA6BF26964aF9D7eEd9e03E53415D37aA96045" as Hex;
 
-    // Encode the full ResolvedCrossChainOrder struct
     const data = encodeAbiParameters(
         [
             {
                 type: "tuple",
                 components: [
                     { type: "address", name: "user" },
+                    { type: "uint256", name: "nonce" },
                     { type: "uint256", name: "originChainId" },
-                    { type: "uint32", name: "openDeadline" },
+                    { type: "uint32", name: "expires" },
                     { type: "uint32", name: "fillDeadline" },
-                    { type: "bytes32", name: "orderId" },
+                    { type: "address", name: "inputOracle" },
+                    { type: "uint256[2][]", name: "inputs" },
                     {
                         type: "tuple[]",
-                        name: "maxSpent",
+                        name: "outputs",
                         components: [
+                            { type: "bytes32", name: "oracle" },
+                            { type: "bytes32", name: "settler" },
+                            { type: "uint256", name: "chainId" },
                             { type: "bytes32", name: "token" },
                             { type: "uint256", name: "amount" },
                             { type: "bytes32", name: "recipient" },
-                            { type: "uint256", name: "chainId" },
-                        ],
-                    },
-                    {
-                        type: "tuple[]",
-                        name: "minReceived",
-                        components: [
-                            { type: "bytes32", name: "token" },
-                            { type: "uint256", name: "amount" },
-                            { type: "bytes32", name: "recipient" },
-                            { type: "uint256", name: "chainId" },
-                        ],
-                    },
-                    {
-                        type: "tuple[]",
-                        name: "fillInstructions",
-                        components: [
-                            { type: "uint256", name: "destinationChainId" },
-                            { type: "bytes32", name: "destinationSettler" },
-                            { type: "bytes", name: "originData" },
+                            { type: "bytes", name: "callbackData" },
+                            { type: "bytes", name: "context" },
                         ],
                     },
                 ],
@@ -68,34 +67,22 @@ const createMockOpenEventLog = (overrides?: Partial<Log>): Log => {
         [
             {
                 user,
+                nonce,
                 originChainId,
-                openDeadline,
+                expires,
                 fillDeadline,
-                orderId,
-                maxSpent: [
+                inputOracle,
+                inputs: [[inputToken, inputAmount]],
+                outputs: [
                     {
-                        token: "0x0000000000000000000000000000000000000000000000000000000000000001" as Hex,
-                        amount: inputAmount,
-                        recipient:
-                            "0x0000000000000000000000000000000000000000000000000000000000000002" as Hex,
-                        chainId: originChainId,
-                    },
-                ],
-                minReceived: [
-                    {
-                        token: "0x0000000000000000000000000000000000000000000000000000000000000003" as Hex,
+                        oracle: outputOracle,
+                        settler: outputSettler,
+                        chainId: outputChainId,
+                        token: outputToken,
                         amount: outputAmount,
-                        recipient:
-                            "0x0000000000000000000000000000000000000000000000000000000000000004" as Hex,
-                        chainId: destinationChainId,
-                    },
-                ],
-                fillInstructions: [
-                    {
-                        destinationChainId,
-                        destinationSettler:
-                            "0x0000000000000000000000000000000000000000000000000000000000000005" as Hex,
-                        originData: "0x" as Hex,
+                        recipient,
+                        callbackData: "0x",
+                        context: "0x",
                     },
                 ],
             },
@@ -103,164 +90,103 @@ const createMockOpenEventLog = (overrides?: Partial<Log>): Log => {
     );
 
     return {
-        address: "0x5f9D51679F5A0C7C1e2b7F0aE8F2c3c7c9c1c2c3" as Address,
-        blockHash: "0xaabbccdd1234567890aabbccdd1234567890aabbccdd1234567890aabbccdd12" as Hex,
-        blockNumber: 1000000n,
+        address: OIF_INPUT_SETTLER_ESCROW_BY_CHAIN[42161]! as Address,
+        blockHash: "0xblockhash" as Hex,
+        blockNumber: 100n,
         data,
         logIndex: 0,
-        removed: false,
-        topics: [OPEN_EVENT_SIGNATURE as Hex, orderId], // topic[0] = event sig, topic[1] = orderId (indexed)
-        transactionHash:
-            "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" as Hex,
+        topics: [OIF_OPEN_EVENT_SIGNATURE, orderId],
+        transactionHash: "0xtxhash" as Hex,
         transactionIndex: 0,
+        removed: false,
         ...overrides,
-    } as Log;
+    };
 };
+
+const mockTxHash = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" as Hex;
+const mockChainId = 42161;
 
 describe("OIFOpenedIntentParser", () => {
     let parser: OIFOpenedIntentParser;
-    let mockClientManager: PublicClientManager;
-    let mockPublicClient: PublicClient;
-
-    const mockTxHash = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" as Hex;
-    const mockChainId = 11155111; // Sepolia
+    let mockGetTransactionReceipt: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
-        vi.clearAllMocks();
+        mockGetTransactionReceipt = vi.fn();
 
-        mockPublicClient = {
-            getTransactionReceipt: vi.fn(),
-        } as unknown as PublicClient;
-
-        mockClientManager = {
-            getClient: vi.fn().mockReturnValue(mockPublicClient),
+        const mockClientManager = {
+            getClient: vi.fn().mockReturnValue({
+                getTransactionReceipt: mockGetTransactionReceipt,
+            } as unknown as PublicClient),
         } as unknown as PublicClientManager;
 
-        parser = new OIFOpenedIntentParser({
-            clientManager: mockClientManager,
-        });
+        parser = new OIFOpenedIntentParser({ clientManager: mockClientManager });
     });
 
-    describe("getOpenedIntent", () => {
-        it("should parse OIF Open event and return complete OpenedIntent", async () => {
-            const mockOpenLog = createMockOpenEventLog();
+    it("parses a valid OIF StandardOrder Open event", async () => {
+        const openLog = createMockOpenEventLog();
 
-            vi.mocked(mockPublicClient.getTransactionReceipt).mockResolvedValue({
-                logs: [mockOpenLog],
-                blockNumber: 1000000n,
-            } as unknown as ReturnType<PublicClient["getTransactionReceipt"]>);
-
-            const result = await parser.getOpenedIntent(mockTxHash, mockChainId);
-
-            // Basic fields
-            expect(result.orderId).toBe(
-                "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-            );
-            expect(result.txHash).toBe(mockTxHash);
-            expect(result.blockNumber).toBe(1000000n);
-            expect(result.originContract).toBe(mockOpenLog.address);
-
-            // Check fillInstructions array
-            expect(result.fillInstructions).toBeDefined();
-            expect(result.fillInstructions.length).toBeGreaterThan(0);
+        mockGetTransactionReceipt.mockResolvedValue({
+            logs: [openLog],
+            blockNumber: 100n,
         });
 
-        it("should throw OIFOpenEventNotFoundError when no Open event in receipt", async () => {
-            const nonOpenLog: Log = {
-                address: "0x5f9D51679F5A0C7C1e2b7F0aE8F2c3c7c9c1c2c3" as Address,
-                blockHash: "0xaabbccdd" as Hex,
-                blockNumber: 1000000n,
-                data: "0x" as Hex,
-                logIndex: 0,
-                removed: false,
-                topics: ["0xdifferentsignature" as Hex],
-                transactionHash: mockTxHash,
-                transactionIndex: 0,
-            };
+        const intent = await parser.getOpenedIntent(mockTxHash, mockChainId);
 
-            vi.mocked(mockPublicClient.getTransactionReceipt).mockResolvedValue({
-                logs: [nonOpenLog],
-                blockNumber: 1000000n,
-            } as unknown as ReturnType<PublicClient["getTransactionReceipt"]>);
+        expect(intent.orderId).toBe(
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        );
+        expect(intent.user.toLowerCase()).toBe(
+            "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".toLowerCase(),
+        );
+        expect(intent.originChainId).toBe(42161);
+        expect(intent.fillDeadline).toBe(1700003600);
+        expect(intent.openDeadline).toBe(1700003900); // mapped from expires
+        expect(intent.maxSpent).toHaveLength(1);
+        expect(intent.maxSpent[0]!.amount).toBe(1000000n);
+        expect(intent.minReceived).toHaveLength(1);
+        expect(intent.minReceived[0]!.amount).toBe(960000n);
+        expect(intent.minReceived[0]!.chainId).toBe(8453);
+        expect(intent.fillInstructions).toHaveLength(1);
+        expect(intent.fillInstructions[0]!.destinationChainId).toBe(8453);
+    });
 
-            await expect(parser.getOpenedIntent(mockTxHash, mockChainId)).rejects.toThrow(
-                OIFOpenEventNotFoundError,
-            );
+    it("throws OIFOpenEventNotFoundError when no Open event in receipt", async () => {
+        mockGetTransactionReceipt.mockResolvedValue({
+            logs: [],
+            blockNumber: 100n,
         });
 
-        it("should throw OIFOpenEventNotFoundError when receipt has no logs", async () => {
-            vi.mocked(mockPublicClient.getTransactionReceipt).mockResolvedValue({
-                logs: [],
-                blockNumber: 1000000n,
-            } as unknown as ReturnType<PublicClient["getTransactionReceipt"]>);
+        await expect(parser.getOpenedIntent(mockTxHash, mockChainId)).rejects.toBeInstanceOf(
+            OIFOpenEventNotFoundError,
+        );
+    });
 
-            await expect(parser.getOpenedIntent(mockTxHash, mockChainId)).rejects.toThrow(
-                OIFOpenEventNotFoundError,
-            );
+    it("throws InvalidOpenEventError when event data is malformed", async () => {
+        const badLog = createMockOpenEventLog({ data: "0x0000" as Hex });
+
+        mockGetTransactionReceipt.mockResolvedValue({
+            logs: [badLog],
+            blockNumber: 100n,
         });
 
-        it("should find Open event among multiple logs", async () => {
-            const otherLog: Log = {
-                address: "0x1111111111111111111111111111111111111111" as Address,
-                blockHash: "0xaabbccdd" as Hex,
-                blockNumber: 1000000n,
-                data: "0x" as Hex,
-                logIndex: 0,
-                removed: false,
-                topics: ["0xothersignature" as Hex],
-                transactionHash: mockTxHash,
-                transactionIndex: 0,
-            };
+        await expect(parser.getOpenedIntent(mockTxHash, mockChainId)).rejects.toBeInstanceOf(
+            InvalidOpenEventError,
+        );
+    });
 
-            const mockOpenLog = createMockOpenEventLog();
-
-            vi.mocked(mockPublicClient.getTransactionReceipt).mockResolvedValue({
-                logs: [otherLog, mockOpenLog, otherLog],
-                blockNumber: 1000000n,
-            } as unknown as ReturnType<PublicClient["getTransactionReceipt"]>);
-
-            const result = await parser.getOpenedIntent(mockTxHash, mockChainId);
-
-            expect(result.orderId).toBe(
-                "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-            );
+    it("includes SDK metadata in the result", async () => {
+        const openLog = createMockOpenEventLog();
+        mockGetTransactionReceipt.mockResolvedValue({
+            logs: [openLog],
+            blockNumber: 100n,
         });
 
-        it("should use correct chain client", async () => {
-            const mockOpenLog = createMockOpenEventLog();
+        const intent = await parser.getOpenedIntent(mockTxHash, mockChainId);
 
-            vi.mocked(mockPublicClient.getTransactionReceipt).mockResolvedValue({
-                logs: [mockOpenLog],
-                blockNumber: 1000000n,
-            } as unknown as ReturnType<PublicClient["getTransactionReceipt"]>);
-
-            await parser.getOpenedIntent(mockTxHash, mockChainId);
-
-            expect(mockClientManager.getClient).toHaveBeenCalled();
-        });
-
-        it("should throw InvalidOpenEventError for malformed event data", async () => {
-            // Create a log with the correct signature but invalid data
-            const malformedLog: Log = {
-                address: "0x5f9D51679F5A0C7C1e2b7F0aE8F2c3c7c9c1c2c3" as Address,
-                blockHash: "0xaabbccdd" as Hex,
-                blockNumber: 1000000n,
-                data: "0x" as Hex, // Empty data will cause decode to fail
-                logIndex: 0,
-                removed: false,
-                topics: [OPEN_EVENT_SIGNATURE as Hex], // Correct signature but missing orderId topic
-                transactionHash: mockTxHash,
-                transactionIndex: 0,
-            };
-
-            vi.mocked(mockPublicClient.getTransactionReceipt).mockResolvedValue({
-                logs: [malformedLog],
-                blockNumber: 1000000n,
-            } as unknown as ReturnType<PublicClient["getTransactionReceipt"]>);
-
-            await expect(parser.getOpenedIntent(mockTxHash, mockChainId)).rejects.toThrow(
-                InvalidOpenEventError,
-            );
-        });
+        expect(intent.txHash).toBe(mockTxHash);
+        expect(intent.blockNumber).toBe(100n);
+        expect(intent.originContract.toLowerCase()).toBe(
+            OIF_INPUT_SETTLER_ESCROW_BY_CHAIN[42161]!.toLowerCase(),
+        );
     });
 });

--- a/packages/cross-chain/test/services/OrderTracker.spec.ts
+++ b/packages/cross-chain/test/services/OrderTracker.spec.ts
@@ -838,4 +838,102 @@ describe("OrderTracker", () => {
             expect(timeoutEvents[0]!.message).toContain("Stopped watching after timeout");
         });
     });
+
+    describe("tracking method routing", () => {
+        const orderId = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" as Hex;
+        let mockOnChainWatcher: FillWatcher;
+
+        beforeEach(() => {
+            mockOnChainWatcher = {
+                getFill: vi.fn(),
+                waitForFill: vi.fn(),
+            } as unknown as FillWatcher;
+
+            tracker = new OrderTracker(
+                mockOpenedIntentParser,
+                mockFillWatcher,
+                undefined,
+                undefined,
+                mockOnChainWatcher,
+            );
+        });
+
+        async function runWatchOrder(params: WatchOrderParams): Promise<void> {
+            for await (const item of tracker.watchOrder(params)) {
+                if (
+                    item.type === OrderTrackerYieldType.Update &&
+                    item.update.status === OrderStatus.Finalized
+                )
+                    break;
+            }
+        }
+
+        function setupOnChainFill(): void {
+            vi.mocked(mockOpenedIntentParser.getOpenedIntent).mockResolvedValue(
+                createMockOpenedIntent(),
+            );
+            vi.mocked(mockOnChainWatcher.waitForFill).mockResolvedValue(createMockFillEvent());
+        }
+
+        function setupApiFill(): void {
+            vi.mocked(mockFillWatcher.getFill).mockResolvedValue({
+                fillEvent: createMockFillEvent(),
+                status: OrderStatus.Finalized,
+            });
+        }
+
+        it("txHash only → on-chain watcher", async () => {
+            setupOnChainFill();
+            await runWatchOrder({ txHash: mockTxHash, originChainId: mockOriginChainId });
+            expect(mockOnChainWatcher.waitForFill).toHaveBeenCalled();
+            expect(mockFillWatcher.waitForFill).not.toHaveBeenCalled();
+        });
+
+        it("orderId only → API watcher", async () => {
+            setupApiFill();
+            await runWatchOrder({
+                orderId,
+                originChainId: mockOriginChainId,
+                destinationChainId: mockDestinationChainId,
+            });
+            expect(mockFillWatcher.getFill).toHaveBeenCalled();
+            expect(mockOnChainWatcher.getFill).not.toHaveBeenCalled();
+        });
+
+        it("both + tracking: 'on-chain' → on-chain watcher", async () => {
+            setupOnChainFill();
+            await runWatchOrder({
+                txHash: mockTxHash,
+                orderId,
+                tracking: "on-chain",
+                originChainId: mockOriginChainId,
+            });
+            expect(mockOnChainWatcher.waitForFill).toHaveBeenCalled();
+        });
+
+        it("both + tracking: 'api' → API watcher", async () => {
+            setupApiFill();
+            await runWatchOrder({
+                txHash: mockTxHash,
+                orderId,
+                tracking: "api",
+                originChainId: mockOriginChainId,
+                destinationChainId: mockDestinationChainId,
+            });
+            expect(mockFillWatcher.getFill).toHaveBeenCalled();
+            expect(mockOnChainWatcher.getFill).not.toHaveBeenCalled();
+        });
+
+        it("both without tracking → defaults to API", async () => {
+            setupApiFill();
+            await runWatchOrder({
+                txHash: mockTxHash,
+                orderId,
+                originChainId: mockOriginChainId,
+                destinationChainId: mockDestinationChainId,
+            });
+            expect(mockFillWatcher.getFill).toHaveBeenCalled();
+            expect(mockOnChainWatcher.getFill).not.toHaveBeenCalled();
+        });
+    });
 });


### PR DESCRIPTION
## Summary

- OIF provider now supports `buildQuote()` via the InputSettlerEscrow `open(StandardOrder)` function
- Fill tracking watches `OutputFilled` events on the OutputSettler contract instead of polling the solver API
- Added dual fill watcher support: providers can now return separate configs for API-based tracking (getQuotes) and on-chain tracking (buildQuote) via `onChainFillWatcherConfig`
- Fixed `OIFOpenedIntentParser` to parse the actual OIF Open event (`StandardOrder`) instead of the ERC-7683 standard event (`ResolvedCrossChainOrder`), which the OIF settlers don't emit
- Removed dead ERC-7683 ABIs and types that never matched the real contracts
- Extracted shared `addressToBytes32` utility from Across and OIF providers

## Tested

- ARB → Base with OIF mock USDC on mainnet, fill detected via OutputFilled event
- Verified with real tx: https://arbiscan.io/tx/0x3545055ac02803bee28d24bcaf608dd7e696e7e9fc6961c4cede6ce2135b9fe2

Closes EFI-869