### PR TITLE
fix(cross-chain): replace axios.get leftover with httpRequest in tests

### DIFF
--- a/packages/cross-chain/test/services/OIFAssetDiscoveryService.spec.ts
+++ b/packages/cross-chain/test/services/OIFAssetDiscoveryService.spec.ts
@@ -102,9 +102,8 @@ describe("OIFAssetDiscoveryService", () => {
         });
 
         it("surfaces name and logoURI when the solver returns them", async () => {
-            vi.mocked(axios.get).mockResolvedValueOnce({
-                status: 200,
-                data: {
+            vi.mocked(httpRequest).mockResolvedValueOnce(
+                mockOk({
                     networks: {
                         "1": {
                             chain_id: 1,
@@ -119,8 +118,8 @@ describe("OIFAssetDiscoveryService", () => {
                             ],
                         },
                     },
-                },
-            });
+                }),
+            );
 
             const result = await service.getSupportedAssets();
             const usdc = result.tokenMetadata[1]?.["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"];
@@ -130,9 +129,8 @@ describe("OIFAssetDiscoveryService", () => {
         });
 
         it("treats null name/logoURI as undefined", async () => {
-            vi.mocked(axios.get).mockResolvedValueOnce({
-                status: 200,
-                data: {
+            vi.mocked(httpRequest).mockResolvedValueOnce(
+                mockOk({
                     networks: {
                         "1": {
                             chain_id: 1,
@@ -147,8 +145,8 @@ describe("OIFAssetDiscoveryService", () => {
                             ],
                         },
                     },
-                },
-            });
+                }),
+            );
 
             const result = await service.getSupportedAssets();
             const usdc = result.tokenMetadata[1]?.["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"];


### PR DESCRIPTION
Closes EFI-915

## Summary

The axios → fetch refactor (#294) replaced most `vi.mocked(axios.get)` calls with `vi.mocked(httpRequest)` in the SDK tests, but two cases inside the `name` / `logoURI` tests added later by #296 were missed: `OIFAssetDiscoveryService.spec.ts` lines 105 and 133 still call `vi.mocked(axios.get)` even though `axios` is no longer imported.

ESLint flags those references as `Unsafe member access on an 'error' typed value`, so `pnpm lint` returns 4 errors. Any new PR opened against `dev` fails the `build-lint` check because GitHub merges `dev` into the PR before linting (PR #298 is currently blocked by this).

This swaps both calls to the `vi.mocked(httpRequest).mockResolvedValueOnce(mockOk(...))` pattern already used by every other test in the file. Behavior of the tests is unchanged.

## Test plan

- [x] `pnpm --filter @wonderland/interop-cross-chain lint` (0 errors)
- [x] `pnpm --filter @wonderland/interop-cross-chain test test/services/OIFAssetDiscoveryService.spec.ts` (15 passed)