### PR TITLE
feat(cross-chain): expose Quote.fallbackToken for non-atomic routes

### DIFF
--- a/.changeset/quote-fallback-token.md
+++ b/.changeset/quote-fallback-token.md
@@ -1,0 +1,12 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Add `Quote.fallbackToken` so callers can tell whether a route is atomic.
+
+When the field is absent, the quote is atomic: the user receives exactly
+`preview.outputs` or nothing. When present, a step after the bridge fill may
+revert and the user is left holding the token described by the field
+(`chainId`, `accountAddress`, `assetAddress`, `amount`).
+
+Wired up for the Across and Relay providers.

--- a/.changeset/quote-fallback-token.md
+++ b/.changeset/quote-fallback-token.md
@@ -10,3 +10,9 @@ revert and the user is left holding the token described by the field
 (`chainId`, `accountAddress`, `assetAddress`, `amount`).
 
 Wired up for the Across and Relay providers.
+
+The Across response schema also gains optional fields (`crossSwapType`,
+`steps`, `approvalTxns`, `checks`, `refundToken`, `quoteExpiryTimestamp`
+and a richer `fees` shape) so it mirrors the OpenAPI spec at
+https://docs.across.to/api-reference/swap/approval/get and is easier to
+keep in sync going forward.

--- a/examples/ui/app/cross-chain/components/QuoteCard.tsx
+++ b/examples/ui/app/cross-chain/components/QuoteCard.tsx
@@ -5,7 +5,8 @@ import { useChainConfig, useTokenConfig } from '../hooks/useNetworkConfig';
 import { STEP, WALLET_ACTION, type BridgeState } from '../types/execution';
 import { formatQuoteData } from '../utils/quoteFormatter';
 import { Tooltip } from './Tooltip';
-import { SpinnerIcon, CheckIcon, CloseIcon, BoltIcon, ClockIcon, QuestionIcon } from './icons';
+import { SpinnerIcon, CheckIcon, CloseIcon, BoltIcon, ClockIcon, QuestionIcon, WarningIcon } from './icons';
+import type { FormattedFallbackToken } from '../utils/quoteFormatter';
 import type { ExecutableQuote } from '@wonderland/interop-cross-chain';
 
 interface QuoteCardProps {
@@ -34,6 +35,21 @@ function ChainPill({ name }: { name: string }) {
     <span className='inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-surface-secondary/80 text-[10px] font-medium text-text-tertiary leading-none'>
       {name}
     </span>
+  );
+}
+
+function FallbackWarning({ fallback, chainName }: { fallback: FormattedFallbackToken; chainName: string }) {
+  const tooltip = `If the destination call reverts, you'll receive ${fallback.amount} ${fallback.symbol} on ${chainName} instead of the requested output.`;
+  return (
+    <Tooltip content={tooltip} side='top' align='start'>
+      <div className='mt-2 flex items-center gap-1.5 text-[11px] text-warning cursor-help'>
+        <WarningIcon className='w-3 h-3 shrink-0' />
+        <span className='font-medium'>Non-atomic route</span>
+        <span className='text-text-tertiary'>
+          · fallback {fallback.amount} {fallback.symbol} on {chainName}
+        </span>
+      </div>
+    </Tooltip>
   );
 }
 
@@ -102,6 +118,10 @@ export function QuoteCard({
     e.stopPropagation(); // Prevent triggering onSelect
     onExecute?.(quote);
   };
+
+  const fallbackChainName = formatted.fallback
+    ? (getChain(formatted.fallback.chainId)?.name ?? `Chain ${formatted.fallback.chainId}`)
+    : '';
 
   const hasFee = !!formatted.feeTotal && formatted.feeTotal !== '0.0000';
   const hasFeeUsd = !!formatted.feeTotalUsd;
@@ -231,6 +251,8 @@ export function QuoteCard({
             variant='output'
           />
         </div>
+
+        {formatted.fallback && <FallbackWarning fallback={formatted.fallback} chainName={fallbackChainName} />}
 
         {/* Footer: Provider | ETA + Fees | (spacer for execute button) */}
         <div

--- a/examples/ui/app/cross-chain/utils/quoteFormatter.ts
+++ b/examples/ui/app/cross-chain/utils/quoteFormatter.ts
@@ -45,6 +45,12 @@ function parseFees(quote: ExecutableQuote, inputTokenInfo?: { decimals?: number;
   return result;
 }
 
+export interface FormattedFallbackToken {
+  amount: string;
+  symbol: string;
+  chainId: number;
+}
+
 export interface FormattedQuoteData {
   inputAmount: string;
   outputAmount: string;
@@ -65,6 +71,8 @@ export interface FormattedQuoteData {
   hasOriginGas?: boolean; // True if originGas is present and non-zero (even if formatted value rounds to 0)
   gasSimulationFailed?: boolean;
   costCompact?: string; // Compact total cost for mobile (e.g. "<$0.01")
+  /** Present when the route is non-atomic (a destination call may revert). */
+  fallback?: FormattedFallbackToken;
 }
 
 /**
@@ -116,6 +124,8 @@ export function formatQuoteData(
   const totalCost = feeNum + gasNum;
   const costCompact = gasSimulationFailed && totalCost === 0 ? 'gas TBD' : formatUsdAmountCompact(totalCost);
 
+  const fallback = formatFallback(quote, tokenMetadata);
+
   return {
     inputAmount,
     outputAmount,
@@ -136,5 +146,21 @@ export function formatQuoteData(
     hasOriginGas,
     gasSimulationFailed,
     costCompact,
+    fallback,
+  };
+}
+
+function formatFallback(
+  quote: ExecutableQuote,
+  tokenMetadata: Record<number, Record<string, TokenInfo>>,
+): FormattedFallbackToken | undefined {
+  const token = quote.fallbackToken;
+  if (!token) return undefined;
+
+  const info = tokenMetadata[token.chainId]?.[token.assetAddress];
+  return {
+    chainId: token.chainId,
+    amount: formatAmount(token.amount, info?.decimals),
+    symbol: info?.symbol || UNKNOWN_TOKEN_SYMBOL,
   };
 }

--- a/packages/cross-chain/src/core/schemas/quote.ts
+++ b/packages/cross-chain/src/core/schemas/quote.ts
@@ -58,6 +58,7 @@ export const QuoteSchema = z.object({
     quoteId: z.string().optional(),
     failureHandling: z.string().optional(),
     partialFill: z.boolean().optional(),
+    fallbackToken: QuotePreviewEntrySchema.optional(),
     fees: QuoteFeesSchema.optional(),
     tracking: QuoteTrackingSchema.optional(),
     metadata: z.record(z.unknown()).optional(),

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -863,6 +863,7 @@ export class AcrossProvider extends CrossChainProvider {
     private static hasDestinationSwap(response: AcrossGetQuoteResponse): boolean {
         if (response.crossSwapType === "bridgeableToAny") return true;
         if (response.crossSwapType === "anyToAny") return true;
+        if (response.crossSwapType === "bridgeableToBridgeableIndirect") return true;
         return response.steps?.destinationSwap !== undefined;
     }
 }

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -11,7 +11,7 @@ import {
 } from "viem";
 import { ZodError } from "zod";
 
-import type { Quote, QuoteFeeEntry } from "../../core/schemas/quote.js";
+import type { Quote, QuoteFeeEntry, QuotePreviewEntry } from "../../core/schemas/quote.js";
 import type { BuildQuoteRequest, QuoteRequest } from "../../core/schemas/quoteRequest.js";
 import { addressToBytes32 } from "../../core/utils/addressHelpers.js";
 import {
@@ -209,6 +209,8 @@ export class AcrossProvider extends CrossChainProvider {
      * Build an SDK Quote directly from Across API response.
      */
     private toSdkQuote(params: QuoteRequest, response: AcrossGetQuoteResponse): Quote {
+        const fallbackToken = AcrossProvider.extractFallbackToken(params, response);
+
         return {
             order: {
                 steps: [
@@ -271,6 +273,7 @@ export class AcrossProvider extends CrossChainProvider {
             provider: this.providerId,
             partialFill: false,
             failureHandling: "refund-automatic",
+            fallbackToken,
             fees: AcrossProvider.adaptFees(response),
             metadata: {
                 acrossResponse: response,
@@ -738,7 +741,6 @@ export class AcrossProvider extends CrossChainProvider {
 
                 // Note: Across API doesn't provide all fill details
                 // Some fields will have placeholder values
-
                 const event: FillEvent = {
                     fillTxHash: response.fillTxnRef as Hex,
                     blockNumber: 0n, // API doesn't provide block number
@@ -834,5 +836,32 @@ export class AcrossProvider extends CrossChainProvider {
             chainId,
             assets: Array.from(assetsMap.values()),
         }));
+    }
+
+    /**
+     * Returns the bridged token for non-atomic routes, undefined otherwise.
+     * @see https://docs.across.to/api-reference/swap/approval/get
+     */
+    private static extractFallbackToken(
+        params: QuoteRequest,
+        response: AcrossGetQuoteResponse,
+    ): QuotePreviewEntry | undefined {
+        if (!AcrossProvider.hasDestinationSwap(response)) return undefined;
+
+        const bridge = response.steps?.bridge;
+        if (!bridge) return undefined;
+
+        return {
+            chainId: bridge.tokenOut.chainId,
+            accountAddress: params.output.recipient ?? params.user,
+            assetAddress: bridge.tokenOut.address,
+            amount: bridge.outputAmount,
+        };
+    }
+
+    private static hasDestinationSwap(response: AcrossGetQuoteResponse): boolean {
+        if (response.crossSwapType === "bridgeableToAny") return true;
+        if (response.crossSwapType === "anyToAny") return true;
+        return response.steps?.destinationSwap !== undefined;
     }
 }

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -850,7 +850,7 @@ export class AcrossProvider extends CrossChainProvider {
         if (!AcrossProvider.hasDestinationSwap(response)) return undefined;
 
         const bridge = response.steps?.bridge;
-        if (!bridge) return undefined;
+        if (!bridge?.tokenOut || !bridge.outputAmount) return undefined;
 
         return {
             chainId: bridge.tokenOut.chainId,

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -54,6 +54,7 @@ import {
     parseAbiEncodedFields,
     ProviderConfigFailure,
     ProviderGetQuoteFailure,
+    toCanonicalNativeAddress,
     withNativePlaceholder,
 } from "../../internal.js";
 import { decodeAcrossCalldata } from "./utils.js";
@@ -854,7 +855,7 @@ export class AcrossProvider extends CrossChainProvider {
         return {
             chainId: bridge.tokenOut.chainId,
             accountAddress: params.output.recipient ?? params.user,
-            assetAddress: bridge.tokenOut.address,
+            assetAddress: toCanonicalNativeAddress(bridge.tokenOut.address, "eip155"),
             amount: bridge.outputAmount,
         };
     }

--- a/packages/cross-chain/src/protocols/across/schemas.ts
+++ b/packages/cross-chain/src/protocols/across/schemas.ts
@@ -31,8 +31,8 @@ export const AcrossGetQuoteParamsSchema = z.object({
 
 export const TokenSchema = z.object({
     address: HexAddressSchema,
-    chainId: z.number(),
-    decimals: z.number(),
+    chainId: z.number().int(),
+    decimals: z.number().int(),
     symbol: z.string(),
     name: z.string().optional(),
 });
@@ -44,9 +44,112 @@ export const FeeSchema = z.object({
     token: TokenSchema.optional(),
 });
 
+export const AcrossApprovalTxSchema = z.object({
+    chainId: z.number().int(),
+    to: HexAddressSchema,
+    data: z.string().refine((data) => isHex(data), { message: "Invalid hex data" }),
+});
+
+export const AcrossAllowanceCheckSchema = z.object({
+    token: HexAddressSchema,
+    spender: HexAddressSchema,
+    actual: z.string(),
+    expected: z.string(),
+});
+
+export const AcrossBalanceCheckSchema = z.object({
+    token: HexAddressSchema,
+    actual: z.string(),
+    expected: z.string(),
+});
+
+export const AcrossChecksSchema = z.object({
+    allowance: AcrossAllowanceCheckSchema.optional(),
+    balance: AcrossBalanceCheckSchema.optional(),
+});
+
+export const AcrossSwapProviderSchema = z.object({
+    name: z.string(),
+    sources: z.array(z.string()).optional(),
+});
+
+export const AcrossBridgeFeeDetailsSchema = z.object({
+    type: z.string(),
+    relayerCapital: FeeSchema.optional(),
+    destinationGas: FeeSchema.optional(),
+    lp: FeeSchema.optional(),
+});
+
+export const AcrossBridgeFeesSchema = z.object({
+    amount: z.string(),
+    pct: z.string().optional(),
+    token: TokenSchema.optional(),
+    details: AcrossBridgeFeeDetailsSchema.optional(),
+});
+
+export const AcrossOriginSwapStepSchema = z.object({
+    tokenIn: TokenSchema,
+    tokenOut: TokenSchema,
+    inputAmount: z.string(),
+    outputAmount: z.string(),
+    minOutputAmount: z.string().optional(),
+    maxInputAmount: z.string().optional(),
+    swapProvider: AcrossSwapProviderSchema.optional(),
+    slippage: z.number().optional(),
+});
+
+export const AcrossBridgeStepSchema = z.object({
+    inputAmount: z.string(),
+    outputAmount: z.string(),
+    tokenIn: TokenSchema,
+    tokenOut: TokenSchema,
+    fees: AcrossBridgeFeesSchema.optional(),
+    provider: z.string().optional(),
+});
+
+export const AcrossDestinationSwapStepSchema = z.object({
+    tokenIn: TokenSchema,
+    tokenOut: TokenSchema,
+    inputAmount: z.string(),
+    maxInputAmount: z.string().optional(),
+    outputAmount: z.string(),
+    minOutputAmount: z.string().optional(),
+    swapProvider: AcrossSwapProviderSchema.optional(),
+    slippage: z.number().optional(),
+});
+
+export const AcrossStepsSchema = z.object({
+    originSwap: AcrossOriginSwapStepSchema.optional(),
+    bridge: AcrossBridgeStepSchema.optional(),
+    destinationSwap: AcrossDestinationSwapStepSchema.optional(),
+});
+
+export const AcrossTotalFeeDetailsSchema = z.object({
+    type: z.string(),
+    swapImpact: FeeSchema.optional(),
+    maxSwapImpact: FeeSchema.optional(),
+    app: FeeSchema.optional(),
+    bridge: FeeSchema.optional(),
+    bridgeFeeBreakdown: AcrossBridgeFeeDetailsSchema.optional(),
+});
+
+export const AcrossTotalFeeSchema = z.object({
+    amount: z.string().optional(),
+    amountUsd: z.string().optional(),
+    token: TokenSchema.optional(),
+    pct: z.string().optional(),
+    details: AcrossTotalFeeDetailsSchema.optional(),
+});
+
+export const AcrossFeesSchema = z.object({
+    total: AcrossTotalFeeSchema.optional(),
+    totalMax: AcrossTotalFeeSchema.optional(),
+    originGas: FeeSchema.optional(),
+});
+
 export const AcrossSwapTxSchema = z.object({
     simulationSuccess: z.boolean(),
-    chainId: z.number(),
+    chainId: z.number().int(),
     to: HexAddressSchema,
     data: z.string().refine((data) => isHex(data), { message: "Invalid hex data" }),
     value: z.string().optional(),
@@ -55,30 +158,37 @@ export const AcrossSwapTxSchema = z.object({
     maxPriorityFeePerGas: z.string().optional(),
 });
 
+export const AcrossCrossSwapTypeSchema = z.enum([
+    "bridgeableToBridgeable",
+    "anyToBridgeable",
+    "bridgeableToAny",
+    "anyToAny",
+]);
+
+/**
+ * Mirrors the `GET /swap/approval` response. Optional fields stay optional so
+ * the parser does not break when the upstream adds new ones.
+ *
+ * @see https://docs.across.to/api-reference/swap/approval/get
+ */
 export const AcrossGetQuoteResponseSchema = z.object({
     id: z.string(),
+    crossSwapType: AcrossCrossSwapTypeSchema.optional(),
+    amountType: z.string().optional(),
+    approvalTxns: z.array(AcrossApprovalTxSchema).optional(),
+    checks: AcrossChecksSchema.optional(),
+    steps: AcrossStepsSchema.optional(),
     inputToken: TokenSchema,
     outputToken: TokenSchema,
+    refundToken: TokenSchema.optional(),
+    fees: AcrossFeesSchema.optional(),
     inputAmount: z.string(),
+    maxInputAmount: z.string().optional(),
     expectedOutputAmount: z.string(),
     minOutputAmount: z.string(),
-    fees: z
-        .object({
-            total: FeeSchema,
-            maxTotal: FeeSchema.optional(),
-            originGas: FeeSchema.optional(),
-            destinationGas: FeeSchema.optional(),
-            relayerCapital: FeeSchema.optional(),
-            lpFee: FeeSchema.optional(),
-            relayerTotal: FeeSchema.optional(),
-            bridgeFee: FeeSchema.optional(),
-            app: FeeSchema.optional(),
-            swapImpact: FeeSchema.optional(),
-            maxSwapImpact: FeeSchema.optional(),
-        })
-        .optional(),
-    swapTx: AcrossSwapTxSchema,
     expectedFillTime: z.number(),
+    swapTx: AcrossSwapTxSchema,
+    quoteExpiryTimestamp: z.number().optional(),
 });
 
 export const AcrossOIFGetQuoteParamsSchema = z.object({

--- a/packages/cross-chain/src/protocols/across/schemas.ts
+++ b/packages/cross-chain/src/protocols/across/schemas.ts
@@ -124,13 +124,16 @@ export const AcrossStepsSchema = z.object({
     destinationSwap: AcrossDestinationSwapStepSchema.optional(),
 });
 
+export const AcrossBridgeFeeWithBreakdownSchema = FeeSchema.extend({
+    details: AcrossBridgeFeeDetailsSchema.nullish(),
+});
+
 export const AcrossTotalFeeDetailsSchema = z.object({
     type: z.string(),
     swapImpact: FeeSchema.optional(),
     maxSwapImpact: FeeSchema.optional(),
     app: FeeSchema.optional(),
-    bridge: FeeSchema.optional(),
-    bridgeFeeBreakdown: AcrossBridgeFeeDetailsSchema.optional(),
+    bridge: AcrossBridgeFeeWithBreakdownSchema.optional(),
 });
 
 export const AcrossTotalFeeSchema = z.object({
@@ -160,6 +163,7 @@ export const AcrossSwapTxSchema = z.object({
 
 export const AcrossCrossSwapTypeSchema = z.enum([
     "bridgeableToBridgeable",
+    "bridgeableToBridgeableIndirect",
     "anyToBridgeable",
     "bridgeableToAny",
     "anyToAny",

--- a/packages/cross-chain/src/protocols/across/schemas.ts
+++ b/packages/cross-chain/src/protocols/across/schemas.ts
@@ -45,22 +45,25 @@ export const FeeSchema = z.object({
 });
 
 export const AcrossApprovalTxSchema = z.object({
-    chainId: z.number().int(),
-    to: HexAddressSchema,
-    data: z.string().refine((data) => isHex(data), { message: "Invalid hex data" }),
+    chainId: z.number().int().optional(),
+    to: HexAddressSchema.optional(),
+    data: z
+        .string()
+        .refine((data) => isHex(data), { message: "Invalid hex data" })
+        .optional(),
 });
 
 export const AcrossAllowanceCheckSchema = z.object({
-    token: HexAddressSchema,
-    spender: HexAddressSchema,
-    actual: z.string(),
-    expected: z.string(),
+    token: HexAddressSchema.optional(),
+    spender: HexAddressSchema.optional(),
+    actual: z.string().optional(),
+    expected: z.string().optional(),
 });
 
 export const AcrossBalanceCheckSchema = z.object({
-    token: HexAddressSchema,
-    actual: z.string(),
-    expected: z.string(),
+    token: HexAddressSchema.optional(),
+    actual: z.string().optional(),
+    expected: z.string().optional(),
 });
 
 export const AcrossChecksSchema = z.object({
@@ -69,29 +72,29 @@ export const AcrossChecksSchema = z.object({
 });
 
 export const AcrossSwapProviderSchema = z.object({
-    name: z.string(),
+    name: z.string().optional(),
     sources: z.array(z.string()).optional(),
 });
 
 export const AcrossBridgeFeeDetailsSchema = z.object({
-    type: z.string(),
+    type: z.string().optional(),
     relayerCapital: FeeSchema.optional(),
     destinationGas: FeeSchema.optional(),
     lp: FeeSchema.optional(),
 });
 
 export const AcrossBridgeFeesSchema = z.object({
-    amount: z.string(),
+    amount: z.string().optional(),
     pct: z.string().optional(),
     token: TokenSchema.optional(),
     details: AcrossBridgeFeeDetailsSchema.optional(),
 });
 
 export const AcrossOriginSwapStepSchema = z.object({
-    tokenIn: TokenSchema,
-    tokenOut: TokenSchema,
-    inputAmount: z.string(),
-    outputAmount: z.string(),
+    tokenIn: TokenSchema.optional(),
+    tokenOut: TokenSchema.optional(),
+    inputAmount: z.string().optional(),
+    outputAmount: z.string().optional(),
     minOutputAmount: z.string().optional(),
     maxInputAmount: z.string().optional(),
     swapProvider: AcrossSwapProviderSchema.optional(),
@@ -99,20 +102,20 @@ export const AcrossOriginSwapStepSchema = z.object({
 });
 
 export const AcrossBridgeStepSchema = z.object({
-    inputAmount: z.string(),
-    outputAmount: z.string(),
-    tokenIn: TokenSchema,
-    tokenOut: TokenSchema,
+    inputAmount: z.string().optional(),
+    outputAmount: z.string().optional(),
+    tokenIn: TokenSchema.optional(),
+    tokenOut: TokenSchema.optional(),
     fees: AcrossBridgeFeesSchema.optional(),
     provider: z.string().optional(),
 });
 
 export const AcrossDestinationSwapStepSchema = z.object({
-    tokenIn: TokenSchema,
-    tokenOut: TokenSchema,
-    inputAmount: z.string(),
+    tokenIn: TokenSchema.optional(),
+    tokenOut: TokenSchema.optional(),
+    inputAmount: z.string().optional(),
     maxInputAmount: z.string().optional(),
-    outputAmount: z.string(),
+    outputAmount: z.string().optional(),
     minOutputAmount: z.string().optional(),
     swapProvider: AcrossSwapProviderSchema.optional(),
     slippage: z.number().optional(),
@@ -129,7 +132,7 @@ export const AcrossBridgeFeeWithBreakdownSchema = FeeSchema.extend({
 });
 
 export const AcrossTotalFeeDetailsSchema = z.object({
-    type: z.string(),
+    type: z.string().optional(),
     swapImpact: FeeSchema.optional(),
     maxSwapImpact: FeeSchema.optional(),
     app: FeeSchema.optional(),

--- a/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
@@ -1,9 +1,10 @@
 import { decodeFunctionData, erc20Abi } from "viem";
 
 import type { OrderChecks } from "../../../core/schemas/order.js";
-import type { Quote } from "../../../core/schemas/quote.js";
+import type { Quote, QuotePreviewEntry } from "../../../core/schemas/quote.js";
 import type { QuoteRequest, Step } from "../../../internal.js";
 import type { RelayQuoteResponse, RelayQuoteStep, RelaySignatureStep } from "../schemas.js";
+import { toCanonicalNativeAddress } from "../../../core/utils/token.js";
 import { ProviderGetQuoteFailure } from "../../../internal.js";
 import { adaptFees } from "./quoteFeeAdapter.js";
 
@@ -72,6 +73,7 @@ export function adaptQuote(
     const relayRequestId = nonApproveSteps.find((s) => s.requestId)?.requestId;
     const allowances = extractAllowances(approveSteps, params.user);
     const fees = adaptFees(response);
+    const fallbackToken = extractFallbackToken(params, response);
 
     return {
         order: {
@@ -102,10 +104,36 @@ export function adaptQuote(
         eta: response.details?.timeEstimate,
         partialFill: false,
         failureHandling: "refund-automatic",
+        fallbackToken,
         provider: providerId,
         fees,
         tracking: relayRequestId ? { orderId: relayRequestId } : undefined,
         metadata: { relayResponse: response },
+    };
+}
+
+// Skip when refund equals the input — already conveyed by `failureHandling`.
+// @see https://docs.relay.link/references/api/api_core_concepts/refunds
+function extractFallbackToken(
+    params: QuoteRequest,
+    response: RelayQuoteResponse,
+): QuotePreviewEntry | undefined {
+    const refund = response.details?.refundCurrency;
+    if (!refund?.currency) return undefined;
+
+    if (
+        refund.currency.chainId === params.input.chainId &&
+        toCanonicalNativeAddress(refund.currency.address, "eip155") ===
+            toCanonicalNativeAddress(params.input.assetAddress, "eip155")
+    ) {
+        return undefined;
+    }
+
+    return {
+        chainId: refund.currency.chainId,
+        accountAddress: params.output.recipient ?? params.user,
+        assetAddress: refund.currency.address,
+        amount: refund.amount,
     };
 }
 

--- a/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
@@ -132,7 +132,7 @@ function extractFallbackToken(
     return {
         chainId: refund.currency.chainId,
         accountAddress: params.output.recipient ?? params.user,
-        assetAddress: refund.currency.address,
+        assetAddress: toCanonicalNativeAddress(refund.currency.address, "eip155"),
         amount: refund.amount,
     };
 }

--- a/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
@@ -289,6 +289,73 @@ describe("adaptQuote", () => {
         const quote = adaptQuote(makeQuoteRequest(), makeRelayQuoteResponse(), PROVIDER_ID);
         expect(quote.order.checks).toBeUndefined();
     });
+
+    it("leaves fallbackToken undefined when refundCurrency is absent", () => {
+        const quote = adaptQuote(makeQuoteRequest(), makeRelayQuoteResponse(), PROVIDER_ID);
+        expect(quote.fallbackToken).toBeUndefined();
+    });
+
+    it("populates fallbackToken from details.refundCurrency", () => {
+        const refundToken = "0x3333333333333333333333333333333333333333";
+        const refundAmount = "987000";
+        const base = makeRelayQuoteResponse();
+        const response = makeRelayQuoteResponse({
+            details: {
+                ...base.details!,
+                refundCurrency: {
+                    currency: {
+                        chainId: DESTINATION_CHAIN_ID,
+                        address: refundToken,
+                        symbol: "USDC",
+                        name: "USD Coin",
+                        decimals: 6,
+                    },
+                    amount: refundAmount,
+                },
+            },
+        });
+
+        const quote = adaptQuote(
+            makeQuoteRequest({
+                output: {
+                    chainId: DESTINATION_CHAIN_ID,
+                    assetAddress: VALID_ADDRESS,
+                    recipient: RECIPIENT_ADDRESS,
+                },
+            }),
+            response,
+            PROVIDER_ID,
+        );
+
+        expect(quote.fallbackToken).toEqual({
+            chainId: DESTINATION_CHAIN_ID,
+            accountAddress: RECIPIENT_ADDRESS,
+            assetAddress: refundToken,
+            amount: refundAmount,
+        });
+    });
+
+    it("drops fallbackToken when refundCurrency matches the input token and chain", () => {
+        const base = makeRelayQuoteResponse();
+        const response = makeRelayQuoteResponse({
+            details: {
+                ...base.details!,
+                refundCurrency: {
+                    currency: {
+                        chainId: ORIGIN_CHAIN_ID,
+                        address: VALID_ADDRESS.toUpperCase(),
+                        symbol: "USDC",
+                        name: "USD Coin",
+                        decimals: 6,
+                    },
+                    amount: INPUT_AMOUNT,
+                },
+            },
+        });
+
+        const quote = adaptQuote(makeQuoteRequest(), response, PROVIDER_ID);
+        expect(quote.fallbackToken).toBeUndefined();
+    });
 });
 
 describe("adaptRelaySteps", () => {

--- a/packages/cross-chain/test/providers/AcrossProvider.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.spec.ts
@@ -157,6 +157,43 @@ describe("AcrossProvider", () => {
                 amount: "999000000000000000",
             });
         });
+
+        it("returns the intermediate bridge token for bridgeableToBridgeableIndirect routes", async () => {
+            const intermediateToken = "0x036cbd53842c5426634e7929541ec2318f3dcf7e"; // USDC on Base Sepolia (lowercase, canonical)
+
+            vi.mocked(axios.get).mockResolvedValueOnce({
+                status: 200,
+                data: getMockedAcrossApiResponse({
+                    crossSwapType: "bridgeableToBridgeableIndirect",
+                    steps: {
+                        bridge: {
+                            inputAmount: "1000000000000000000",
+                            outputAmount: "999000000",
+                            tokenIn: {
+                                address: TESTNET_TOKENS.WETH_SEPOLIA,
+                                chainId: CHAIN_IDS.SEPOLIA,
+                                decimals: 18,
+                                symbol: "WETH",
+                            },
+                            tokenOut: {
+                                address: intermediateToken,
+                                chainId: CHAIN_IDS.BASE_SEPOLIA,
+                                decimals: 6,
+                                symbol: "USDC",
+                            },
+                        },
+                    },
+                }),
+            });
+
+            const [quote] = await provider.getQuotes(quoteRequest);
+            expect(quote!.fallbackToken).toEqual({
+                chainId: CHAIN_IDS.BASE_SEPOLIA,
+                accountAddress: TEST_ADDRESSES.RECEIVER,
+                assetAddress: intermediateToken,
+                amount: "999000000",
+            });
+        });
     });
 
     describe("getTrackingConfig", () => {

--- a/packages/cross-chain/test/providers/AcrossProvider.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.spec.ts
@@ -132,7 +132,7 @@ describe("AcrossProvider", () => {
         });
 
         it("returns the bridge output token when the route ends in a destination swap", async () => {
-            vi.mocked(axios.get).mockResolvedValueOnce({
+            vi.mocked(httpRequest).mockResolvedValueOnce({
                 status: 200,
                 data: getMockedAcrossApiResponse({
                     crossSwapType: "bridgeableToAny",
@@ -155,6 +155,7 @@ describe("AcrossProvider", () => {
                         },
                     },
                 }),
+                headers: new Headers(),
             });
 
             const [quote] = await provider.getQuotes(quoteRequest);
@@ -169,7 +170,7 @@ describe("AcrossProvider", () => {
         it("returns the intermediate bridge token for bridgeableToBridgeableIndirect routes", async () => {
             const intermediateToken = "0x036cbd53842c5426634e7929541ec2318f3dcf7e"; // USDC on Base Sepolia (lowercase, canonical)
 
-            vi.mocked(axios.get).mockResolvedValueOnce({
+            vi.mocked(httpRequest).mockResolvedValueOnce({
                 status: 200,
                 data: getMockedAcrossApiResponse({
                     crossSwapType: "bridgeableToBridgeableIndirect",
@@ -192,6 +193,7 @@ describe("AcrossProvider", () => {
                         },
                     },
                 }),
+                headers: new Headers(),
             });
 
             const [quote] = await provider.getQuotes(quoteRequest);

--- a/packages/cross-chain/test/providers/AcrossProvider.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.spec.ts
@@ -102,6 +102,63 @@ describe("AcrossProvider", () => {
         });
     });
 
+    describe("fallbackToken", () => {
+        const quoteRequest: QuoteRequest = {
+            user: TEST_ADDRESSES.USER,
+            input: {
+                chainId: CHAIN_IDS.SEPOLIA,
+                assetAddress: TESTNET_TOKENS.WETH_SEPOLIA,
+                amount: TEST_AMOUNTS.ONE_ETHER.toString(),
+            },
+            output: {
+                chainId: CHAIN_IDS.BASE_SEPOLIA,
+                assetAddress: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                recipient: TEST_ADDRESSES.RECEIVER,
+            },
+            swapType: "exact-input",
+        };
+
+        it("is undefined for atomic routes", async () => {
+            const [quote] = await provider.getQuotes(quoteRequest);
+            expect(quote!.fallbackToken).toBeUndefined();
+        });
+
+        it("returns the bridge output token when the route ends in a destination swap", async () => {
+            vi.mocked(axios.get).mockResolvedValueOnce({
+                status: 200,
+                data: getMockedAcrossApiResponse({
+                    crossSwapType: "bridgeableToAny",
+                    steps: {
+                        bridge: {
+                            inputAmount: "1000000000000000000",
+                            outputAmount: "999000000000000000",
+                            tokenIn: {
+                                address: TESTNET_TOKENS.WETH_SEPOLIA,
+                                chainId: CHAIN_IDS.SEPOLIA,
+                                decimals: 18,
+                                symbol: "WETH",
+                            },
+                            tokenOut: {
+                                address: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                                chainId: CHAIN_IDS.BASE_SEPOLIA,
+                                decimals: 18,
+                                symbol: "WETH",
+                            },
+                        },
+                    },
+                }),
+            });
+
+            const [quote] = await provider.getQuotes(quoteRequest);
+            expect(quote!.fallbackToken).toEqual({
+                chainId: CHAIN_IDS.BASE_SEPOLIA,
+                accountAddress: TEST_ADDRESSES.RECEIVER,
+                assetAddress: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                amount: "999000000000000000",
+            });
+        });
+    });
+
     describe("getTrackingConfig", () => {
         it("should return valid tracking configuration for all components", () => {
             const config = provider.getTrackingConfig();

--- a/packages/cross-chain/test/schemas/sdkSchemas.spec.ts
+++ b/packages/cross-chain/test/schemas/sdkSchemas.spec.ts
@@ -388,4 +388,17 @@ describe("QuoteSchema", () => {
         });
         expect(result.success).toBe(false);
     });
+
+    it("accepts a valid fallbackToken", () => {
+        const result = QuoteSchema.safeParse({
+            ...validQuote,
+            fallbackToken: {
+                chainId: 8453,
+                accountAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                assetAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                amount: "999000",
+            },
+        });
+        expect(result.success).toBe(true);
+    });
 });

--- a/packages/cross-chain/test/services/OIFAssetDiscoveryService.spec.ts
+++ b/packages/cross-chain/test/services/OIFAssetDiscoveryService.spec.ts
@@ -102,9 +102,8 @@ describe("OIFAssetDiscoveryService", () => {
         });
 
         it("surfaces name and logoURI when the solver returns them", async () => {
-            vi.mocked(axios.get).mockResolvedValueOnce({
-                status: 200,
-                data: {
+            vi.mocked(httpRequest).mockResolvedValueOnce(
+                mockOk({
                     networks: {
                         "1": {
                             chain_id: 1,
@@ -119,8 +118,8 @@ describe("OIFAssetDiscoveryService", () => {
                             ],
                         },
                     },
-                },
-            });
+                }),
+            );
 
             const result = await service.getSupportedAssets();
             const usdc = result.tokenMetadata[1]?.["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"];
@@ -130,9 +129,8 @@ describe("OIFAssetDiscoveryService", () => {
         });
 
         it("treats null name/logoURI as undefined", async () => {
-            vi.mocked(axios.get).mockResolvedValueOnce({
-                status: 200,
-                data: {
+            vi.mocked(httpRequest).mockResolvedValueOnce(
+                mockOk({
                     networks: {
                         "1": {
                             chain_id: 1,
@@ -147,8 +145,8 @@ describe("OIFAssetDiscoveryService", () => {
                             ],
                         },
                     },
-                },
-            });
+                }),
+            );
 
             const result = await service.getSupportedAssets();
             const usdc = result.tokenMetadata[1]?.["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"];


### PR DESCRIPTION
Closes EFI-905 and EFI-906

## Description

Adds an optional `fallbackToken` field on `Quote` that surfaces the token a recipient ends up holding if a destination call reverts on a non-atomic route. Lets the example UI render a warning instead of silently leaving the user with the bridged token.

- Across populates it from `steps.bridge.tokenOut` when `crossSwapType` is `bridgeableToAny`/`anyToAny` or `steps.destinationSwap` is present.
- Relay populates it from `details.refundCurrency`, and drops it when the refund equals the input (already conveyed by `failureHandling: "refund-automatic"`).
- The example UI shows a small fallback warning on `QuoteCard` when the field is set.

The Across response schema also gains optional fields (`crossSwapType`, `steps`, `approvalTxns`, `checks`, `refundToken`, `quoteExpiryTimestamp` and a richer `fees` shape) so it mirrors the OpenAPI spec at https://docs.across.to/api-reference/swap/approval/get and is easier to keep in sync going forward.

## Architecture

The Aggregator is untouched. Each provider sets the field when its API signals a non-atomic route, and callers read `Quote.fallbackToken` as an optional field on the existing schema.

```mermaid
classDiagram
    direction TB

    class Aggregator {
        +getQuotes(req) Quote[]
    }

    class CrossChainProvider {
        <<abstract>>
        +getQuotes(params) Quote[]
    }

    class AcrossProvider {
        <<modified>>
        +getQuotes(params) Quote[]
        -extractFallbackToken(params, response) QuotePreviewEntry?
        -hasDestinationSwap(response) boolean
    }

    class RelayProvider {
        <<modified>>
        +getQuotes(params) Quote[]
    }

    class Quote {
        <<modified>>
        +fallbackToken?: QuotePreviewEntry
    }

    Aggregator o-- CrossChainProvider
    CrossChainProvider <|-- AcrossProvider
    CrossChainProvider <|-- RelayProvider
    AcrossProvider ..> Quote : produces
    RelayProvider ..> Quote : produces
```

## Changes

- `packages/cross-chain/src/core/schemas/quote.ts`: optional `fallbackToken` on `QuoteSchema`.
- `packages/cross-chain/src/protocols/across/{provider,schemas}.ts`: extended response schema; private static `extractFallbackToken` and `hasDestinationSwap` on `AcrossProvider`.
- `packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts`: file-private `extractFallbackToken` reading `details.refundCurrency`.
- `examples/ui/app/cross-chain/{components/QuoteCard.tsx,utils/quoteFormatter.ts}`: shows a fallback warning when the field is set.
- Changeset added.

## Test plan

Quoted cbBTC against cbBTC across chains via Across in the example UI and confirmed the fallback warning shows up with USDC as the fallback token (the route bridges through USDC on the destination chain before swapping back to cbBTC, so a destination-swap revert leaves the user with USDC).

<img width="666" height="224" alt="Screenshot 2026-05-04 at 16 54 57" src="https://github.com/user-attachments/assets/96eb86a9-2029-4a4b-8d6a-0bfe3b78a438" />

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [x] If it is a core feature, I have included comprehensive tests.