### PR TITLE
feat(cross-chain): add deadline-based eta fallback (EFI-889)

### DIFF
--- a/.changeset/efi-889-eta-fallback.md
+++ b/.changeset/efi-889-eta-fallback.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Quotes now expose an `eta` (estimated seconds until fill) across every protocol. When a provider does not return its own ETA, the SDK falls back to the deadline embedded in the quote response (`quoteExpiryTimestamp` for Across, `quoteExpiry` for Bungee, `protocol.v2.orderData.output.deadline` for Relay) or, for LiFi Intents, decoded directly from the open-intent calldata since the response does not surface any deadline of its own.
+
+The fallback policy lives in a single `EtaResolverService` that adapters depend on, so the rule is uniform across protocols and easy to extend if new deadline candidates appear.

--- a/packages/cross-chain/src/core/services/etaResolver.ts
+++ b/packages/cross-chain/src/core/services/etaResolver.ts
@@ -42,13 +42,13 @@ export class EtaResolverService {
         providerEta: number | undefined,
         deadlines: ReadonlyArray<number | undefined> = [],
     ): number | undefined {
-        if (typeof providerEta === "number" && providerEta >= 0) {
+        if (Number.isFinite(providerEta) && (providerEta as number) >= 0) {
             return providerEta;
         }
 
         for (const deadline of deadlines) {
-            if (typeof deadline === "number") {
-                return Math.max(0, deadline - this.clock());
+            if (Number.isFinite(deadline)) {
+                return Math.max(0, (deadline as number) - this.clock());
             }
         }
 

--- a/packages/cross-chain/src/core/services/etaResolver.ts
+++ b/packages/cross-chain/src/core/services/etaResolver.ts
@@ -1,0 +1,60 @@
+/**
+ * Source of unix-second timestamps. Injected to keep
+ * {@link EtaResolverService} deterministic in tests.
+ */
+export type Clock = () => number;
+
+const defaultClock: Clock = () => Math.floor(Date.now() / 1000);
+
+/**
+ * Resolves the `eta` (estimated seconds until fill) that a Quote should
+ * expose, applying a deadline-based fallback when the provider does not
+ * return an ETA of its own.
+ *
+ * Resolution order:
+ *   1. `providerEta` if it is a non-negative number.
+ *   2. `max(0, deadline - now)` for the first defined deadline candidate.
+ *   3. `undefined` when no information is available.
+ *
+ * Adapters depend on this service so the fallback policy lives in one
+ * place and is open for extension (e.g. adding the order's fillDeadline
+ * as an extra deadline candidate) without modifying call sites.
+ *
+ * @example
+ * ```ts
+ * const eta = etaResolverService.resolve(rawEta, [quoteExpiry]);
+ * ```
+ */
+export class EtaResolverService {
+    private readonly clock: Clock;
+
+    constructor(clock: Clock = defaultClock) {
+        this.clock = clock;
+    }
+
+    /**
+     * @param providerEta - ETA reported by the provider (seconds), if any.
+     * @param deadlines - Ordered list of unix-second deadline candidates;
+     *     the first defined entry is used as fallback.
+     * @returns The ETA in seconds, or `undefined` when no candidate applies.
+     */
+    public resolve(
+        providerEta: number | undefined,
+        deadlines: ReadonlyArray<number | undefined> = [],
+    ): number | undefined {
+        if (typeof providerEta === "number" && providerEta >= 0) {
+            return providerEta;
+        }
+
+        for (const deadline of deadlines) {
+            if (typeof deadline === "number") {
+                return Math.max(0, deadline - this.clock());
+            }
+        }
+
+        return undefined;
+    }
+}
+
+/** Default singleton used by adapters (Spring `@Component` style). */
+export const etaResolverService = new EtaResolverService();

--- a/packages/cross-chain/src/core/services/etaResolver.ts
+++ b/packages/cross-chain/src/core/services/etaResolver.ts
@@ -16,6 +16,11 @@ const defaultClock: Clock = () => Math.floor(Date.now() / 1000);
  *   2. `max(0, deadline - now)` for the first defined deadline candidate.
  *   3. `undefined` when no information is available.
  *
+ * The result is always a non-negative integer (or `undefined`). Fractional
+ * inputs are floored, since `Quote.eta` is constrained to integer seconds
+ * and at least one upstream API (Relay `details.timeEstimate`) is known to
+ * return values like `2.5`.
+ *
  * Adapters depend on this service so the fallback policy lives in one
  * place and is open for extension (e.g. adding the order's fillDeadline
  * as an extra deadline candidate) without modifying call sites.
@@ -43,12 +48,12 @@ export class EtaResolverService {
         deadlines: ReadonlyArray<number | undefined> = [],
     ): number | undefined {
         if (Number.isFinite(providerEta) && (providerEta as number) >= 0) {
-            return providerEta;
+            return Math.floor(providerEta as number);
         }
 
         for (const deadline of deadlines) {
             if (Number.isFinite(deadline)) {
-                return Math.max(0, (deadline as number) - this.clock());
+                return Math.max(0, Math.floor((deadline as number) - this.clock()));
             }
         }
 

--- a/packages/cross-chain/src/core/services/index.ts
+++ b/packages/cross-chain/src/core/services/index.ts
@@ -10,3 +10,4 @@ export * from "./BaseAssetDiscoveryService.js";
 export * from "./StaticAssetDiscoveryService.js";
 export * from "./CustomApiAssetDiscoveryService.js";
 export * from "./APIPreTracker.js";
+export * from "./etaResolver.js";

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -38,6 +38,7 @@ import {
     bytes32ToAddress,
     CrossChainProvider,
     CustomEventOpenedIntentParserConfig,
+    etaResolverService,
     EventBasedFillWatcherConfig,
     FillEvent,
     FillWatcherConfig,
@@ -267,7 +268,9 @@ export class AcrossProvider extends CrossChainProvider {
                 ],
             },
             quoteId: response.id,
-            eta: response.expectedFillTime,
+            eta: etaResolverService.resolve(response.expectedFillTime, [
+                response.quoteExpiryTimestamp,
+            ]),
             provider: this.providerId,
             partialFill: false,
             failureHandling: "refund-automatic",

--- a/packages/cross-chain/src/protocols/across/schemas.ts
+++ b/packages/cross-chain/src/protocols/across/schemas.ts
@@ -78,7 +78,7 @@ export const AcrossGetQuoteResponseSchema = z.object({
         })
         .optional(),
     swapTx: AcrossSwapTxSchema,
-    expectedFillTime: z.number().optional(),
+    expectedFillTime: z.number().int().nonnegative().optional(),
     quoteExpiryTimestamp: z.number().int().nonnegative().optional(),
 });
 

--- a/packages/cross-chain/src/protocols/across/schemas.ts
+++ b/packages/cross-chain/src/protocols/across/schemas.ts
@@ -78,7 +78,7 @@ export const AcrossGetQuoteResponseSchema = z.object({
         })
         .optional(),
     swapTx: AcrossSwapTxSchema,
-    expectedFillTime: z.number(),
+    expectedFillTime: z.number().optional(),
     quoteExpiryTimestamp: z.number().int().nonnegative().optional(),
 });
 

--- a/packages/cross-chain/src/protocols/across/schemas.ts
+++ b/packages/cross-chain/src/protocols/across/schemas.ts
@@ -79,6 +79,7 @@ export const AcrossGetQuoteResponseSchema = z.object({
         .optional(),
     swapTx: AcrossSwapTxSchema,
     expectedFillTime: z.number(),
+    quoteExpiryTimestamp: z.number().int().nonnegative().optional(),
 });
 
 export const AcrossOIFGetQuoteParamsSchema = z.object({

--- a/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
@@ -7,6 +7,7 @@ import type {
     BungeeQuoteResult,
     BungeeTxData,
 } from "../schemas.js";
+import { etaResolverService } from "../../../internal.js";
 import { BungeeTxDataSchema } from "../schemas.js";
 import { adaptFees } from "./quoteFeeAdapter.js";
 
@@ -87,7 +88,7 @@ function adaptAutoRouteQuote(
             ],
         },
         quoteId: autoRoute.quoteId,
-        eta: autoRoute.estimatedTime,
+        eta: etaResolverService.resolve(autoRoute.estimatedTime, [autoRoute.quoteExpiry]),
         partialFill: false,
         failureHandling: "refund-automatic",
         provider: providerId,

--- a/packages/cross-chain/src/protocols/lifi-intents/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/lifi-intents/adapters/quoteResponseAdapter.ts
@@ -12,7 +12,8 @@ import { hexToBytes } from "viem";
 
 import type { Quote } from "../../../core/schemas/quote.js";
 import type { LifiIntentsQuoteEntry } from "../schemas.js";
-import { adaptOifOrder, fromInteropAccountId } from "../../../internal.js";
+import { adaptOifOrder, etaResolverService, fromInteropAccountId } from "../../../internal.js";
+import { extractLifiIntentExpiry } from "../utils/calldataDecoder.js";
 
 function toErc7930(chainString: string, address: string): string {
     const chainId = Number(chainString.split(":")[1]);
@@ -59,6 +60,11 @@ export function adaptQuoteResponse(entry: LifiIntentsQuoteEntry, providerId: str
     const inputChainId = Number(inputEntry.chain.split(":")[1]);
     const outputChainId = Number(outputEntry.chain.split(":")[1]);
 
+    const calldataExpiry =
+        entry.order?.openIntentTx?.data !== undefined
+            ? extractLifiIntentExpiry(entry.order.openIntentTx.data as `0x${string}`)
+            : undefined;
+
     return {
         order: sdkOrder,
         preview: {
@@ -81,6 +87,7 @@ export function adaptQuoteResponse(entry: LifiIntentsQuoteEntry, providerId: str
         },
         quoteId: entry.quoteId,
         validUntil: entry.validUntil,
+        eta: etaResolverService.resolve(undefined, [entry.validUntil ?? calldataExpiry]),
         provider: providerId,
         failureHandling: entry.failureHandling,
         partialFill: entry.partialFill,

--- a/packages/cross-chain/src/protocols/lifi-intents/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/lifi-intents/adapters/quoteResponseAdapter.ts
@@ -60,10 +60,7 @@ export function adaptQuoteResponse(entry: LifiIntentsQuoteEntry, providerId: str
     const inputChainId = Number(inputEntry.chain.split(":")[1]);
     const outputChainId = Number(outputEntry.chain.split(":")[1]);
 
-    const calldataExpiry =
-        entry.order?.openIntentTx?.data !== undefined
-            ? extractLifiIntentExpiry(entry.order.openIntentTx.data as `0x${string}`)
-            : undefined;
+    const calldataExpiry = extractLifiIntentExpiry(entry.order?.openIntentTx?.data);
 
     return {
         order: sdkOrder,

--- a/packages/cross-chain/src/protocols/lifi-intents/utils/calldataDecoder.ts
+++ b/packages/cross-chain/src/protocols/lifi-intents/utils/calldataDecoder.ts
@@ -1,5 +1,4 @@
-import type { Hex } from "viem";
-import { hexToBigInt, slice } from "viem";
+import { bytesToHex, hexToBigInt, isHex, slice } from "viem";
 
 /**
  * Byte layout observed across multiple live LiFi `oif-user-open-v0`
@@ -31,14 +30,23 @@ const MAX_PLAUSIBLE_TIMESTAMP = 7_000_000_000;
  * Best-effort extraction of the intent expiry from a LiFi
  * `oif-user-open-v0` open-intent calldata.
  *
- * @returns the expiry unix-second timestamp, or `undefined` when the
- *   calldata does not match the expected layout.
+ * Accepts the calldata as either a hex string, raw bytes, or `undefined`
+ * (so callers can pass `entry.order?.openIntentTx?.data` directly without
+ * a guard). Returns `undefined` for any input that is not a valid hex
+ * string of the expected shape.
  */
-export function extractLifiIntentExpiry(calldata: Hex | Uint8Array): number | undefined {
+export function extractLifiIntentExpiry(
+    calldata: string | Uint8Array | undefined,
+): number | undefined {
+    if (calldata === undefined) return undefined;
+
     try {
         const hex = typeof calldata === "string" ? calldata : bytesToHex(calldata);
+        if (!isHex(hex)) return undefined;
+
         const word = slice(hex, EXPIRY_BYTE_OFFSET, EXPIRY_BYTE_END);
         const value = Number(hexToBigInt(word));
+
         if (value < MIN_PLAUSIBLE_TIMESTAMP || value > MAX_PLAUSIBLE_TIMESTAMP) {
             return undefined;
         }
@@ -46,12 +54,4 @@ export function extractLifiIntentExpiry(calldata: Hex | Uint8Array): number | un
     } catch {
         return undefined;
     }
-}
-
-function bytesToHex(bytes: Uint8Array): Hex {
-    let hex = "0x";
-    for (const byte of bytes) {
-        hex += byte.toString(16).padStart(2, "0");
-    }
-    return hex as Hex;
 }

--- a/packages/cross-chain/src/protocols/lifi-intents/utils/calldataDecoder.ts
+++ b/packages/cross-chain/src/protocols/lifi-intents/utils/calldataDecoder.ts
@@ -1,0 +1,57 @@
+import type { Hex } from "viem";
+import { hexToBigInt, slice } from "viem";
+
+/**
+ * Byte layout observed across multiple live LiFi `oif-user-open-v0`
+ * intents (selector `0x7515fd56`):
+ *
+ *   [0..3]      function selector
+ *   [4..35]     ABI offset header (`0x20`)
+ *   [36..67]    user address
+ *   [68..99]    nonce
+ *   [100..131]  origin chainId
+ *   [132..163]  intent expiry  (unix-second timestamp)   ← what we extract
+ *   [164..195]  validAfter / openedAt (unix-second timestamp)
+ *   ...
+ *
+ * The format is not part of the OIF spec — the spec leaves
+ * `openIntentTx.data` opaque to the SDK. We extract the field by offset
+ * with a strict plausibility check, and fall back to `undefined` on any
+ * unexpected shape so callers can degrade gracefully.
+ */
+const EXPIRY_BYTE_OFFSET = 132;
+const EXPIRY_BYTE_END = 164;
+
+/** Minimum plausible unix-second timestamp (year 2001). */
+const MIN_PLAUSIBLE_TIMESTAMP = 1_000_000_000;
+/** Maximum plausible unix-second timestamp (year 2191). */
+const MAX_PLAUSIBLE_TIMESTAMP = 7_000_000_000;
+
+/**
+ * Best-effort extraction of the intent expiry from a LiFi
+ * `oif-user-open-v0` open-intent calldata.
+ *
+ * @returns the expiry unix-second timestamp, or `undefined` when the
+ *   calldata does not match the expected layout.
+ */
+export function extractLifiIntentExpiry(calldata: Hex | Uint8Array): number | undefined {
+    try {
+        const hex = typeof calldata === "string" ? calldata : bytesToHex(calldata);
+        const word = slice(hex, EXPIRY_BYTE_OFFSET, EXPIRY_BYTE_END);
+        const value = Number(hexToBigInt(word));
+        if (value < MIN_PLAUSIBLE_TIMESTAMP || value > MAX_PLAUSIBLE_TIMESTAMP) {
+            return undefined;
+        }
+        return value;
+    } catch {
+        return undefined;
+    }
+}
+
+function bytesToHex(bytes: Uint8Array): Hex {
+    let hex = "0x";
+    for (const byte of bytes) {
+        hex += byte.toString(16).padStart(2, "0");
+    }
+    return hex as Hex;
+}

--- a/packages/cross-chain/src/protocols/oif/adapters/quoteAdapter.ts
+++ b/packages/cross-chain/src/protocols/oif/adapters/quoteAdapter.ts
@@ -11,6 +11,7 @@ import type { Address } from "viem";
 import type { ProviderQuote } from "../../../core/interfaces/quotes.interface.js";
 import type { Order } from "../../../core/schemas/order.js";
 import type { Quote, QuotePreviewEntry } from "../../../core/schemas/quote.js";
+import { etaResolverService } from "../../../core/services/etaResolver.js";
 import { toInteropAccountId } from "../../../core/utils/interopAccountId.js";
 import { adaptOifOrder } from "./orderAdapter.js";
 import { extractPermit2Allowances } from "./permit2AllowanceExtractor.js";
@@ -58,7 +59,7 @@ export function adaptQuote(providerQuote: ProviderQuote): Quote {
         order,
         preview,
         validUntil: providerQuote.validUntil,
-        eta: providerQuote.eta,
+        eta: etaResolverService.resolve(providerQuote.eta, [providerQuote.validUntil]),
         provider: providerQuote.provider ?? "",
         quoteId: providerQuote.quoteId,
         failureHandling: providerQuote.failureHandling as string | undefined,

--- a/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
@@ -4,7 +4,7 @@ import type { OrderChecks } from "../../../core/schemas/order.js";
 import type { Quote } from "../../../core/schemas/quote.js";
 import type { QuoteRequest, Step } from "../../../internal.js";
 import type { RelayQuoteResponse, RelayQuoteStep, RelaySignatureStep } from "../schemas.js";
-import { ProviderGetQuoteFailure } from "../../../internal.js";
+import { etaResolverService, ProviderGetQuoteFailure } from "../../../internal.js";
 import { adaptFees } from "./quoteFeeAdapter.js";
 
 /**
@@ -97,7 +97,9 @@ export function adaptQuote(
             ],
         },
         quoteId: response.protocol?.v2?.orderId,
-        eta: response.details?.timeEstimate,
+        eta: etaResolverService.resolve(response.details?.timeEstimate, [
+            response.protocol?.v2?.orderData?.output?.deadline,
+        ]),
         partialFill: false,
         failureHandling: "refund-automatic",
         provider: providerId,

--- a/packages/cross-chain/src/protocols/relay/schemas.ts
+++ b/packages/cross-chain/src/protocols/relay/schemas.ts
@@ -286,10 +286,22 @@ const RelayDetailsSchema = z.object({
         .optional(),
 });
 
+/** Partial shape for the v2 order data; we only model the fields we read. */
+const RelayOrderDataSchema = z
+    .object({
+        output: z
+            .object({
+                deadline: z.number().int().nonnegative().optional(),
+            })
+            .passthrough()
+            .optional(),
+    })
+    .passthrough();
+
 /** Schema for the protocol-specific v2 order data. */
 const RelayProtocolV2Schema = z.object({
     orderId: z.string().optional(),
-    orderData: z.unknown().optional(),
+    orderData: RelayOrderDataSchema.optional(),
     paymentDetails: z
         .object({
             chainId: z.string().optional(),

--- a/packages/cross-chain/test/adapters/lifiIntentsQuoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/adapters/lifiIntentsQuoteResponseAdapter.spec.ts
@@ -48,6 +48,14 @@ describe("LI.FI Intents adaptQuoteResponse", () => {
         expect(quote.preview.outputs[0]!.amount).toBe("9968269");
     });
 
+    it("derives eta from validUntil when the LiFi response omits an explicit ETA", () => {
+        const entry = getMockedLifiQuoteResponse().quotes[0]!;
+        const quote = adaptQuoteResponse(entry, PROVIDER_ID);
+
+        expect(quote.eta).toBeGreaterThan(0);
+        expect(quote.eta).toBeLessThanOrEqual(600);
+    });
+
     it("preserves metadata fields", () => {
         const entry = getMockedLifiQuoteResponse().quotes[0]!;
         const quote = adaptQuoteResponse(entry, PROVIDER_ID);

--- a/packages/cross-chain/test/adapters/quoteAdapter.spec.ts
+++ b/packages/cross-chain/test/adapters/quoteAdapter.spec.ts
@@ -103,6 +103,17 @@ describe("quoteAdapter", () => {
         expect(result.eta).toBe(30);
     });
 
+    it("falls back to validUntil when the provider does not return an eta", () => {
+        const quote = createMockProviderQuote();
+        quote.eta = undefined;
+        quote.validUntil = Math.floor(Date.now() / 1000) + 120;
+
+        const result = adaptQuote(quote);
+
+        expect(result.eta).toBeGreaterThan(0);
+        expect(result.eta).toBeLessThanOrEqual(120);
+    });
+
     it("defaults amount to '0' when undefined", () => {
         const quote = createMockProviderQuote();
         quote.preview.inputs[0]!.amount = undefined as unknown as string;

--- a/packages/cross-chain/test/core/services/etaResolver.spec.ts
+++ b/packages/cross-chain/test/core/services/etaResolver.spec.ts
@@ -33,6 +33,17 @@ describe("EtaResolverService", () => {
         expect(service.resolve(-1, [NOW + 200])).toBe(200);
     });
 
+    it("rejects NaN inputs and falls through cleanly", () => {
+        expect(service.resolve(NaN, [NOW + 200])).toBe(200);
+        expect(service.resolve(undefined, [NaN, NOW + 200])).toBe(200);
+        expect(service.resolve(NaN, [NaN])).toBeUndefined();
+    });
+
+    it("rejects Infinity inputs", () => {
+        expect(service.resolve(Infinity, [NOW + 200])).toBe(200);
+        expect(service.resolve(undefined, [Infinity, NOW + 200])).toBe(200);
+    });
+
     it("uses the injected clock for deterministic computations", () => {
         const customClock = (): number => 2_000_000_000;
         const customService = new EtaResolverService(customClock);

--- a/packages/cross-chain/test/core/services/etaResolver.spec.ts
+++ b/packages/cross-chain/test/core/services/etaResolver.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { EtaResolverService } from "../../../src/core/services/etaResolver.js";
+
+const NOW = 1_700_000_000;
+const fixedClock = (): number => NOW;
+
+describe("EtaResolverService", () => {
+    const service = new EtaResolverService(fixedClock);
+
+    it("returns the provider eta when defined", () => {
+        expect(service.resolve(120, [NOW + 600])).toBe(120);
+    });
+
+    it("treats provider eta of 0 as a valid instant fill", () => {
+        expect(service.resolve(0, [NOW + 600])).toBe(0);
+    });
+
+    it("falls back to the first defined deadline when provider eta is missing", () => {
+        expect(service.resolve(undefined, [undefined, NOW + 300])).toBe(300);
+    });
+
+    it("clamps deadlines in the past to 0", () => {
+        expect(service.resolve(undefined, [NOW - 100])).toBe(0);
+    });
+
+    it("returns undefined when no provider eta and no deadlines are available", () => {
+        expect(service.resolve(undefined, [])).toBeUndefined();
+        expect(service.resolve(undefined, [undefined, undefined])).toBeUndefined();
+    });
+
+    it("ignores negative provider eta and falls through to deadlines", () => {
+        expect(service.resolve(-1, [NOW + 200])).toBe(200);
+    });
+
+    it("uses the injected clock for deterministic computations", () => {
+        const customClock = (): number => 2_000_000_000;
+        const customService = new EtaResolverService(customClock);
+        expect(customService.resolve(undefined, [2_000_000_500])).toBe(500);
+    });
+
+    it("defaults to the wall clock when none is provided", () => {
+        const defaultService = new EtaResolverService();
+        const futureDeadline = Math.floor(Date.now() / 1000) + 1000;
+        const result = defaultService.resolve(undefined, [futureDeadline]);
+        expect(result).toBeGreaterThan(0);
+        expect(result).toBeLessThanOrEqual(1000);
+    });
+});

--- a/packages/cross-chain/test/core/services/etaResolver.spec.ts
+++ b/packages/cross-chain/test/core/services/etaResolver.spec.ts
@@ -44,6 +44,16 @@ describe("EtaResolverService", () => {
         expect(service.resolve(undefined, [Infinity, NOW + 200])).toBe(200);
     });
 
+    it("floors fractional provider eta to an integer", () => {
+        // Real case: Relay's `details.timeEstimate` returns 2.5 for some routes.
+        expect(service.resolve(2.5, [])).toBe(2);
+        expect(service.resolve(0.9, [])).toBe(0);
+    });
+
+    it("floors fractional deadline diffs", () => {
+        expect(service.resolve(undefined, [NOW + 0.7])).toBe(0);
+    });
+
     it("uses the injected clock for deterministic computations", () => {
         const customClock = (): number => 2_000_000_000;
         const customService = new EtaResolverService(customClock);

--- a/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
@@ -228,6 +228,13 @@ describe("adaptQuotes", () => {
         expect(quote!.failureHandling).toBe("refund-automatic");
     });
 
+    it("propagates eta from the auto route's estimatedTime", () => {
+        const response = buildBungeeQuoteResponse();
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+
+        expect(quote!.eta).toBe(30);
+    });
+
     it("deduplicates autoRoute and autoRoutes by quoteId", () => {
         const response = buildBungeeQuoteResponse();
         (response.result as Record<string, unknown>).autoRoutes = [

--- a/packages/cross-chain/test/protocols/lifi-intents/calldataDecoder.spec.ts
+++ b/packages/cross-chain/test/protocols/lifi-intents/calldataDecoder.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { extractLifiIntentExpiry } from "../../../src/protocols/lifi-intents/utils/calldataDecoder.js";
+
+const LIVE_CALLDATA =
+    "0x7515fd56" +
+    "0000000000000000000000000000000000000000000000000000000000000020" +
+    "0000000000000000000000006f1be137988e6e860f02e7d4e4d3c55869948daa" +
+    "00000000000000000000000000000000000000000000000000000000 2b282a0a".replace(/\s/g, "") +
+    "0000000000000000000000000000000000000000000000000000000000002105" +
+    "0000000000000000000000000000000000000000000000000000000069f4cbe3" +
+    "0000000000000000000000000000000000000000000000000000000069f24503" +
+    "0000000000000000000000000000003e06000007a224aee90052fa6bb46d43c9" +
+    "0000000000000000000000000000000000000000000000000000000000000100";
+
+const LIVE_EXPIRY = 0x69f4cbe3; // 1777481443
+
+describe("extractLifiIntentExpiry", () => {
+    it("extracts the expiry timestamp from real LiFi open-intent calldata", () => {
+        expect(extractLifiIntentExpiry(LIVE_CALLDATA as `0x${string}`)).toBe(LIVE_EXPIRY);
+    });
+
+    it("accepts Uint8Array input as well as hex strings", () => {
+        const bytes = new Uint8Array(
+            LIVE_CALLDATA.slice(2)
+                .match(/.{2}/g)!
+                .map((b) => parseInt(b, 16)),
+        );
+        expect(extractLifiIntentExpiry(bytes)).toBe(LIVE_EXPIRY);
+    });
+
+    it("returns undefined when the calldata is shorter than the expected layout", () => {
+        expect(extractLifiIntentExpiry("0x1234" as `0x${string}`)).toBeUndefined();
+    });
+
+    it("returns undefined when the decoded value is implausible", () => {
+        // Same prefix but with the expiry word zeroed out
+        const bogus =
+            "0x7515fd56" +
+            "0000000000000000000000000000000000000000000000000000000000000020" +
+            "0000000000000000000000006f1be137988e6e860f02e7d4e4d3c55869948daa" +
+            "0000000000000000000000000000000000000000000000000000000000000000" +
+            "0000000000000000000000000000000000000000000000000000000000002105" +
+            "0000000000000000000000000000000000000000000000000000000000000000" + // expiry = 0
+            "0000000000000000000000000000000000000000000000000000000000000000";
+        expect(extractLifiIntentExpiry(bogus as `0x${string}`)).toBeUndefined();
+    });
+
+    it("returns undefined for malformed hex", () => {
+        expect(extractLifiIntentExpiry("not-hex" as `0x${string}`)).toBeUndefined();
+    });
+});

--- a/packages/cross-chain/test/protocols/lifi-intents/calldataDecoder.spec.ts
+++ b/packages/cross-chain/test/protocols/lifi-intents/calldataDecoder.spec.ts
@@ -17,7 +17,7 @@ const LIVE_EXPIRY = 0x69f4cbe3; // 1777481443
 
 describe("extractLifiIntentExpiry", () => {
     it("extracts the expiry timestamp from real LiFi open-intent calldata", () => {
-        expect(extractLifiIntentExpiry(LIVE_CALLDATA as `0x${string}`)).toBe(LIVE_EXPIRY);
+        expect(extractLifiIntentExpiry(LIVE_CALLDATA)).toBe(LIVE_EXPIRY);
     });
 
     it("accepts Uint8Array input as well as hex strings", () => {
@@ -29,8 +29,12 @@ describe("extractLifiIntentExpiry", () => {
         expect(extractLifiIntentExpiry(bytes)).toBe(LIVE_EXPIRY);
     });
 
+    it("returns undefined for undefined input", () => {
+        expect(extractLifiIntentExpiry(undefined)).toBeUndefined();
+    });
+
     it("returns undefined when the calldata is shorter than the expected layout", () => {
-        expect(extractLifiIntentExpiry("0x1234" as `0x${string}`)).toBeUndefined();
+        expect(extractLifiIntentExpiry("0x1234")).toBeUndefined();
     });
 
     it("returns undefined when the decoded value is implausible", () => {
@@ -43,10 +47,10 @@ describe("extractLifiIntentExpiry", () => {
             "0000000000000000000000000000000000000000000000000000000000002105" +
             "0000000000000000000000000000000000000000000000000000000000000000" + // expiry = 0
             "0000000000000000000000000000000000000000000000000000000000000000";
-        expect(extractLifiIntentExpiry(bogus as `0x${string}`)).toBeUndefined();
+        expect(extractLifiIntentExpiry(bogus)).toBeUndefined();
     });
 
-    it("returns undefined for malformed hex", () => {
-        expect(extractLifiIntentExpiry("not-hex" as `0x${string}`)).toBeUndefined();
+    it("returns undefined for non-hex strings", () => {
+        expect(extractLifiIntentExpiry("not-hex")).toBeUndefined();
     });
 });


### PR DESCRIPTION
# 🤖 Linear

Closes EFI-889

## Description

Cross-chain quotes now expose `eta` (estimated seconds until fill) for every provider, even when the protocol API does not return one. The fallback derives the value from a deadline candidate already present in the response: quote expiry for Across and Bungee, the order's output deadline for Relay, and the expiry decoded from the open-intent calldata for LiFi Intents.

The rule lives in a single `EtaResolverService`. Adapters depend on it and pass their available deadline candidates as input. The service prefers the provider's own ETA and only falls back when it is missing.

LiFi Intents is the awkward case. Its API does not surface any deadline at quote level, so the SDK reads the expiry word out of the OIF user-open-v0 calldata at the offset observed across multiple live samples. The decoder is defensive: bad input or unexpected layouts return `undefined` instead of throwing.

### Architecture

```mermaid
classDiagram
    direction TB

    class Aggregator

    namespace Providers {
        class AcrossProvider
        class BungeeProvider
        class LifiIntentsProvider
        class OifProvider
        class RelayProvider
    }

    class EtaResolverService {
        +resolve(eta, deadlines)
    }

    class extractLifiIntentExpiry {
        +decode(calldata)
    }

    Aggregator --> AcrossProvider
    Aggregator --> BungeeProvider
    Aggregator --> LifiIntentsProvider
    Aggregator --> OifProvider
    Aggregator --> RelayProvider

    AcrossProvider ..> EtaResolverService
    BungeeProvider ..> EtaResolverService
    LifiIntentsProvider ..> EtaResolverService
    OifProvider ..> EtaResolverService
    RelayProvider ..> EtaResolverService

    LifiIntentsProvider ..> extractLifiIntentExpiry
```

### Changes

- New \`EtaResolverService\` in \`core/services/etaResolver.ts\` plus singleton export
- New calldata decoder in \`protocols/lifi-intents/utils/calldataDecoder.ts\`
- Across schema reads \`quoteExpiryTimestamp\`; provider feeds it to the resolver
- Relay schema reads \`protocol.v2.orderData.output.deadline\`; adapter feeds it to the resolver
- Bungee adapter passes \`quoteExpiry\` to the resolver
- OIF adapter passes \`validUntil\` to the resolver
- Unit tests for both new modules and fallback paths in the existing protocol specs

### Test plan

The regression case I checked by hand was a USDC to USDC swap routed through LiFi Intents. Before this change the LiFi quote came back with no ETA at all, while Across and Relay did show one in the same run. After the change the LiFi quote exposes an ETA derived from the calldata expiry, so the UI no longer shows a blank field next to that route.

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [x] If it is a core feature, I have included comprehensive tests.