### PR TITLE
chore(cross-chain): gate oif-resource-lock-v0 until support lands

### DIFF
--- a/.changeset/efi-886-gate-resource-lock.md
+++ b/.changeset/efi-886-gate-resource-lock.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Gate `oif-resource-lock-v0` at the SDK entry points until support is finalized. The OIF request adapter no longer requests it from solvers, and the payload validator throws if a solver returns one.

--- a/packages/cross-chain/src/protocols/oif/adapters/quoteRequestAdapter.ts
+++ b/packages/cross-chain/src/protocols/oif/adapters/quoteRequestAdapter.ts
@@ -31,19 +31,21 @@ export interface AdaptOptions {
  */
 const LOCK_TO_ORDER_TYPES: Record<string, string[]> = {
     "oif-escrow": ["oif-escrow-v0", "oif-3009-v0"],
-    "compact-resource-lock": ["oif-resource-lock-v0"],
+    // TODO (EFI-887): re-enable when resource-lock support lands.
+    // "compact-resource-lock": ["oif-resource-lock-v0"],
 };
 
 /** All known OIF order types (used when no lock filter is specified). */
 const ALL_OIF_ORDER_TYPES = [
     "oif-escrow-v0",
     "oif-3009-v0",
-    "oif-resource-lock-v0",
+    // TODO (EFI-887): re-enable when resource-lock support lands.
+    // "oif-resource-lock-v0",
     "oif-user-open-v0",
 ];
 
 /** Gasless (signature-based) order types */
-const GASLESS_ORDER_TYPES = new Set(["oif-escrow-v0", "oif-3009-v0", "oif-resource-lock-v0"]);
+const GASLESS_ORDER_TYPES = new Set(["oif-escrow-v0", "oif-3009-v0"]);
 
 function toSupportedTypes(options?: AdaptOptions): string[] {
     const { supportedLocks, submissionModes } = options ?? {};

--- a/packages/cross-chain/src/protocols/oif/provider.ts
+++ b/packages/cross-chain/src/protocols/oif/provider.ts
@@ -128,6 +128,15 @@ export class OifProvider extends CrossChainProvider {
             getQuoteResponseSchema.parse(response.data);
             const { quotes } = response.data as GetQuoteResponse;
 
+            // TODO (EFI-887): re-enable when resource-lock support lands.
+            for (const quote of quotes) {
+                if (quote.order.type === "oif-resource-lock-v0") {
+                    throw new ProviderGetQuoteFailure(
+                        "oif-resource-lock-v0 is not supported in this release",
+                    );
+                }
+            }
+
             // 2. Map OIF quotes → ProviderQuote (with typedData normalization)
             const providerQuotes: ProviderQuote[] = quotes.map((quote): ProviderQuote => {
                 const adaptedQuote = adaptTypedDataPayload(quote);

--- a/packages/cross-chain/src/protocols/oif/validators/oifPayloadValidator.ts
+++ b/packages/cross-chain/src/protocols/oif/validators/oifPayloadValidator.ts
@@ -2,7 +2,6 @@ import type { GetQuoteRequest, Order } from "@openintentsframework/oif-specs";
 
 import { validate3009Order } from "./oif3009Validator.js";
 import { validateEscrowOrder } from "./oifEscrowValidator.js";
-import { validateResourceLockOrder } from "./oifResourceLockValidator.js";
 import { validateUserOpenOrder } from "./oifUserOpenValidator.js";
 
 export async function validateOifPayload(
@@ -12,12 +11,13 @@ export async function validateOifPayload(
     switch (order.type) {
         case "oif-escrow-v0":
             return validateEscrowOrder(userIntent, order);
-        case "oif-resource-lock-v0":
-            return validateResourceLockOrder(userIntent, order);
         case "oif-3009-v0":
             return validate3009Order(userIntent, order);
         case "oif-user-open-v0":
             return validateUserOpenOrder(userIntent, order);
+        case "oif-resource-lock-v0":
+            // TODO (EFI-887): re-enable when resource-lock support lands.
+            throw new Error("oif-resource-lock-v0 is not supported in this release");
         default:
             return false;
     }

--- a/packages/cross-chain/test/adapters/quoteRequestAdapter.spec.ts
+++ b/packages/cross-chain/test/adapters/quoteRequestAdapter.spec.ts
@@ -143,8 +143,8 @@ describe("adaptQuoteRequest", () => {
             const result = adaptQuoteRequest(baseRequest);
             expect(result.supportedTypes).toContain("oif-escrow-v0");
             expect(result.supportedTypes).toContain("oif-3009-v0");
-            expect(result.supportedTypes).toContain("oif-resource-lock-v0");
             expect(result.supportedTypes).toContain("oif-user-open-v0");
+            expect(result.supportedTypes).not.toContain("oif-resource-lock-v0");
         });
 
         it("returns all OIF order types when options has empty supportedLocks", () => {
@@ -161,7 +161,8 @@ describe("adaptQuoteRequest", () => {
             expect(result.supportedTypes).not.toContain("oif-resource-lock-v0");
         });
 
-        it("maps compact-resource-lock to resource lock type", () => {
+        // TODO (EFI-887): re-enable when resource-lock support lands.
+        it.skip("maps compact-resource-lock to resource lock type", () => {
             const options: AdaptOptions = { supportedLocks: ["compact-resource-lock"] };
             const result = adaptQuoteRequest(baseRequest, options);
             expect(result.supportedTypes).toContain("oif-resource-lock-v0");
@@ -174,7 +175,7 @@ describe("adaptQuoteRequest", () => {
             const result = adaptQuoteRequest(baseRequest, options);
             expect(result.supportedTypes).toContain("oif-escrow-v0");
             expect(result.supportedTypes).toContain("oif-3009-v0");
-            expect(result.supportedTypes).toContain("oif-resource-lock-v0");
+            expect(result.supportedTypes).not.toContain("oif-resource-lock-v0");
             expect(result.supportedTypes).not.toContain("oif-user-open-v0");
         });
 

--- a/packages/cross-chain/test/providers/OifProvider.spec.ts
+++ b/packages/cross-chain/test/providers/OifProvider.spec.ts
@@ -11,6 +11,7 @@ import {
 import { OIF_ADDRESSES } from "../mocks/fixtures.js";
 import {
     getMockedOifQuoteResponse,
+    getMockedOifResourceLockQuoteResponse,
     getMockedOifUserOpenQuoteResponse,
 } from "../mocks/oif/index.js";
 
@@ -149,6 +150,18 @@ describe("OifProvider", () => {
             expect(quotes[0]!.order.steps).toBeDefined();
             expect(quotes[0]!.order.steps.length).toBeGreaterThan(0);
             expect(quotes[0]!.order.steps[0]!.kind).toBe("transaction");
+        });
+
+        // TODO (EFI-887): re-enable when resource-lock support lands.
+        it("rejects oif-resource-lock-v0 quotes returned by the solver", async () => {
+            vi.mocked(axios.post).mockResolvedValue({
+                status: 200,
+                data: getMockedOifResourceLockQuoteResponse(),
+            });
+
+            await expect(provider.getQuotes(mockQuoteRequest)).rejects.toThrow(
+                ProviderGetQuoteFailure,
+            );
         });
     });
 

--- a/packages/cross-chain/test/validators/oifPayloadValidator.spec.ts
+++ b/packages/cross-chain/test/validators/oifPayloadValidator.spec.ts
@@ -76,7 +76,8 @@ describe("validateOifPayload", () => {
         });
     });
 
-    describe("oif-resource-lock-v0", () => {
+    // TODO (EFI-887): re-enable when resource-lock support lands.
+    describe.skip("oif-resource-lock-v0", () => {
         it("returns true when order matches intent", async () => {
             const response = getMockedOifResourceLockQuoteResponse();
             const intent = createIntentFromQuote(response, "oif-resource-lock-v0");


### PR DESCRIPTION
# 🤖 Linear

Closes EFI-886
Refs EFI-887

## Description

Gates the partially-supported `oif-resource-lock-v0` order type at the SDK entry points so it cannot reach the typed-data path in this release. The request adapter no longer requests it from solvers, and the payload validator throws if a solver returns one. Re-enable tracked in EFI-887.

Verified locally: `check-types` clean, full cross-chain test suite passes (969 passed, 14 skipped — 5 from this change marked with TODO).

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [x] If it is a core feature, I have included comprehensive tests.