### PR TITLE
feat(ui): re-enable Bungee provider in examples

### DIFF
--- a/examples/ui/app/cross-chain/services/sdk.ts
+++ b/examples/ui/app/cross-chain/services/sdk.ts
@@ -6,8 +6,7 @@ import {
   OrderTrackerFactory,
   LIFI_INTENTS_ORDER_SERVER_URL,
   LIFI_INTENTS_ORDER_SERVER_DEV_URL,
-  // TODO: enable after release
-  // BungeeApiTier,
+  BungeeApiTier,
   type Aggregator,
   type CrossChainProvider,
 } from '@wonderland/interop-cross-chain';
@@ -45,12 +44,11 @@ const PROVIDER_CONFIGS: ProviderConfig[] = [
     displayName: 'LI.FI',
     supportsBuildQuote: false,
   },
-  // TODO: enable after release
-  // {
-  //   providerId: 'bungee',
-  //   displayName: 'Bungee',
-  //   supportsBuildQuote: false,
-  // },
+  {
+    providerId: 'bungee',
+    displayName: 'Bungee',
+    supportsBuildQuote: false,
+  },
 ];
 
 export function buildExecutor(isTestnet: boolean): Aggregator {
@@ -78,15 +76,14 @@ export function buildExecutor(isTestnet: boolean): Aggregator {
     }),
   ];
 
-  // TODO: enable after release
-  // if (!isTestnet) {
-  //   providers.push(
-  //     createCrossChainProvider(PROTOCOLS.BUNGEE, {
-  //       tier: BungeeApiTier.Sandbox,
-  //       providerId: 'bungee',
-  //     }),
-  //   );
-  // }
+  if (!isTestnet) {
+    providers.push(
+      createCrossChainProvider(PROTOCOLS.BUNGEE, {
+        tier: BungeeApiTier.Sandbox,
+        providerId: 'bungee',
+      }),
+    );
+  }
 
   return createAggregator({
     providers,


### PR DESCRIPTION
Closes EFI-885

Bungee is in scope for v1, the SDK already exports `BungeeProvider` and `BungeeApiTier`, so the example UI should expose it. Uncomments the import, the `PROVIDER_CONFIGS` entry, and the mainnet-only `createCrossChainProvider(PROTOCOLS.BUNGEE, ...)` push, all gated behind `!isTestnet` (sandbox tier).

## Test plan
- Verified `BungeeApiTier.Sandbox` and `PROTOCOLS.BUNGEE` still match the SDK API.
- `pnpm lint` and `turbo run check-types` clean locally.
- Manual smoke on a Playwright/e2e run with a mainnet build to confirm Bungee shows up in the provider list.