### PR TITLE
feat(cross-chain): expose USD values on quote preview entries

### DIFF
--- a/.changeset/efi-888-quote-preview-usd.md
+++ b/.changeset/efi-888-quote-preview-usd.md
@@ -1,0 +1,10 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Expose USD values on quote preview inputs and outputs
+
+-   `QuotePreviewEntrySchema` now includes an optional `amountUsd` decimal-string field, mirroring the convention of `QuoteFeeEntrySchema.amountUsd`.
+-   Relay adapter populates `amountUsd` from `details.currencyIn.amountUsd` and `details.currencyOut.amountUsd`.
+-   Bungee adapter populates `amountUsd` from `result.input.valueInUsd` and `autoRoute.output.valueInUsd`.
+-   Across, OIF and LIFI-Intents leave the field undefined; their upstream APIs do not surface preview-level USD pricing.

--- a/.changeset/efi-888-quote-preview-usd.md
+++ b/.changeset/efi-888-quote-preview-usd.md
@@ -7,4 +7,3 @@ Expose USD values on quote preview inputs and outputs
 -   `QuotePreviewEntrySchema` now includes an optional `amountUsd` decimal-string field, mirroring the convention of `QuoteFeeEntrySchema.amountUsd`.
 -   Relay adapter populates `amountUsd` from `details.currencyIn.amountUsd` and `details.currencyOut.amountUsd`.
 -   Bungee adapter populates `amountUsd` from `result.input.valueInUsd` and `autoRoute.output.valueInUsd`.
--   Across, OIF and LIFI-Intents leave the field undefined; their upstream APIs do not surface preview-level USD pricing.

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -470,12 +470,19 @@ interface BuildQuoteRequest {
 interface Quote {
     order: Order;
     preview: {
-        inputs: { chainId: number; accountAddress: string; assetAddress: string; amount: string }[];
+        inputs: {
+            chainId: number;
+            accountAddress: string;
+            assetAddress: string;
+            amount: string;
+            amountUsd?: string;
+        }[];
         outputs: {
             chainId: number;
             accountAddress: string;
             assetAddress: string;
             amount: string;
+            amountUsd?: string;
         }[];
     };
     provider: string;

--- a/examples/ui/app/cross-chain/components/QuoteCard.tsx
+++ b/examples/ui/app/cross-chain/components/QuoteCard.tsx
@@ -39,11 +39,13 @@ function ChainPill({ name }: { name: string }) {
 
 function TokenAmount({
   amount,
+  amountUsd,
   symbol,
   chainName,
   variant,
 }: {
   amount: string;
+  amountUsd?: string;
   symbol: string;
   chainName: string;
   variant: 'input' | 'output';
@@ -60,6 +62,7 @@ function TokenAmount({
         <span className={`font-medium ${isOutput ? 'text-sm text-text-primary' : 'text-xs text-text-tertiary'}`}>
           {symbol}
         </span>
+        {amountUsd && <span className='text-[10px] text-text-tertiary tabular-nums'>~{amountUsd}</span>}
       </div>
       <ChainPill name={chainName} />
     </div>
@@ -208,6 +211,7 @@ export function QuoteCard({
         <div className='flex items-center gap-2'>
           <TokenAmount
             amount={formatted.inputAmount}
+            amountUsd={formatted.inputAmountUsd}
             symbol={formatted.inputSymbol}
             chainName={inputChainName}
             variant='input'
@@ -221,6 +225,7 @@ export function QuoteCard({
 
           <TokenAmount
             amount={formatted.outputAmount}
+            amountUsd={formatted.outputAmountUsd}
             symbol={formatted.outputSymbol}
             chainName={outputChainName}
             variant='output'

--- a/examples/ui/app/cross-chain/utils/quoteFormatter.ts
+++ b/examples/ui/app/cross-chain/utils/quoteFormatter.ts
@@ -48,6 +48,8 @@ function parseFees(quote: ExecutableQuote, inputTokenInfo?: { decimals?: number;
 export interface FormattedQuoteData {
   inputAmount: string;
   outputAmount: string;
+  inputAmountUsd?: string;
+  outputAmountUsd?: string;
   inputSymbol: string;
   outputSymbol: string;
   eta: string;
@@ -91,6 +93,9 @@ export function formatQuoteData(
     ? formatAmount(outputPreview.amount, outputTokenInfo?.decimals)
     : NOT_AVAILABLE;
 
+  const inputAmountUsd = inputPreview?.amountUsd ? formatUsdAmount(inputPreview.amountUsd) : undefined;
+  const outputAmountUsd = outputPreview?.amountUsd ? formatUsdAmount(outputPreview.amountUsd) : undefined;
+
   const eta = quote.eta ? formatETA(quote.eta) : NOT_AVAILABLE;
   const effectiveProviderId = quote._providerId || quote.provider || 'unknown';
   const providerDisplayName = getProviderDisplayName(effectiveProviderId);
@@ -114,6 +119,8 @@ export function formatQuoteData(
   return {
     inputAmount,
     outputAmount,
+    inputAmountUsd,
+    outputAmountUsd,
     inputSymbol: inputTokenInfo?.symbol || UNKNOWN_TOKEN_SYMBOL,
     outputSymbol: outputTokenInfo?.symbol || UNKNOWN_TOKEN_SYMBOL,
     eta,

--- a/packages/cross-chain/src/core/schemas/common.ts
+++ b/packages/cross-chain/src/core/schemas/common.ts
@@ -15,3 +15,5 @@ export const amountSchema = z
 export const chainIdSchema = z.number().int().positive().refine(Number.isSafeInteger, {
     message: "chainId must be a safe integer",
 });
+
+export const amountUsdSchema = z.string().optional().describe("USD equivalent as a decimal string");

--- a/packages/cross-chain/src/core/schemas/quote.ts
+++ b/packages/cross-chain/src/core/schemas/quote.ts
@@ -1,7 +1,7 @@
 import type { Hex } from "viem";
 import { z } from "zod";
 
-import { addressString, amountSchema, chainIdSchema } from "./common.js";
+import { addressString, amountSchema, amountUsdSchema, chainIdSchema } from "./common.js";
 import { OrderSchema } from "./order.js";
 
 export const QuotePreviewEntrySchema = z.object({
@@ -9,6 +9,7 @@ export const QuotePreviewEntrySchema = z.object({
     accountAddress: addressString,
     assetAddress: addressString,
     amount: amountSchema,
+    amountUsd: amountUsdSchema,
 });
 
 export const QuotePreviewSchema = z.object({
@@ -21,7 +22,7 @@ export const QuoteFeeEntrySchema = z.object({
     /** Raw fee amount in token smallest units. */
     amount: z.string(),
     /** USD equivalent of the fee (decimal string). */
-    amountUsd: z.string().optional(),
+    amountUsd: amountUsdSchema,
     /** Token metadata for display (symbol, decimals, address). */
     token: z
         .object({

--- a/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
@@ -48,19 +48,6 @@ function collectAutoRoutes(result: BungeeQuoteResult): BungeeAutoRoute[] {
     return routes;
 }
 
-/**
- * Convert a Bungee `valueInUsd` (number) to a plain decimal string.
- *
- * Returns `undefined` for non-finite values (NaN, Infinity) and expands
- * scientific notation that `String(...)` would emit for very small numbers
- * (e.g. `1e-7`) to keep the `amountUsd` decimal-string contract.
- */
-function toUsdString(value: number): string | undefined {
-    if (!Number.isFinite(value)) return undefined;
-    const str = String(value);
-    return str.includes("e") ? value.toFixed(20).replace(/\.?0+$/, "") : str;
-}
-
 /** Adapt a single auto route into an SDK Quote. */
 function adaptAutoRouteQuote(
     response: BungeeQuoteResponse,
@@ -88,7 +75,7 @@ function adaptAutoRouteQuote(
                     accountAddress: result.userAddress,
                     assetAddress: result.input.token.address,
                     amount: result.input.amount,
-                    amountUsd: toUsdString(result.input.valueInUsd),
+                    amountUsd: String(result.input.valueInUsd),
                 },
             ],
             outputs: [
@@ -97,7 +84,7 @@ function adaptAutoRouteQuote(
                     accountAddress: result.receiverAddress,
                     assetAddress: autoRoute.output.token.address,
                     amount: autoRoute.output.amount,
-                    amountUsd: toUsdString(autoRoute.output.valueInUsd),
+                    amountUsd: String(autoRoute.output.valueInUsd),
                 },
             ],
         },

--- a/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
@@ -48,6 +48,19 @@ function collectAutoRoutes(result: BungeeQuoteResult): BungeeAutoRoute[] {
     return routes;
 }
 
+/**
+ * Convert a Bungee `valueInUsd` (number) to a plain decimal string.
+ *
+ * Returns `undefined` for non-finite values (NaN, Infinity) and expands
+ * scientific notation that `String(...)` would emit for very small numbers
+ * (e.g. `1e-7`) to keep the `amountUsd` decimal-string contract.
+ */
+function toUsdString(value: number): string | undefined {
+    if (!Number.isFinite(value)) return undefined;
+    const str = String(value);
+    return str.includes("e") ? value.toFixed(20).replace(/\.?0+$/, "") : str;
+}
+
 /** Adapt a single auto route into an SDK Quote. */
 function adaptAutoRouteQuote(
     response: BungeeQuoteResponse,
@@ -75,7 +88,7 @@ function adaptAutoRouteQuote(
                     accountAddress: result.userAddress,
                     assetAddress: result.input.token.address,
                     amount: result.input.amount,
-                    amountUsd: String(result.input.valueInUsd),
+                    amountUsd: toUsdString(result.input.valueInUsd),
                 },
             ],
             outputs: [
@@ -84,7 +97,7 @@ function adaptAutoRouteQuote(
                     accountAddress: result.receiverAddress,
                     assetAddress: autoRoute.output.token.address,
                     amount: autoRoute.output.amount,
-                    amountUsd: String(autoRoute.output.valueInUsd),
+                    amountUsd: toUsdString(autoRoute.output.valueInUsd),
                 },
             ],
         },

--- a/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
@@ -75,6 +75,7 @@ function adaptAutoRouteQuote(
                     accountAddress: result.userAddress,
                     assetAddress: result.input.token.address,
                     amount: result.input.amount,
+                    amountUsd: String(result.input.valueInUsd),
                 },
             ],
             outputs: [
@@ -83,6 +84,7 @@ function adaptAutoRouteQuote(
                     accountAddress: result.receiverAddress,
                     assetAddress: autoRoute.output.token.address,
                     amount: autoRoute.output.amount,
+                    amountUsd: String(autoRoute.output.valueInUsd),
                 },
             ],
         },

--- a/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
@@ -85,6 +85,7 @@ export function adaptQuote(
                     accountAddress: params.user,
                     assetAddress: currencyIn?.currency.address ?? params.input.assetAddress,
                     amount: currencyIn?.amount ?? params.input.amount ?? "0",
+                    amountUsd: currencyIn?.amountUsd,
                 },
             ],
             outputs: [
@@ -93,6 +94,7 @@ export function adaptQuote(
                     accountAddress: params.output.recipient ?? params.user,
                     assetAddress: currencyOut?.currency.address ?? params.output.assetAddress,
                     amount: currencyOut?.amount ?? params.output.amount ?? "0",
+                    amountUsd: currencyOut?.amountUsd,
                 },
             ],
         },

--- a/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
@@ -201,6 +201,32 @@ describe("adaptQuotes", () => {
         expect(quote!.preview.outputs[0]!.amountUsd).toBe("4.9972825837");
     });
 
+    it("expands scientific notation to a plain decimal string", () => {
+        const response = buildBungeeQuoteResponse();
+        response.result.input.valueInUsd = 1e-7;
+        response.result.autoRoute = buildAutoRoute({
+            output: { ...buildAutoRoute().output, valueInUsd: 1e-10 },
+        });
+
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+
+        expect(quote!.preview.inputs[0]!.amountUsd).toBe("0.0000001");
+        expect(quote!.preview.outputs[0]!.amountUsd).toBe("0.0000000001");
+    });
+
+    it("leaves amountUsd undefined for non-finite valueInUsd", () => {
+        const response = buildBungeeQuoteResponse();
+        response.result.input.valueInUsd = Number.NaN;
+        response.result.autoRoute = buildAutoRoute({
+            output: { ...buildAutoRoute().output, valueInUsd: Number.POSITIVE_INFINITY },
+        });
+
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+
+        expect(quote!.preview.inputs[0]!.amountUsd).toBeUndefined();
+        expect(quote!.preview.outputs[0]!.amountUsd).toBeUndefined();
+    });
+
     it("uses input.amount for allowance required (not approvalData.amount)", () => {
         const response = buildBungeeQuoteResponse();
         const [quote] = adaptQuotes(response as never, PROVIDER_ID);

--- a/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
@@ -180,6 +180,27 @@ describe("adaptQuotes", () => {
         expect(quote!.preview.outputs[0]!.chainId).toBe(10);
     });
 
+    it("maps valueInUsd to preview.amountUsd as decimal string", () => {
+        const response = buildBungeeQuoteResponse();
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+
+        expect(quote!.preview.inputs[0]!.amountUsd).toBe("1800");
+        expect(quote!.preview.outputs[0]!.amountUsd).toBe("999");
+    });
+
+    it("serializes fractional valueInUsd losslessly", () => {
+        const response = buildBungeeQuoteResponse();
+        response.result.input.valueInUsd = 1800.42;
+        response.result.autoRoute = buildAutoRoute({
+            output: { ...buildAutoRoute().output, valueInUsd: 4.9972825837 },
+        });
+
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+
+        expect(quote!.preview.inputs[0]!.amountUsd).toBe("1800.42");
+        expect(quote!.preview.outputs[0]!.amountUsd).toBe("4.9972825837");
+    });
+
     it("uses input.amount for allowance required (not approvalData.amount)", () => {
         const response = buildBungeeQuoteResponse();
         const [quote] = adaptQuotes(response as never, PROVIDER_ID);

--- a/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
@@ -201,32 +201,6 @@ describe("adaptQuotes", () => {
         expect(quote!.preview.outputs[0]!.amountUsd).toBe("4.9972825837");
     });
 
-    it("expands scientific notation to a plain decimal string", () => {
-        const response = buildBungeeQuoteResponse();
-        response.result.input.valueInUsd = 1e-7;
-        response.result.autoRoute = buildAutoRoute({
-            output: { ...buildAutoRoute().output, valueInUsd: 1e-10 },
-        });
-
-        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
-
-        expect(quote!.preview.inputs[0]!.amountUsd).toBe("0.0000001");
-        expect(quote!.preview.outputs[0]!.amountUsd).toBe("0.0000000001");
-    });
-
-    it("leaves amountUsd undefined for non-finite valueInUsd", () => {
-        const response = buildBungeeQuoteResponse();
-        response.result.input.valueInUsd = Number.NaN;
-        response.result.autoRoute = buildAutoRoute({
-            output: { ...buildAutoRoute().output, valueInUsd: Number.POSITIVE_INFINITY },
-        });
-
-        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
-
-        expect(quote!.preview.inputs[0]!.amountUsd).toBeUndefined();
-        expect(quote!.preview.outputs[0]!.amountUsd).toBeUndefined();
-    });
-
     it("uses input.amount for allowance required (not approvalData.amount)", () => {
         const response = buildBungeeQuoteResponse();
         const [quote] = adaptQuotes(response as never, PROVIDER_ID);

--- a/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
@@ -142,6 +142,32 @@ describe("adaptQuote", () => {
         expect(quote.eta).toBeUndefined();
         expect(quote.preview.inputs[0]!.amount).toBe(INPUT_AMOUNT);
         expect(quote.preview.outputs[0]!.amount).toBe("0");
+        expect(quote.preview.inputs[0]!.amountUsd).toBeUndefined();
+        expect(quote.preview.outputs[0]!.amountUsd).toBeUndefined();
+    });
+
+    it("maps amountUsd from details.currencyIn and currencyOut", () => {
+        const baseResponse = makeRelayQuoteResponse();
+        const response: RelayQuoteResponse = {
+            ...baseResponse,
+            details: {
+                ...baseResponse.details!,
+                currencyIn: { ...baseResponse.details!.currencyIn!, amountUsd: "10.50" },
+                currencyOut: { ...baseResponse.details!.currencyOut!, amountUsd: "10.45" },
+            },
+        };
+
+        const quote = adaptQuote(makeQuoteRequest(), response, PROVIDER_ID);
+
+        expect(quote.preview.inputs[0]!.amountUsd).toBe("10.50");
+        expect(quote.preview.outputs[0]!.amountUsd).toBe("10.45");
+    });
+
+    it("leaves amountUsd undefined when raw response omits it", () => {
+        const quote = adaptQuote(makeQuoteRequest(), makeRelayQuoteResponse(), PROVIDER_ID);
+
+        expect(quote.preview.inputs[0]!.amountUsd).toBeUndefined();
+        expect(quote.preview.outputs[0]!.amountUsd).toBeUndefined();
     });
 
     it("handles missing protocol.v2 gracefully", () => {


### PR DESCRIPTION
# 🤖 Linear

Closes EFI-888

## Description

Add an optional `amountUsd` field to `QuotePreviewEntrySchema` so wallets can show route values in USD.

- Relay maps `details.currencyIn.amountUsd` and `details.currencyOut.amountUsd`.
- Bungee converts `result.input.valueInUsd` and `autoRoute.output.valueInUsd` from number to a decimal string.
- New shared `amountUsdSchema` in `core/schemas/common.ts`, reused by `QuoteFeeEntrySchema.amountUsd`.

## Test Plan

Tested in the example UI under `examples/ui` against live Relay and Bungee quotes. The USD value renders next to the input and output amounts as expected.

<img width="698" height="378" alt="Screenshot 2026-04-30 at 10 41 17" src="https://github.com/user-attachments/assets/e5a19a90-9a76-49f1-acf2-1c39383acdfa" />


## Checklist before requesting a review

- [x] Self-reviewed
- [x] Tests added for the Relay and Bungee adapter changes
- [x] Changeset added
- [x] Type-check and lint pass