### PR TITLE
feat(cross-chain): surface token name and logoURI on discovered assets

### DIFF
--- a/.changeset/asset-icons-and-names.md
+++ b/.changeset/asset-icons-and-names.md
@@ -1,0 +1,9 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Surface token `name` and `logoURI` on `DiscoveredAssetInfo`
+
+-   `AssetInfo` (and therefore `DiscoveredAssetInfo`) gains optional `name` and `logoURI` fields.
+-   Bungee, Across, LiFi Intents and Relay adapters now propagate every metadata field their endpoints actually return; `logoURI` is `undefined` for providers whose discovery endpoints don't include a logo (LiFi `/routes`, Relay `/chains`).
+-   `toDiscoveredAssets` and `mergeDiscoveredAssets` keep the first non-empty `name` / `logoURI` when the same token shows up under multiple providers, matching how `providers[]` is already merged.

--- a/packages/cross-chain/src/core/schemas/assetDiscovery.ts
+++ b/packages/cross-chain/src/core/schemas/assetDiscovery.ts
@@ -23,6 +23,18 @@ export const assetInfoSchema = z.object({
         .min(0)
         .max(255)
         .describe("Asset decimal precision (e.g., 6 for USDC, 18 for WETH)"),
+    name: z
+        .string()
+        .nullable()
+        .optional()
+        .transform((v) => v ?? undefined)
+        .describe('Full asset name when reported by the solver (e.g., "USD Coin")'),
+    logoURI: z
+        .string()
+        .nullable()
+        .optional()
+        .transform((v) => v ?? undefined)
+        .describe("Asset logo URL when reported by the solver"),
 });
 
 /**

--- a/packages/cross-chain/src/core/types/assetDiscovery.ts
+++ b/packages/cross-chain/src/core/types/assetDiscovery.ts
@@ -16,7 +16,9 @@
  * {
  *   address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Ethereum
  *   symbol: "USDC",
- *   decimals: 6
+ *   decimals: 6,
+ *   name: "USD Coin",
+ *   logoURI: "https://assets.coingecko.com/coins/images/6319/large/USDC.png"
  * }
  */
 export interface AssetInfo {
@@ -26,6 +28,10 @@ export interface AssetInfo {
     symbol: string;
     /** Number of decimal places for the asset */
     decimals: number;
+    /** Full asset name when reported by the provider */
+    name?: string;
+    /** Asset logo URL when reported by the provider */
+    logoURI?: string;
 }
 
 /**

--- a/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
+++ b/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
@@ -51,8 +51,8 @@ export function toDiscoveredAssets(
                     if (!existing.providers.includes(result.providerId)) {
                         existing.providers.push(result.providerId);
                     }
-                    existing.name ??= asset.name;
-                    existing.logoURI ??= asset.logoURI;
+                    existing.name ||= asset.name;
+                    existing.logoURI ||= asset.logoURI;
                 } else {
                     tokenMetadata[chainId][canonicalAddr] = {
                         address: publicAddr,
@@ -112,8 +112,8 @@ export function mergeDiscoveredAssets(sources: DiscoveredAssets[]): DiscoveredAs
                             existing.providers.push(pid);
                         }
                     }
-                    existing.name ??= meta.name;
-                    existing.logoURI ??= meta.logoURI;
+                    existing.name ||= meta.name;
+                    existing.logoURI ||= meta.logoURI;
                 } else {
                     const publicAddr = isNativeAddress(meta.address, "eip155")
                         ? canonical

--- a/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
+++ b/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
@@ -51,11 +51,15 @@ export function toDiscoveredAssets(
                     if (!existing.providers.includes(result.providerId)) {
                         existing.providers.push(result.providerId);
                     }
+                    existing.name ??= asset.name;
+                    existing.logoURI ??= asset.logoURI;
                 } else {
                     tokenMetadata[chainId][canonicalAddr] = {
                         address: publicAddr,
                         symbol: asset.symbol,
                         decimals: asset.decimals,
+                        name: asset.name,
+                        logoURI: asset.logoURI,
                         providers: [result.providerId],
                     };
                 }
@@ -75,7 +79,7 @@ export function toDiscoveredAssets(
  * Used by Aggregator to combine results from multiple providers.
  * Deduplicates tokens by canonical address (native placeholders collapse
  * to the canonical EIP-7528 form); merges `providers` arrays (first-write-wins
- * for symbol/decimals, union for providers).
+ * for symbol/decimals, first non-empty wins for name/logoURI, union for providers).
  *
  * @internal Used by Aggregator - not exported publicly
  * @param sources - Array of DiscoveredAssets to merge
@@ -108,6 +112,8 @@ export function mergeDiscoveredAssets(sources: DiscoveredAssets[]): DiscoveredAs
                             existing.providers.push(pid);
                         }
                     }
+                    existing.name ??= meta.name;
+                    existing.logoURI ??= meta.logoURI;
                 } else {
                     const publicAddr = isNativeAddress(meta.address, "eip155")
                         ? canonical

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -817,6 +817,8 @@ export class AcrossProvider extends CrossChainProvider {
                 address: token.address,
                 symbol: token.symbol,
                 decimals: token.decimals,
+                name: token.name,
+                logoURI: token.logoUrl,
             };
 
             if (!chainMap.has(token.chainId)) {

--- a/packages/cross-chain/src/protocols/bungee/adapters/discoveryAdapter.ts
+++ b/packages/cross-chain/src/protocols/bungee/adapters/discoveryAdapter.ts
@@ -30,5 +30,7 @@ function toAssetInfo(token: BungeeTokenExt): AssetInfo {
         address: token.address,
         symbol: token.symbol,
         decimals: token.decimals,
+        name: token.name,
+        logoURI: token.logoURI ?? undefined,
     };
 }

--- a/packages/cross-chain/src/protocols/lifi-intents/services/parseRoutes.ts
+++ b/packages/cross-chain/src/protocols/lifi-intents/services/parseRoutes.ts
@@ -1,12 +1,9 @@
-import type { NetworkAssets } from "../../../core/types/assetDiscovery.js";
+import type { AssetInfo, NetworkAssets } from "../../../core/types/assetDiscovery.js";
 import { LifiIntentsRoutesResponseSchema } from "../schemas.js";
 
 export function parseRoutesIntoAssets(data: unknown): NetworkAssets[] {
     const { routes } = LifiIntentsRoutesResponseSchema.parse(data);
-    const chainAssetMap = new Map<
-        number,
-        Map<string, { address: string; symbol: string; decimals: number }>
-    >();
+    const chainAssetMap = new Map<number, Map<string, AssetInfo>>();
 
     for (const route of routes) {
         const fromChainId = Number(route.fromChain.chainId);
@@ -22,7 +19,7 @@ export function parseRoutesIntoAssets(data: unknown): NetworkAssets[] {
 }
 
 function addToMap(
-    map: Map<number, Map<string, { address: string; symbol: string; decimals: number }>>,
+    map: Map<number, Map<string, AssetInfo>>,
     chainId: number,
     token: { address: string; symbol: string | null; name: string | null; decimals: number },
 ): void {
@@ -35,6 +32,7 @@ function addToMap(
             address: token.address,
             symbol: token.symbol ?? "",
             decimals: token.decimals,
+            name: token.name ?? undefined,
         });
     }
 }

--- a/packages/cross-chain/src/protocols/relay/adapters/discoveryAdapter.ts
+++ b/packages/cross-chain/src/protocols/relay/adapters/discoveryAdapter.ts
@@ -37,5 +37,6 @@ function toAssetInfo(currency: RelaySolverCurrency): AssetInfo {
         address: currency.address,
         symbol: currency.symbol,
         decimals: currency.decimals,
+        name: currency.name,
     };
 }

--- a/packages/cross-chain/test/protocols/bungee/adapters/discoveryAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/adapters/discoveryAdapter.spec.ts
@@ -37,7 +37,7 @@ describe("parseBungeeTokenListResponse", () => {
         expect(result[0]!.assets[0]!.decimals).toBe(6);
     });
 
-    it("extracts only address, symbol, decimals from tokens", () => {
+    it("surfaces address, symbol, decimals, name and logoURI from tokens", () => {
         const response = buildTokenListResponse({
             "1": [buildTokenEntry({ logoURI: "https://example.com/logo.png", isVerified: true })],
         });
@@ -49,7 +49,19 @@ describe("parseBungeeTokenListResponse", () => {
             address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
             symbol: "USDC",
             decimals: 6,
+            name: "USD Coin",
+            logoURI: "https://example.com/logo.png",
         });
+    });
+
+    it("leaves logoURI undefined when the response omits it", () => {
+        const response = buildTokenListResponse({ "1": [buildTokenEntry()] });
+
+        const result = parseBungeeTokenListResponse(response);
+        const asset = result[0]!.assets[0]!;
+
+        expect(asset.logoURI).toBeUndefined();
+        expect(asset.name).toBe("USD Coin");
     });
 
     it("filters out chains with empty token arrays", () => {

--- a/packages/cross-chain/test/protocols/relay/adapters/discoveryAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/adapters/discoveryAdapter.spec.ts
@@ -152,7 +152,7 @@ describe("parseRelayChainsResponse", () => {
         expect(result[0]!.chainId).toBe(ETHEREUM_CHAIN_ID);
     });
 
-    it("maps only address, symbol, and decimals to AssetInfo", () => {
+    it("maps address, symbol, decimals and name to AssetInfo", () => {
         const result = parseRelayChainsResponse({
             chains: [makeChain(ETHEREUM_CHAIN_ID, "evm", [makeSolverCurrency()])],
         });
@@ -162,6 +162,7 @@ describe("parseRelayChainsResponse", () => {
             address: USDC_ADDRESS,
             symbol: "USDC",
             decimals: 6,
+            name: "USD Coin",
         });
     });
 

--- a/packages/cross-chain/test/providers/AcrossProvider.discovery.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.discovery.spec.ts
@@ -196,6 +196,27 @@ describe("AcrossProvider.discovery", () => {
 
             expect(result).toHaveLength(1);
             expect(result[0]?.assets[0]?.symbol).toBe("USDC");
+            expect(result[0]?.assets[0]?.name).toBeUndefined();
+            expect(result[0]?.assets[0]?.logoURI).toBeUndefined();
+        });
+
+        it("surfaces name and maps logoUrl to logoURI", () => {
+            const mockTokens = [
+                {
+                    chainId: 1,
+                    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    symbol: "USDC",
+                    decimals: 6,
+                    name: "USD Coin",
+                    logoUrl: "https://example.com/usdc.png",
+                },
+            ];
+
+            const result: NetworkAssets[] = parseResponse(mockTokens);
+            const asset = result[0]?.assets[0];
+
+            expect(asset?.name).toBe("USD Coin");
+            expect(asset?.logoURI).toBe("https://example.com/usdc.png");
         });
 
         it("should throw on invalid schema (missing required fields)", () => {

--- a/packages/cross-chain/test/services/LifiIntentsAssetDiscoveryService.spec.ts
+++ b/packages/cross-chain/test/services/LifiIntentsAssetDiscoveryService.spec.ts
@@ -98,6 +98,18 @@ describe("parseRoutesIntoAssets", () => {
         const ethAssets = result.find((n) => n.chainId === 1)!.assets;
         const token = ethAssets.find((a) => a.address.toLowerCase() === addr)!;
         expect(token.symbol).toBe("");
+        expect(token.name).toBeUndefined();
+    });
+
+    it("surfaces token name and leaves logoURI undefined", () => {
+        const result = parseRoutesIntoAssets(mockRoutesResponse);
+
+        const baseAssets = result.find((n) => n.chainId === 8453)!.assets;
+        const usdc = baseAssets.find(
+            (a) => a.address === "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        )!;
+        expect(usdc.name).toBe("USD Coin");
+        expect(usdc.logoURI).toBeUndefined();
     });
 
     it("throws on invalid response schema", () => {

--- a/packages/cross-chain/test/services/OIFAssetDiscoveryService.spec.ts
+++ b/packages/cross-chain/test/services/OIFAssetDiscoveryService.spec.ts
@@ -94,6 +94,62 @@ describe("OIFAssetDiscoveryService", () => {
             expect(axios.get).toHaveBeenCalledTimes(1);
         });
 
+        it("surfaces name and logoURI when the solver returns them", async () => {
+            vi.mocked(axios.get).mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    networks: {
+                        "1": {
+                            chain_id: 1,
+                            assets: [
+                                {
+                                    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                                    symbol: "USDC",
+                                    decimals: 6,
+                                    name: "USD Coin",
+                                    logoURI: "https://logo/usdc.png",
+                                },
+                            ],
+                        },
+                    },
+                },
+            });
+
+            const result = await service.getSupportedAssets();
+            const usdc = result.tokenMetadata[1]?.["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"];
+
+            expect(usdc?.name).toBe("USD Coin");
+            expect(usdc?.logoURI).toBe("https://logo/usdc.png");
+        });
+
+        it("treats null name/logoURI as undefined", async () => {
+            vi.mocked(axios.get).mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    networks: {
+                        "1": {
+                            chain_id: 1,
+                            assets: [
+                                {
+                                    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                                    symbol: "USDC",
+                                    decimals: 6,
+                                    name: null,
+                                    logoURI: null,
+                                },
+                            ],
+                        },
+                    },
+                },
+            });
+
+            const result = await service.getSupportedAssets();
+            const usdc = result.tokenMetadata[1]?.["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"];
+
+            expect(usdc?.name).toBeUndefined();
+            expect(usdc?.logoURI).toBeUndefined();
+        });
+
         it("should filter by chainIds when provided", async () => {
             vi.mocked(axios.get).mockResolvedValueOnce({
                 status: 200,

--- a/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
+++ b/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
@@ -98,6 +98,23 @@ describe("toDiscoveredAssets", () => {
             expect(meta.logoURI).toBe("https://logo/usdc.png");
         });
 
+        it("treats empty strings as missing and lets later providers fill name/logoURI", () => {
+            const out = toDiscoveredAssets([
+                result("provider-1", {
+                    chainId: 1,
+                    assets: [{ ...usdcEth, name: "", logoURI: "" }],
+                }),
+                result("provider-2", {
+                    chainId: 1,
+                    assets: [{ ...usdcEth, name: "USD Coin", logoURI: "https://logo/usdc.png" }],
+                }),
+            ]);
+
+            const meta = out.tokenMetadata[1]![USDC_ETH.toLowerCase()]!;
+            expect(meta.name).toBe("USD Coin");
+            expect(meta.logoURI).toBe("https://logo/usdc.png");
+        });
+
         it("keeps the first non-empty name/logoURI when later providers also report them", () => {
             const out = toDiscoveredAssets([
                 result("provider-1", {
@@ -280,6 +297,25 @@ describe("mergeDiscoveredAssets", () => {
 
         expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.symbol).toBe("USDC-FIRST");
         expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.decimals).toBe(6);
+    });
+
+    it("treats empty strings as missing in cross-source merges", () => {
+        const sourceA = toDiscoveredAssets([
+            result("provider-a", { chainId: 1, assets: [{ ...usdcEth, name: "", logoURI: "" }] }),
+        ]);
+        const sourceB = toDiscoveredAssets([
+            result("provider-b", {
+                chainId: 1,
+                assets: [{ ...usdcEth, name: "USD Coin", logoURI: "https://logo/usdc.png" }],
+            }),
+        ]);
+
+        const merged = mergeDiscoveredAssets([sourceA, sourceB]);
+
+        expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.name).toBe("USD Coin");
+        expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.logoURI).toBe(
+            "https://logo/usdc.png",
+        );
     });
 
     it("fills missing name/logoURI from a later source", () => {

--- a/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
+++ b/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
@@ -84,6 +84,37 @@ describe("toDiscoveredAssets", () => {
             expect(meta.providers).toEqual(["provider-1", "provider-2"]);
         });
 
+        it("fills missing name/logoURI from later providers", () => {
+            const out = toDiscoveredAssets([
+                result("provider-1", { chainId: 1, assets: [usdcEth] }),
+                result("provider-2", {
+                    chainId: 1,
+                    assets: [{ ...usdcEth, name: "USD Coin", logoURI: "https://logo/usdc.png" }],
+                }),
+            ]);
+
+            const meta = out.tokenMetadata[1]![USDC_ETH.toLowerCase()]!;
+            expect(meta.name).toBe("USD Coin");
+            expect(meta.logoURI).toBe("https://logo/usdc.png");
+        });
+
+        it("keeps the first non-empty name/logoURI when later providers also report them", () => {
+            const out = toDiscoveredAssets([
+                result("provider-1", {
+                    chainId: 1,
+                    assets: [{ ...usdcEth, name: "USD Coin", logoURI: "https://logo/first.png" }],
+                }),
+                result("provider-2", {
+                    chainId: 1,
+                    assets: [{ ...usdcEth, name: "Different", logoURI: "https://logo/second.png" }],
+                }),
+            ]);
+
+            const meta = out.tokenMetadata[1]![USDC_ETH.toLowerCase()]!;
+            expect(meta.name).toBe("USD Coin");
+            expect(meta.logoURI).toBe("https://logo/first.png");
+        });
+
         it("not duplicate same provider in providers array", () => {
             const out = toDiscoveredAssets([
                 result(
@@ -249,6 +280,25 @@ describe("mergeDiscoveredAssets", () => {
 
         expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.symbol).toBe("USDC-FIRST");
         expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.decimals).toBe(6);
+    });
+
+    it("fills missing name/logoURI from a later source", () => {
+        const sourceA = toDiscoveredAssets([
+            result("provider-a", { chainId: 1, assets: [usdcEth] }),
+        ]);
+        const sourceB = toDiscoveredAssets([
+            result("provider-b", {
+                chainId: 1,
+                assets: [{ ...usdcEth, name: "USD Coin", logoURI: "https://logo/usdc.png" }],
+            }),
+        ]);
+
+        const merged = mergeDiscoveredAssets([sourceA, sourceB]);
+
+        expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.name).toBe("USD Coin");
+        expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.logoURI).toBe(
+            "https://logo/usdc.png",
+        );
     });
 
     it("not duplicate providers when same provider appears in multiple sources", () => {


### PR DESCRIPTION
## Summary

`DiscoveredAssetInfo` only carried `address`, `symbol`, `decimals`. Bungee and Across already return token logos and full names on their discovery endpoints, but the adapters dropped them, so every consumer (Ambire, future wallets) had to re-fetch the metadata from elsewhere or fall back to symbol-as-name with no icon.

This widens `AssetInfo` with optional `name` and `logoURI`, and makes every existing adapter pass through whatever metadata its endpoint actually returns. No new API calls, no extra dependencies.

## What each provider gives us

Verified by hitting the live endpoints:

| Provider | Endpoint | `name` | `logoURI` |
|---|---|---|---|
| Bungee | `/api/v1/tokens/list` | yes | yes (`logoURI`) |
| Across | `/swap/tokens` | yes | yes (`logoUrl` → `logoURI`) |
| LiFi Intents | `order.li.fi/routes` | yes | not returned |
| Relay | `/chains` (`solverCurrencies`) | yes | not returned |

LiFi and Relay simply don't include a logo on the endpoints we already use. Rather than introduce a second request or a bundled token list, the SDK leaves `logoURI` undefined for those providers and lets consumers decide what placeholder to render. Bungee/Across cover the bulk of the listings, so most discovered tokens end up with a logo regardless.

## Aggregator behavior

`toDiscoveredAssets` and `mergeDiscoveredAssets` already deduplicate by canonical address and union the `providers[]` array. They now also fill `name` and `logoURI` from later providers when the existing entry is missing them (first non-empty wins). So a token reported first by LiFi (no logo) and later by Bungee will end up with Bungee's logo, instead of staying blank.

## Out of scope

- No fallback to external token lists (CoinGecko, trustwallet, etc.). If a provider doesn't return a logo, the field stays undefined.
- `priceUsd` from Across is not surfaced — it's market data, not asset identity, and belongs to a different concern.