### PR TITLE
fix(cross-chain): correct LiFi Intents Open event ABI mismatch

### DIFF
--- a/.changeset/lifi-open-event-abi.md
+++ b/.changeset/lifi-open-event-abi.md
@@ -1,0 +1,9 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Fix LiFi Intents `Open` event ABI mismatch in `LifiOpenedIntentParser`
+
+-   `maxSpent` is now decoded as `uint256[2][]` (token packed as uint256, then amount), matching the layout the LiFi solver actually emits on-chain. Previously typed as `tuple(address,uint256)[]`, which made `decodeEventLog` throw `AbiEventSignatureNotFoundError` and broke `getOrderStatus` / `watchOrder` for any user-open LiFi route.
+-   `LIFI_OPEN_EVENT_SIGNATURE` is now derived from the ABI via `toEventSelector` instead of being hardcoded, so the topic check stays in sync with the ABI.
+-   Added an anvil-fork integration test that runs the parser against a real Base tx and asserts orderId, user, origin chain, and fill instructions decode correctly.

--- a/packages/cross-chain/src/protocols/lifi-intents/services/LifiOpenedIntentParser.ts
+++ b/packages/cross-chain/src/protocols/lifi-intents/services/LifiOpenedIntentParser.ts
@@ -1,5 +1,5 @@
 import type { Address } from "viem";
-import { Chain, decodeEventLog, Hex, PublicClient } from "viem";
+import { Chain, decodeEventLog, Hex, PublicClient, toEventSelector } from "viem";
 
 import type {
     FillInstruction,
@@ -12,12 +12,9 @@ import { bytes32ToAddress, getChainById, OpenedIntentNotFoundError } from "../..
 
 /**
  * LI.FI uses a different Open event signature than the standard ERC-7683.
- * The struct layout differs: (address user, uint256 nonce, uint256 originChainId, ...)
- * vs the standard (address user, uint256 originChainId, uint32 openDeadline, ...).
+ * `maxSpent` is encoded as `uint256[2][]` (token packed as uint256, then amount),
+ * not as `tuple(address,uint256)[]`.
  */
-const LIFI_OPEN_EVENT_SIGNATURE =
-    "0x9ff74bd56d00785b881ef9fa3f03d7b598686a39a9bcff89a6008db588b18a7b" as const;
-
 const LIFI_OPEN_EVENT_ABI = [
     {
         type: "event" as const,
@@ -35,14 +32,7 @@ const LIFI_OPEN_EVENT_ABI = [
                     { name: "openDeadline", type: "uint32" as const },
                     { name: "fillDeadline", type: "uint32" as const },
                     { name: "orderDataType", type: "address" as const },
-                    {
-                        name: "maxSpent",
-                        type: "tuple[]" as const,
-                        components: [
-                            { name: "token", type: "address" as const },
-                            { name: "amount", type: "uint256" as const },
-                        ],
-                    },
+                    { name: "maxSpent", type: "uint256[2][]" as const },
                     {
                         name: "fillInstructions",
                         type: "tuple[]" as const,
@@ -63,6 +53,8 @@ const LIFI_OPEN_EVENT_ABI = [
     },
 ] as const;
 
+const LIFI_OPEN_EVENT_SIGNATURE = toEventSelector(LIFI_OPEN_EVENT_ABI[0]);
+
 interface LifiResolvedOrder {
     user: Address;
     nonce: bigint;
@@ -70,7 +62,7 @@ interface LifiResolvedOrder {
     openDeadline: number;
     fillDeadline: number;
     orderDataType: Address;
-    maxSpent: ReadonlyArray<{ token: Address; amount: bigint }>;
+    maxSpent: ReadonlyArray<readonly [bigint, bigint]>;
     fillInstructions: ReadonlyArray<{
         destinationSettler: Hex;
         outputSettler: Hex;
@@ -121,9 +113,9 @@ export class LifiOpenedIntentParser implements OpenedIntentParser {
 
         const originChainId = Number(resolvedOrder.originChainId);
 
-        const maxSpent: TokenTransfer[] = resolvedOrder.maxSpent.map((entry) => ({
-            token: entry.token as Hex,
-            amount: entry.amount,
+        const maxSpent: TokenTransfer[] = resolvedOrder.maxSpent.map(([tokenAsUint, amount]) => ({
+            token: `0x${tokenAsUint.toString(16).padStart(40, "0")}` as Address,
+            amount,
             recipient: openLog.address as Hex,
             chainId: originChainId,
         }));

--- a/packages/cross-chain/src/protocols/lifi-intents/services/LifiOpenedIntentParser.ts
+++ b/packages/cross-chain/src/protocols/lifi-intents/services/LifiOpenedIntentParser.ts
@@ -1,5 +1,5 @@
 import type { Address } from "viem";
-import { Chain, decodeEventLog, Hex, PublicClient, toEventSelector } from "viem";
+import { Chain, decodeEventLog, Hex, PublicClient, toEventSelector, toHex } from "viem";
 
 import type {
     FillInstruction,
@@ -114,7 +114,8 @@ export class LifiOpenedIntentParser implements OpenedIntentParser {
         const originChainId = Number(resolvedOrder.originChainId);
 
         const maxSpent: TokenTransfer[] = resolvedOrder.maxSpent.map(([tokenAsUint, amount]) => ({
-            token: `0x${tokenAsUint.toString(16).padStart(40, "0")}` as Address,
+            // toHex throws if tokenAsUint exceeds 20 bytes — surface unexpected encoding loudly.
+            token: toHex(tokenAsUint, { size: 20 }) as Address,
             amount,
             recipient: openLog.address as Hex,
             chainId: originChainId,

--- a/packages/cross-chain/test/mocks/mainnetTransactions.ts
+++ b/packages/cross-chain/test/mocks/mainnetTransactions.ts
@@ -6,6 +6,23 @@ import { Address, Hex } from "viem";
  */
 
 /**
+ * Successful LI.FI Intents open on Base (USDC Base -> USDC Arbitrum).
+ *
+ * Used to verify the Open event ABI matches the layout the LiFi solver
+ * actually emits on-chain. The event signature is keccak256 of the canonical
+ * type string with `maxSpent` as `uint256[2][]`, not `tuple(address,uint256)[]`.
+ *
+ * @see https://basescan.org/tx/0xedf9a8237a49212bfb936ea67ad7eb66a20b13a6231c14e2664b9b346b42a370
+ */
+export const LIFI_INTENTS_OPEN_BASE = {
+    txHash: "0xedf9a8237a49212bfb936ea67ad7eb66a20b13a6231c14e2664b9b346b42a370" as Hex,
+    originChainId: 8453, // Base
+    destinationChainId: 42161, // Arbitrum
+    user: "0xd550780b24C8c25ef1471773498dcb63eF415298" as Address,
+    orderId: "0xe71f283a8137f86dbe3c2378ed2537c58326dd35e4f274f92ca3507b9a3e5a0b" as Hex,
+} as const;
+
+/**
  * Across fill where destination swap failed.
  *
  * 0.4 USDT on Optimism -> cbBTC on Arbitrum. The relay filled USDT to the

--- a/packages/cross-chain/test/services/lifiOpenedIntentParser.fork.spec.ts
+++ b/packages/cross-chain/test/services/lifiOpenedIntentParser.fork.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Verifies the LifiOpenedIntentParser decodes the Open event emitted by the
+ * real LiFi solver on-chain. Guards against ABI drift: if the on-chain event
+ * layout (notably `maxSpent` encoded as `uint256[2][]`) ever stops matching
+ * the parser's ABI, this test fails.
+ */
+import { base } from "viem/chains";
+import { describe, expect, it } from "vitest";
+
+import { LifiOpenedIntentParser } from "../../src/protocols/lifi-intents/services/LifiOpenedIntentParser.js";
+import { useAnvilFork } from "../helpers/anvilFork.js";
+import { LIFI_INTENTS_OPEN_BASE } from "../mocks/mainnetTransactions.js";
+
+describe("LifiOpenedIntentParser (anvil fork)", () => {
+    const fork = useAnvilFork(base, 8560);
+
+    it("decodes the Open event on a real Base tx", async () => {
+        if (!fork.current) return;
+
+        const parser = new LifiOpenedIntentParser({
+            clientManager: fork.current.clientManager,
+        });
+
+        const opened = await parser.getOpenedIntent(
+            LIFI_INTENTS_OPEN_BASE.txHash,
+            LIFI_INTENTS_OPEN_BASE.originChainId,
+        );
+
+        expect(opened.orderId).toBe(LIFI_INTENTS_OPEN_BASE.orderId);
+        expect(opened.user).toBe(LIFI_INTENTS_OPEN_BASE.user);
+        expect(opened.originChainId).toBe(LIFI_INTENTS_OPEN_BASE.originChainId);
+        expect(opened.txHash).toBe(LIFI_INTENTS_OPEN_BASE.txHash);
+        expect(opened.maxSpent.length).toBeGreaterThan(0);
+        expect(opened.fillInstructions.length).toBeGreaterThan(0);
+        expect(opened.fillInstructions[0]?.destinationChainId).toBe(
+            LIFI_INTENTS_OPEN_BASE.destinationChainId,
+        );
+    }, 30000);
+});


### PR DESCRIPTION
Closes EFI-914

## Summary

`LifiOpenedIntentParser` was failing on every real LiFi Intents bridge with `AbiEventSignatureNotFoundError`, breaking `getOrderStatus` and `watchOrder` for any user-open route. The Open event's `maxSpent` field is encoded as `uint256[2][]` on-chain, not `tuple(address,uint256)[]`.

- ABI: `maxSpent` switched to `uint256[2][]`. Decode mapping destructures `[tokenAsUint, amount]` and converts the uint256 to an address.
- `LIFI_OPEN_EVENT_SIGNATURE` is now derived via `toEventSelector(LIFI_OPEN_EVENT_ABI[0])` instead of being hardcoded, so the topic check stays in sync with the ABI.
- Added an anvil-fork integration test (`lifiOpenedIntentParser.fork.spec.ts`) that runs the parser against a real Base tx and asserts orderId, user, origin chain, and fill instructions decode correctly. Verified the test fails when the ABI is reverted.

## Test plan

- [x] `pnpm --filter @wonderland/interop-cross-chain test` (993 passed)
- [x] `pnpm --filter @wonderland/interop-cross-chain check-types`
- [x] `pnpm --filter @wonderland/interop-cross-chain lint` (0 errors, only pre-existing warnings)
- [x] `pnpm --filter @wonderland/interop-cross-chain format`
- [x] Bidirectional verification: revert ABI to `tuple(address,uint256)[]`, confirm fork test fails with `OpenedIntentNotFoundError`; restore fix, confirm test passes.