### PR TITLE
fix(ui): remove WBTC from demo token whitelist

### DIFF
--- a/examples/ui/app/cross-chain/constants/display.ts
+++ b/examples/ui/app/cross-chain/constants/display.ts
@@ -16,7 +16,6 @@ export enum DemoToken {
   USDC = 'USDC',
   USDT = 'USDT',
   DAI = 'DAI',
-  WBTC = 'WBTC',
   cbBTC = 'cbBTC',
   mockUSDC = 'mockUSDC',
 }
@@ -32,6 +31,5 @@ export const DEMO_MAX_AMOUNT: Record<DemoToken, number> = {
   [DemoToken.mockUSDC]: 100,
   [DemoToken.ETH]: 0.03,
   [DemoToken.WETH]: 0.03,
-  [DemoToken.WBTC]: 0.001,
   [DemoToken.cbBTC]: 0.001,
 };

--- a/examples/ui/app/cross-chain/utils/amountValidation.spec.ts
+++ b/examples/ui/app/cross-chain/utils/amountValidation.spec.ts
@@ -76,7 +76,6 @@ describe('exceedsDemoLimit', () => {
   });
 
   it('returns true when amount exceeds max for BTC variants', () => {
-    expect(exceedsDemoLimit('0.002', 'WBTC')).toBe(true);
     expect(exceedsDemoLimit('0.002', 'cbBTC')).toBe(true);
   });
 
@@ -84,7 +83,7 @@ describe('exceedsDemoLimit', () => {
     expect(exceedsDemoLimit('100', 'USDC')).toBe(false);
     expect(exceedsDemoLimit('50', 'USDT')).toBe(false);
     expect(exceedsDemoLimit('0.03', 'ETH')).toBe(false);
-    expect(exceedsDemoLimit('0.001', 'WBTC')).toBe(false);
+    expect(exceedsDemoLimit('0.001', 'cbBTC')).toBe(false);
   });
 
   it('returns false for tokens not in the limit map', () => {


### PR DESCRIPTION
Bungee lists two contracts on Base with `symbol = "WBTC"`: the canonical Coinbase Bridge WBTC (`0x0555…d2B9c`) and an unrelated contract (`0x1cea…9ba5`). Both passed the demo whitelist and rendered as indistinguishable "WBTC" rows in the dropdown — the user had no way to know which one they were selecting, and one of them is not what most people mean by WBTC on Base.

The demo doesn't need WBTC: cbBTC stays as the BTC option. Dropping WBTC from the whitelist filters both contracts out cleanly. The underlying SDK behavior (two distinct contracts, two distinct entries) is correct; this just removes the symbol from the demo's whitelist.

Closes EFI-903