### PR TITLE
feat(cross-chain): add explorer URLs to OrderTrackingUpdate

### DIFF
--- a/.changeset/order-explorer-urls.md
+++ b/.changeset/order-explorer-urls.md
@@ -1,0 +1,9 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Add explorer URLs to `OrderTrackingUpdate`
+
+-   `OrderTrackingUpdate` now has `explorers?: { tracker?, origin?, destination? }`, plus `originChainId` (required) and `destinationChainId`.
+-   `CrossChainProvider.getOrderExplorers(params)` returns chain block explorer URLs by default. Across and Bungee override it to also return their bridge tracker URL. LiFi Intents, OIF and Relay use the default until they have a public scanner.
+-   The `OrderTracker` calls the provider's resolver on every yielded update, so consumers read `update.explorers.tracker ?? update.explorers.origin` instead of building URLs themselves.

--- a/apps/docs/docs/cross-chain/api.md
+++ b/apps/docs/docs/cross-chain/api.md
@@ -622,14 +622,29 @@ interface OrderTrackingInfo {
 interface OrderTrackingUpdate {
     status: OrderStatus;
     orderId?: Hex;
+    originChainId: number;
+    destinationChainId?: number; // known after the order is parsed (txHash path)
     openTxHash?: Hex;
     fillTxHash?: Hex;
     timestamp: number;
     message: string;
     failureReason?: OrderFailureReason;
     warnings?: string[]; // e.g. destination swap failed
+    explorers?: OrderExplorers; // ready-to-use links per provider
 }
 ```
+
+#### OrderExplorers
+
+```typescript
+interface OrderExplorers {
+    tracker?: string; // bridge-level scanner covering both legs (Across, Bungee)
+    origin?: string; // origin chain explorer URL for the open tx
+    destination?: string; // destination chain explorer URL for the fill tx
+}
+```
+
+Each `OrderTrackingUpdate` carries an `explorers` object computed by the provider via `getOrderExplorers`. Consumers should prefer `tracker` when present, otherwise show `origin` and `destination`. Across and Bungee return all three; LiFi Intents, OIF and Relay return `origin` / `destination` only.
 
 #### FillEvent
 

--- a/apps/docs/docs/cross-chain/intent-tracking.md
+++ b/apps/docs/docs/cross-chain/intent-tracking.md
@@ -210,6 +210,8 @@ for await (const item of tracker.watchOrder({
 
     if (item.update.status === OrderStatus.Finalized) {
         console.log(`Filled in tx: ${item.update.fillTxHash}`);
+        const url = item.update.explorers?.tracker ?? item.update.explorers?.origin;
+        if (url) console.log(`Track at: ${url}`);
         break;
     } else if (item.update.status === OrderStatus.Failed) {
         console.log("Order failed");

--- a/examples/ui/app/cross-chain/CrossChainClient.tsx
+++ b/examples/ui/app/cross-chain/CrossChainClient.tsx
@@ -226,7 +226,7 @@ export default function CrossChainClient() {
                     </div>
                     <OrderTracking
                       state={executionState}
-                      providerId={selectedQuote._providerId}
+                      providerId={selectedQuote.provider}
                       onReset={handleReset}
                       skipApproval={isNativeAddress(selectedInputToken, 'eip155')}
                     />

--- a/examples/ui/app/cross-chain/CrossChainClient.tsx
+++ b/examples/ui/app/cross-chain/CrossChainClient.tsx
@@ -226,6 +226,7 @@ export default function CrossChainClient() {
                     </div>
                     <OrderTracking
                       state={executionState}
+                      providerId={selectedQuote._providerId}
                       onReset={handleReset}
                       skipApproval={isNativeAddress(selectedInputToken, 'eip155')}
                     />

--- a/examples/ui/app/cross-chain/components/OrderTracking/ErrorView.tsx
+++ b/examples/ui/app/cross-chain/components/OrderTracking/ErrorView.tsx
@@ -33,7 +33,9 @@ export function ErrorView({ state, onReset }: ErrorViewProps) {
   const chainConfig = useChainConfig();
   const originChainId = 'originChainId' in state ? state.originChainId : undefined;
   const originChain = chainConfig.getChain(originChainId);
-  const originTxUrl = chainConfig.getExplorerTxUrl(originChainId, state.txHash);
+  const lastUpdate = state.step === STEP.TIMEOUT ? state.update : state.lastUpdate;
+  const originTxHash = lastUpdate?.openTxHash ?? state.txHash;
+  const { tracker: trackerUrl, origin: originTxUrl } = lastUpdate?.explorers ?? {};
   const isTimeout = state.step === STEP.TIMEOUT;
   const timeoutNotice = getTimeoutNotice(state, originChain?.name);
   const borderColor = isTimeout ? 'border-warning/30' : 'border-error/30';
@@ -68,20 +70,22 @@ export function ErrorView({ state, onReset }: ErrorViewProps) {
       )}
 
       {/* Transaction link if available */}
-      {state.txHash && originTxUrl && (
+      {originTxHash && (trackerUrl || originTxUrl) && (
         <a
-          href={originTxUrl}
+          href={trackerUrl ?? originTxUrl}
           target='_blank'
           rel='noopener noreferrer'
           className={`flex items-center justify-between p-3 rounded-lg ${linkBg} transition-colors group mb-4`}
         >
           <div className='flex items-center gap-2'>
             <div className={`w-2 h-2 rounded-full ${iconBg}`} />
-            <span className={`text-sm ${linkText}`}>Origin Transaction ({originChain?.name ?? 'Unknown'})</span>
+            <span className={`text-sm ${linkText}`}>
+              {trackerUrl ? 'Bridge Tracker' : `Origin Transaction (${originChain?.name ?? 'Unknown'})`}
+            </span>
           </div>
           <div className={`flex items-center gap-2 ${linkHoverText}`}>
             <span className='text-xs font-mono'>
-              {state.txHash.slice(0, 10)}...{state.txHash.slice(-8)}
+              {originTxHash.slice(0, 10)}...{originTxHash.slice(-8)}
             </span>
             <ExternalLinkIcon />
           </div>

--- a/examples/ui/app/cross-chain/components/OrderTracking/ErrorView.tsx
+++ b/examples/ui/app/cross-chain/components/OrderTracking/ErrorView.tsx
@@ -35,7 +35,8 @@ export function ErrorView({ state, onReset }: ErrorViewProps) {
   const originChain = chainConfig.getChain(originChainId);
   const lastUpdate = state.step === STEP.TIMEOUT ? state.update : state.lastUpdate;
   const originTxHash = lastUpdate?.openTxHash ?? state.txHash;
-  const { tracker: trackerUrl, origin: originTxUrl } = lastUpdate?.explorers ?? {};
+  const trackerUrl = lastUpdate?.explorers?.tracker;
+  const originTxUrl = lastUpdate?.explorers?.origin ?? chainConfig.getExplorerTxUrl(originChainId, originTxHash);
   const isTimeout = state.step === STEP.TIMEOUT;
   const timeoutNotice = getTimeoutNotice(state, originChain?.name);
   const borderColor = isTimeout ? 'border-warning/30' : 'border-error/30';

--- a/examples/ui/app/cross-chain/components/OrderTracking/OrderTracking.tsx
+++ b/examples/ui/app/cross-chain/components/OrderTracking/OrderTracking.tsx
@@ -6,7 +6,7 @@ import { ProgressView } from './ProgressView';
 import { SuccessView } from './SuccessView';
 import type { OrderTrackingProps } from './types';
 
-export function OrderTracking({ state, onReset, skipApproval }: OrderTrackingProps) {
+export function OrderTracking({ state, providerId, onReset, skipApproval }: OrderTrackingProps) {
   switch (state.step) {
     case STEP.IDLE:
       return null;
@@ -14,7 +14,7 @@ export function OrderTracking({ state, onReset, skipApproval }: OrderTrackingPro
     case STEP.TRACKING:
       return <ProgressView state={state} skipApproval={skipApproval} />;
     case STEP.DONE:
-      return <SuccessView state={state} onReset={onReset} />;
+      return <SuccessView state={state} providerId={providerId} onReset={onReset} />;
     case STEP.TIMEOUT:
     case STEP.ERROR:
       return <ErrorView state={state} onReset={onReset} />;

--- a/examples/ui/app/cross-chain/components/OrderTracking/ProgressView.tsx
+++ b/examples/ui/app/cross-chain/components/OrderTracking/ProgressView.tsx
@@ -30,10 +30,12 @@ function StepIndicator({ isCurrent, isPassed }: { isCurrent: boolean; isPassed: 
 export function ProgressView({ state, skipApproval }: ProgressViewProps) {
   const chainConfig = useChainConfig();
   const message = getProgressMessage(state);
-  const explorers = state.step === STEP.TRACKING ? state.update.explorers : undefined;
-  const trackerUrl = explorers?.tracker;
-  const originTxUrl = explorers?.origin ?? chainConfig.getExplorerTxUrl(state.originChainId, state.txHash);
-  const fillTxUrl = explorers?.destination;
+  const update = state.step === STEP.TRACKING ? state.update : undefined;
+  const fillTxHash = update?.fillTxHash;
+  const trackerUrl = update?.explorers?.tracker;
+  const originTxUrl = update?.explorers?.origin ?? chainConfig.getExplorerTxUrl(state.originChainId, state.txHash);
+  const fillTxUrl =
+    update?.explorers?.destination ?? chainConfig.getExplorerTxUrl(state.destinationChainId, fillTxHash);
 
   const allSteps = [
     ...(!skipApproval ? [{ id: 'approval', label: 'Approval' }] : []),

--- a/examples/ui/app/cross-chain/components/OrderTracking/ProgressView.tsx
+++ b/examples/ui/app/cross-chain/components/OrderTracking/ProgressView.tsx
@@ -1,4 +1,3 @@
-import { useChainConfig } from '../../hooks/useNetworkConfig';
 import { STEP } from '../../types/execution';
 import { isApprovalPhase, isSubmitPhase, getStateLabel, getProgressMessage } from '../../utils/orderTrackingHelpers';
 import { ExternalLinkIcon, SpinnerIcon, CheckIcon } from '../icons';
@@ -28,11 +27,9 @@ function StepIndicator({ isCurrent, isPassed }: { isCurrent: boolean; isPassed: 
 }
 
 export function ProgressView({ state, skipApproval }: ProgressViewProps) {
-  const chainConfig = useChainConfig();
   const message = getProgressMessage(state);
-  const originTxUrl = chainConfig.getExplorerTxUrl(state.originChainId, state.txHash);
-  const fillTxHash = state.step === STEP.TRACKING ? state.update.fillTxHash : undefined;
-  const fillTxUrl = chainConfig.getExplorerTxUrl(state.destinationChainId, fillTxHash);
+  const explorers = state.step === STEP.TRACKING ? state.update.explorers : undefined;
+  const { tracker: trackerUrl, origin: originTxUrl, destination: fillTxUrl } = explorers ?? {};
 
   const allSteps = [
     ...(!skipApproval ? [{ id: 'approval', label: 'Approval' }] : []),
@@ -88,8 +85,19 @@ export function ProgressView({ state, skipApproval }: ProgressViewProps) {
       </div>
 
       {/* Transaction links during progress */}
-      {(originTxUrl || fillTxUrl) && (
+      {(trackerUrl || originTxUrl || fillTxUrl) && (
         <div className='mt-4 pt-3 border-t border-border space-y-1.5'>
+          {trackerUrl && (
+            <a
+              href={trackerUrl}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-xs text-accent hover:underline flex items-center gap-1'
+            >
+              <span>View on bridge tracker</span>
+              <ExternalLinkIcon />
+            </a>
+          )}
           {originTxUrl && (
             <a
               href={originTxUrl}

--- a/examples/ui/app/cross-chain/components/OrderTracking/ProgressView.tsx
+++ b/examples/ui/app/cross-chain/components/OrderTracking/ProgressView.tsx
@@ -1,3 +1,4 @@
+import { useChainConfig } from '../../hooks/useNetworkConfig';
 import { STEP } from '../../types/execution';
 import { isApprovalPhase, isSubmitPhase, getStateLabel, getProgressMessage } from '../../utils/orderTrackingHelpers';
 import { ExternalLinkIcon, SpinnerIcon, CheckIcon } from '../icons';
@@ -27,9 +28,14 @@ function StepIndicator({ isCurrent, isPassed }: { isCurrent: boolean; isPassed: 
 }
 
 export function ProgressView({ state, skipApproval }: ProgressViewProps) {
+  const chainConfig = useChainConfig();
   const message = getProgressMessage(state);
   const explorers = state.step === STEP.TRACKING ? state.update.explorers : undefined;
-  const { tracker: trackerUrl, origin: originTxUrl, destination: fillTxUrl } = explorers ?? {};
+  const trackerUrl = explorers?.tracker;
+  // Fallback: during STEP.WALLET the tracker hasn't started yet, so explorers is empty.
+  // Use the wallet's origin tx hash to render a chain explorer link.
+  const originTxUrl = explorers?.origin ?? chainConfig.getExplorerTxUrl(state.originChainId, state.txHash);
+  const fillTxUrl = explorers?.destination;
 
   const allSteps = [
     ...(!skipApproval ? [{ id: 'approval', label: 'Approval' }] : []),

--- a/examples/ui/app/cross-chain/components/OrderTracking/ProgressView.tsx
+++ b/examples/ui/app/cross-chain/components/OrderTracking/ProgressView.tsx
@@ -32,8 +32,6 @@ export function ProgressView({ state, skipApproval }: ProgressViewProps) {
   const message = getProgressMessage(state);
   const explorers = state.step === STEP.TRACKING ? state.update.explorers : undefined;
   const trackerUrl = explorers?.tracker;
-  // Fallback: during STEP.WALLET the tracker hasn't started yet, so explorers is empty.
-  // Use the wallet's origin tx hash to render a chain explorer link.
   const originTxUrl = explorers?.origin ?? chainConfig.getExplorerTxUrl(state.originChainId, state.txHash);
   const fillTxUrl = explorers?.destination;
 

--- a/examples/ui/app/cross-chain/components/OrderTracking/SuccessView.tsx
+++ b/examples/ui/app/cross-chain/components/OrderTracking/SuccessView.tsx
@@ -73,7 +73,7 @@ export function SuccessView({ state, providerId, onReset }: SuccessViewProps) {
               <span className='text-xs text-text-tertiary'>{providerId || 'Provider'}</span>
             </div>
             <div className='flex items-center justify-between text-text-tertiary group-hover:text-accent'>
-              <span className='text-sm'>View on provider explorer</span>
+              <span className='text-sm'>View on protocol explorer</span>
               <ExternalLinkIcon />
             </div>
           </a>

--- a/examples/ui/app/cross-chain/components/OrderTracking/SuccessView.tsx
+++ b/examples/ui/app/cross-chain/components/OrderTracking/SuccessView.tsx
@@ -70,7 +70,7 @@ export function SuccessView({ state, providerId, onReset }: SuccessViewProps) {
                 <div className='w-2 h-2 rounded-full bg-accent' />
                 <span className='text-sm font-medium text-text-primary'>Bridge tracker</span>
               </div>
-              <span className='text-xs text-text-tertiary'>{providerId ?? 'Provider'}</span>
+              <span className='text-xs text-text-tertiary'>{providerId || 'Provider'}</span>
             </div>
             <div className='flex items-center justify-between text-text-tertiary group-hover:text-accent'>
               <span className='text-sm'>View on provider explorer</span>

--- a/examples/ui/app/cross-chain/components/OrderTracking/SuccessView.tsx
+++ b/examples/ui/app/cross-chain/components/OrderTracking/SuccessView.tsx
@@ -2,14 +2,13 @@ import { useChainConfig } from '../../hooks/useNetworkConfig';
 import { CheckIcon, ExternalLinkIcon, WarningIcon } from '../icons';
 import type { SuccessViewProps } from './types';
 
-export function SuccessView({ state, onReset }: SuccessViewProps) {
+export function SuccessView({ state, providerId, onReset }: SuccessViewProps) {
   const chainConfig = useChainConfig();
   const originChain = chainConfig.getChain(state.originChainId);
   const destinationChain = chainConfig.getChain(state.destinationChainId);
   const openTxHash = state.update.openTxHash ?? state.txHash;
-  const originTxUrl = chainConfig.getExplorerTxUrl(state.originChainId, openTxHash);
   const fillTxHash = state.update.fillTxHash;
-  const fillTxUrl = chainConfig.getExplorerTxUrl(state.destinationChainId, fillTxHash);
+  const { tracker: trackerUrl, origin: originTxUrl, destination: fillTxUrl } = state.update.explorers ?? {};
   const warnings = state.update.warnings;
   const hasWarnings = warnings && warnings.length > 0;
 
@@ -57,7 +56,31 @@ export function SuccessView({ state, onReset }: SuccessViewProps) {
         </div>
       )}
 
-      {/* Transaction links */}
+      {/* Bridge tracker (covers both legs) */}
+      {trackerUrl && (
+        <div className='space-y-2 mb-4'>
+          <a
+            href={trackerUrl}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='block p-3 rounded-lg bg-surface border border-border hover:border-accent/50 transition-colors group'
+          >
+            <div className='flex items-center justify-between mb-1'>
+              <div className='flex items-center gap-2'>
+                <div className='w-2 h-2 rounded-full bg-accent' />
+                <span className='text-sm font-medium text-text-primary'>Bridge tracker</span>
+              </div>
+              <span className='text-xs text-text-tertiary'>{providerId ?? 'Provider'}</span>
+            </div>
+            <div className='flex items-center justify-between text-text-tertiary group-hover:text-accent'>
+              <span className='text-sm'>View on provider explorer</span>
+              <ExternalLinkIcon />
+            </div>
+          </a>
+        </div>
+      )}
+
+      {/* Per-leg chain explorer links */}
       <div className='space-y-2 mb-4'>
         {openTxHash && originTxUrl && (
           <a

--- a/examples/ui/app/cross-chain/components/OrderTracking/types.ts
+++ b/examples/ui/app/cross-chain/components/OrderTracking/types.ts
@@ -2,6 +2,7 @@ import { STEP, type BridgeState } from '../../types/execution';
 
 export interface OrderTrackingProps {
   state: BridgeState;
+  providerId?: string;
   onReset?: () => void;
   skipApproval?: boolean;
 }
@@ -9,6 +10,8 @@ export interface OrderTrackingProps {
 /** Props for SuccessView - only accepts 'done' step */
 export interface SuccessViewProps {
   state: Extract<BridgeState, { step: typeof STEP.DONE }>;
+  /** Display label for the bridge tracker badge. */
+  providerId?: string;
   onReset?: () => void;
 }
 

--- a/packages/cross-chain/src/core/interfaces/crossChainProvider.interface.ts
+++ b/packages/cross-chain/src/core/interfaces/crossChainProvider.interface.ts
@@ -2,11 +2,13 @@ import type { Hex } from "viem";
 
 import type { Quote, SubmitOrderResponse } from "../schemas/quote.js";
 import type { BuildQuoteRequest, QuoteRequest } from "../schemas/quoteRequest.js";
+import type { GetOrderExplorersParams, OrderExplorers } from "../types/orderExplorers.js";
 import type { AssetDiscoveryConfig } from "./assetDiscovery.interface.js";
 import type { FillWatcherConfig } from "./fillWatcher.interface.js";
 import type { OpenedIntentParserConfig } from "./openedIntentParser.interface.js";
 import type { PreTrackerConfig } from "./preTracker.interface.js";
 import { ProviderExecuteNotImplemented } from "../errors/ProviderExecuteNotImplemented.exception.js";
+import { getChainExplorerTxUrl } from "../utils/blockExplorers.js";
 
 export abstract class CrossChainProvider {
     /**
@@ -130,5 +132,27 @@ export abstract class CrossChainProvider {
      */
     getDiscoveryConfig(): AssetDiscoveryConfig | null {
         return null;
+    }
+
+    /**
+     * Build explorer URLs for an order. Default falls back to chain block
+     * explorers; providers with a bridge scanner should override and return
+     * `{ tracker }`.
+     */
+    getOrderExplorers(params: GetOrderExplorersParams): OrderExplorers {
+        const { originChainId, originTxHash, destinationChainId, destinationTxHash } = params;
+        const result: OrderExplorers = {};
+
+        if (originTxHash) {
+            const origin = getChainExplorerTxUrl(originChainId, originTxHash);
+            if (origin) result.origin = origin;
+        }
+
+        if (destinationChainId !== undefined && destinationTxHash) {
+            const destination = getChainExplorerTxUrl(destinationChainId, destinationTxHash);
+            if (destination) result.destination = destination;
+        }
+
+        return result;
     }
 }

--- a/packages/cross-chain/src/core/services/OrderTracker.ts
+++ b/packages/cross-chain/src/core/services/OrderTracker.ts
@@ -166,7 +166,15 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                 timeout: number;
             });
         } else {
-            yield* this.watchOrderByOrderId({ ...(params as WatchOrderByOrderId), timeout });
+            // For WatchOrderExplicit, the caller's txHash is the openTxHash on the API path.
+            const openTxHash =
+                ("openTxHash" in params ? params.openTxHash : undefined) ??
+                ("txHash" in params ? params.txHash : undefined);
+            yield* this.watchOrderByOrderId({
+                ...(params as WatchOrderByOrderId),
+                openTxHash,
+                timeout,
+            });
         }
     }
 
@@ -307,7 +315,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
     private async *watchOrderByOrderId(
         params: WatchOrderByOrderId & { timeout: number },
     ): AsyncGenerator<OrderTrackerYield> {
-        const { orderId, originChainId, destinationChainId, timeout } = params;
+        const { orderId, originChainId, destinationChainId, openTxHash, timeout } = params;
         const startTime = Date.now();
 
         let lastUpdate: OrderTrackingUpdate = this.createUpdate({
@@ -315,6 +323,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
             orderId,
             originChainId,
             destinationChainId,
+            openTxHash,
             message: "Tracking escrow order...",
         });
         yield { type: OrderTrackerYieldType.Update, update: lastUpdate };
@@ -324,12 +333,13 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
             orderId,
             originChainId,
             destinationChainId,
+            openTxHash,
             message: "Waiting for solver to fill order...",
         });
         yield { type: OrderTrackerYieldType.Update, update: lastUpdate };
 
         yield* this.pollForFillWithYields(
-            { orderId, originChainId, destinationChainId },
+            { orderId, originChainId, destinationChainId, openTxHash },
             timeout - (Date.now() - startTime),
         );
     }
@@ -340,13 +350,18 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
      * The txHash (Across) path uses waitForFillWithTimeout instead.
      */
     private async *pollForFillWithYields(
-        fillParams: { orderId: Hex; originChainId: number; destinationChainId: number },
+        fillParams: {
+            orderId: Hex;
+            originChainId: number;
+            destinationChainId: number;
+            openTxHash?: Hex;
+        },
         timeout: number,
     ): AsyncGenerator<OrderTrackerYield> {
         const terminalFailures = new Set([OrderStatus.Failed, OrderStatus.Refunded]);
         const pollingInterval = 5000;
         const startTime = Date.now();
-        const { originChainId, destinationChainId } = fillParams;
+        const { originChainId, destinationChainId, openTxHash } = fillParams;
         let lastUpdate: OrderTrackingUpdate | undefined;
 
         while (Date.now() - startTime < timeout) {
@@ -362,6 +377,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                         orderId: fillParams.orderId,
                         originChainId,
                         destinationChainId,
+                        openTxHash,
                         fillTxHash: fillEvent.fillTxHash,
                         message: hasWarnings ? "Order filled with warnings" : "Order completed",
                         warnings: fillEvent.warnings,
@@ -378,6 +394,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                         orderId: fillParams.orderId,
                         originChainId,
                         destinationChainId,
+                        openTxHash,
                         message: "Order failed",
                         failureReason: failureReason ?? OrderFailureReason.Unknown,
                     }),
@@ -394,6 +411,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                         orderId: fillParams.orderId,
                         originChainId,
                         destinationChainId,
+                        openTxHash,
                         message: "Order finalized but fill transaction hash unavailable",
                         failureReason: OrderFailureReason.Unknown,
                     }),
@@ -408,6 +426,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                     orderId: fillParams.orderId,
                     originChainId,
                     destinationChainId,
+                    openTxHash,
                     fillTxHash: fillTxHash as Hex,
                     message: `Order ${status}, fill tx detected`,
                 });
@@ -424,6 +443,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                     orderId: fillParams.orderId,
                     originChainId,
                     destinationChainId,
+                    openTxHash,
                     message: "Waiting for solver to fill order...",
                 }),
             0,

--- a/packages/cross-chain/src/core/services/OrderTracker.ts
+++ b/packages/cross-chain/src/core/services/OrderTracker.ts
@@ -4,6 +4,7 @@ import type { FillWatcher } from "../interfaces/fillWatcher.interface.js";
 import type { OpenedIntentParser } from "../interfaces/openedIntentParser.interface.js";
 import type { OrderTrackerEvents } from "../interfaces/orderTracker.interface.js";
 import type { PreTracker } from "../interfaces/preTracker.interface.js";
+import type { GetOrderExplorersParams, OrderExplorers } from "../types/orderExplorers.js";
 import type {
     OpenedIntent,
     OrderTrackerYield,
@@ -42,6 +43,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
         private readonly clientManager?: PublicClientManager,
         private readonly preTracker?: PreTracker,
         onChainFillWatcher?: FillWatcher,
+        private readonly getOrderExplorers?: (params: GetOrderExplorersParams) => OrderExplorers,
     ) {
         super();
         this.apiFillWatcher = fillWatcher;
@@ -177,6 +179,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
 
         let lastUpdate: OrderTrackingUpdate = this.createUpdate({
             status: OrderStatus.Pending,
+            originChainId,
             openTxHash: txHash,
             message: "Parsing order from transaction...",
         });
@@ -188,6 +191,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                 type: OrderTrackerYieldType.Update,
                 update: this.createUpdate({
                     status: OrderStatus.Failed,
+                    originChainId,
                     openTxHash: txHash,
                     message: "Origin transaction reverted",
                     failureReason: OrderFailureReason.OriginTxReverted,
@@ -207,6 +211,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                     type: OrderTrackerYieldType.Update,
                     update: this.createUpdate({
                         status: OrderStatus.Finalized,
+                        originChainId,
                         openTxHash: txHash,
                         message:
                             "Bridge transaction confirmed. Funds may take a few minutes to arrive.",
@@ -217,9 +222,16 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
             throw error;
         }
 
+        const destinationChainId = openedIntent.fillInstructions[0]?.destinationChainId;
+        if (!destinationChainId) {
+            throw new Error("Order has no destination chain in fillInstructions");
+        }
+
         lastUpdate = this.createUpdate({
             status: OrderStatus.Pending,
             orderId: openedIntent.orderId,
+            originChainId,
+            destinationChainId,
             openTxHash: txHash,
             message: `Order parsed with orderId ${openedIntent.orderId.slice(0, 10)}...`,
         });
@@ -235,6 +247,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                 update: this.createUpdate({
                     status: OrderStatus.Failed,
                     orderId: openedIntent.orderId,
+                    originChainId,
+                    destinationChainId,
                     openTxHash: txHash,
                     message: "Deadline exceeded before watching started",
                     failureReason: OrderFailureReason.DeadlineExceeded,
@@ -258,15 +272,12 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
         lastUpdate = this.createUpdate({
             status: OrderStatus.Pending,
             orderId: openedIntent.orderId,
+            originChainId,
+            destinationChainId,
             openTxHash: txHash,
             message: "Waiting for solver to fill order...",
         });
         yield { type: OrderTrackerYieldType.Update, update: lastUpdate };
-
-        const destChainId = openedIntent.fillInstructions[0]?.destinationChainId;
-        if (!destChainId) {
-            throw new Error("Order has no destination chain in fillInstructions");
-        }
 
         const fillResult = await this.waitForFillWithTimeout(
             this.txFillWatcher,
@@ -274,7 +285,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                 orderId: openedIntent.orderId,
                 openTxHash: txHash,
                 originChainId,
-                destinationChainId: destChainId,
+                destinationChainId,
                 user: openedIntent.user,
                 fillDeadline: openedIntent.fillDeadline,
             },
@@ -287,6 +298,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
             txHash,
             lastUpdate,
             fillDeadline,
+            originChainId,
+            destinationChainId,
         );
     }
 
@@ -300,6 +313,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
         let lastUpdate: OrderTrackingUpdate = this.createUpdate({
             status: OrderStatus.Pending,
             orderId,
+            originChainId,
+            destinationChainId,
             message: "Tracking escrow order...",
         });
         yield { type: OrderTrackerYieldType.Update, update: lastUpdate };
@@ -307,6 +322,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
         lastUpdate = this.createUpdate({
             status: OrderStatus.Pending,
             orderId,
+            originChainId,
+            destinationChainId,
             message: "Waiting for solver to fill order...",
         });
         yield { type: OrderTrackerYieldType.Update, update: lastUpdate };
@@ -329,6 +346,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
         const terminalFailures = new Set([OrderStatus.Failed, OrderStatus.Refunded]);
         const pollingInterval = 5000;
         const startTime = Date.now();
+        const { originChainId, destinationChainId } = fillParams;
         let lastUpdate: OrderTrackingUpdate | undefined;
 
         while (Date.now() - startTime < timeout) {
@@ -342,6 +360,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                     update: this.createUpdate({
                         status: OrderStatus.Finalized,
                         orderId: fillParams.orderId,
+                        originChainId,
+                        destinationChainId,
                         fillTxHash: fillEvent.fillTxHash,
                         message: hasWarnings ? "Order filled with warnings" : "Order completed",
                         warnings: fillEvent.warnings,
@@ -356,6 +376,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                     update: this.createUpdate({
                         status: OrderStatus.Failed,
                         orderId: fillParams.orderId,
+                        originChainId,
+                        destinationChainId,
                         message: "Order failed",
                         failureReason: failureReason ?? OrderFailureReason.Unknown,
                     }),
@@ -370,6 +392,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                     update: this.createUpdate({
                         status: OrderStatus.Failed,
                         orderId: fillParams.orderId,
+                        originChainId,
+                        destinationChainId,
                         message: "Order finalized but fill transaction hash unavailable",
                         failureReason: OrderFailureReason.Unknown,
                     }),
@@ -382,6 +406,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                 lastUpdate = this.createUpdate({
                     status,
                     orderId: fillParams.orderId,
+                    originChainId,
+                    destinationChainId,
                     fillTxHash: fillTxHash as Hex,
                     message: `Order ${status}, fill tx detected`,
                 });
@@ -396,6 +422,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                 this.createUpdate({
                     status: OrderStatus.Pending,
                     orderId: fillParams.orderId,
+                    originChainId,
+                    destinationChainId,
                     message: "Waiting for solver to fill order...",
                 }),
             0,
@@ -409,6 +437,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
         openTxHash: Hex | undefined,
         lastUpdate: OrderTrackingUpdate,
         fillDeadline: number,
+        originChainId: number,
+        destinationChainId: number,
     ): OrderTrackerYield {
         if (fillResult.status === FillResultStatus.Finalized) {
             const hasWarnings = fillResult.warnings && fillResult.warnings.length > 0;
@@ -417,6 +447,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                 update: this.createUpdate({
                     status: OrderStatus.Finalized,
                     orderId,
+                    originChainId,
+                    destinationChainId,
                     openTxHash,
                     fillTxHash: fillResult.fillTxHash,
                     message: hasWarnings
@@ -435,6 +467,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                 update: this.createUpdate({
                     status: OrderStatus.Failed,
                     orderId,
+                    originChainId,
+                    destinationChainId,
                     openTxHash,
                     message: "Order failed",
                     failureReason: fillResult.failureReason,
@@ -448,6 +482,8 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
                 update: this.createUpdate({
                     status: OrderStatus.Failed,
                     orderId,
+                    originChainId,
+                    destinationChainId,
                     openTxHash,
                     message: "Deadline exceeded before fill",
                     failureReason: OrderFailureReason.DeadlineExceeded,
@@ -551,10 +587,20 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
         }
     }
 
-    private createUpdate(params: Omit<OrderTrackingUpdate, "timestamp">): OrderTrackingUpdate {
+    private createUpdate(
+        params: Omit<OrderTrackingUpdate, "timestamp" | "explorers">,
+    ): OrderTrackingUpdate {
+        const explorers = this.getOrderExplorers?.({
+            originChainId: params.originChainId,
+            originTxHash: params.openTxHash,
+            destinationChainId: params.destinationChainId,
+            destinationTxHash: params.fillTxHash,
+        });
+
         return {
             ...params,
             timestamp: Math.floor(Date.now() / 1000),
+            explorers,
         };
     }
 

--- a/packages/cross-chain/src/core/services/OrderTracker.ts
+++ b/packages/cross-chain/src/core/services/OrderTracker.ts
@@ -4,7 +4,7 @@ import type { FillWatcher } from "../interfaces/fillWatcher.interface.js";
 import type { OpenedIntentParser } from "../interfaces/openedIntentParser.interface.js";
 import type { OrderTrackerEvents } from "../interfaces/orderTracker.interface.js";
 import type { PreTracker } from "../interfaces/preTracker.interface.js";
-import type { GetOrderExplorersParams, OrderExplorers } from "../types/orderExplorers.js";
+import type { OrderExplorersResolver } from "../types/orderExplorers.js";
 import type {
     OpenedIntent,
     OrderTrackerYield,
@@ -43,7 +43,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
         private readonly clientManager?: PublicClientManager,
         private readonly preTracker?: PreTracker,
         onChainFillWatcher?: FillWatcher,
-        private readonly getOrderExplorers?: (params: GetOrderExplorersParams) => OrderExplorers,
+        private readonly getOrderExplorers?: OrderExplorersResolver,
     ) {
         super();
         this.apiFillWatcher = fillWatcher;

--- a/packages/cross-chain/src/core/types/index.ts
+++ b/packages/cross-chain/src/core/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./orderTracking.js";
 export * from "./assetDiscovery.js";
+export * from "./orderExplorers.js";

--- a/packages/cross-chain/src/core/types/orderExplorers.ts
+++ b/packages/cross-chain/src/core/types/orderExplorers.ts
@@ -20,3 +20,8 @@ export interface GetOrderExplorersParams {
     /** Becomes available once the fill event is observed. */
     destinationTxHash?: Hex;
 }
+
+/** Resolves explorer URLs for an order. Implemented by `CrossChainProvider.getOrderExplorers`. */
+export interface OrderExplorersResolver {
+    (params: GetOrderExplorersParams): OrderExplorers;
+}

--- a/packages/cross-chain/src/core/types/orderExplorers.ts
+++ b/packages/cross-chain/src/core/types/orderExplorers.ts
@@ -1,0 +1,22 @@
+import type { Hex } from "viem";
+
+/**
+ * Explorer URLs for an order. Consumers should prefer `tracker` when present
+ * and fall back to `origin` / `destination` otherwise.
+ */
+export interface OrderExplorers {
+    /** Bridge-level scanner covering both legs (when the provider has one). */
+    tracker?: string;
+    /** Origin chain explorer URL for the open tx. */
+    origin?: string;
+    /** Destination chain explorer URL for the fill tx. Set once the fill is observed. */
+    destination?: string;
+}
+
+export interface GetOrderExplorersParams {
+    originChainId: number;
+    originTxHash?: Hex;
+    destinationChainId?: number;
+    /** Becomes available once the fill event is observed. */
+    destinationTxHash?: Hex;
+}

--- a/packages/cross-chain/src/core/types/orderTracking.ts
+++ b/packages/cross-chain/src/core/types/orderTracking.ts
@@ -1,6 +1,8 @@
 import { OrderStatus } from "@openintentsframework/oif-specs";
 import { Address, Hex } from "viem";
 
+import type { OrderExplorers } from "./orderExplorers.js";
+
 export { OrderStatus };
 
 export const OrderFailureReason = {
@@ -156,6 +158,10 @@ export interface OrderTrackingUpdate {
     status: OrderStatus;
     /** Order ID (available after order is parsed, or immediately for escrow orders) */
     orderId?: Hex;
+    /** Origin chain ID */
+    originChainId: number;
+    /** Destination chain ID (known after the order is parsed for the txHash path) */
+    destinationChainId?: number;
     /** Transaction hash where order was opened (undefined for escrow orders) */
     openTxHash?: Hex;
     /** Fill transaction hash (available when completed) */
@@ -168,6 +174,8 @@ export interface OrderTrackingUpdate {
     failureReason?: OrderFailureReason;
     /** Warnings about the fill (e.g. destination swap failed) */
     warnings?: string[];
+    /** Explorer URLs for the order, recomputed per update as new tx hashes appear. */
+    explorers?: OrderExplorers;
 }
 
 /**

--- a/packages/cross-chain/src/core/utils/blockExplorers.ts
+++ b/packages/cross-chain/src/core/utils/blockExplorers.ts
@@ -1,0 +1,25 @@
+import type { Hex } from "viem";
+
+import { getChainById } from "./chainHelpers.js";
+
+/**
+ * Build a chain block-explorer URL for a transaction.
+ *
+ * Returns `undefined` when the chain isn't in viem's catalogue, or when the
+ * chain has no default block explorer registered. This lets providers fall
+ * back gracefully without forcing consumers to handle thrown errors.
+ */
+export function getChainExplorerTxUrl(chainId: number, txHash: Hex): string | undefined {
+    let chain;
+    try {
+        chain = getChainById(chainId);
+    } catch {
+        return undefined;
+    }
+
+    const explorerUrl = chain.blockExplorers?.default?.url;
+    if (!explorerUrl) return undefined;
+
+    const base = explorerUrl.endsWith("/") ? explorerUrl.slice(0, -1) : explorerUrl;
+    return `${base}/tx/${txHash}`;
+}

--- a/packages/cross-chain/src/core/utils/index.ts
+++ b/packages/cross-chain/src/core/utils/index.ts
@@ -1,6 +1,7 @@
 export * from "./addressHelpers.js";
 export * from "./toDiscoveredAssets.js";
 export * from "./chainHelpers.js";
+export * from "./blockExplorers.js";
 export * from "./eventDataParser.js";
 export * from "./orderTypeHelpers.js";
 export * from "./publicClientManager.js";

--- a/packages/cross-chain/src/factories/orderTrackerFactory.ts
+++ b/packages/cross-chain/src/factories/orderTrackerFactory.ts
@@ -69,6 +69,7 @@ export class OrderTrackerFactory {
             this.clientManager,
             preTracker,
             onChainFillWatcher,
+            (params) => provider.getOrderExplorers(params),
         );
     }
 

--- a/packages/cross-chain/src/protocols/across/constants.ts
+++ b/packages/cross-chain/src/protocols/across/constants.ts
@@ -7,7 +7,7 @@ export const ACROSS_ORDER_DATA_TYPE =
     "0x9df4b782e7bbc178b3b93bfe8aafb909e84e39484d7f3c59f400f1b4691f85e2";
 
 /** Bridge tracker base URL. Append `/${originTxHash}` for a per-order link. */
-export const ACROSS_EXPLORER_BASE_URL = "https://app.across.to/transactions";
+export const ACROSS_EXPLORER_BASE_URL = "https://app.across.to/transaction";
 
 /**
  * Across Origin Settler contract addresses (ERC-7683 IOriginSettler implementation)

--- a/packages/cross-chain/src/protocols/across/constants.ts
+++ b/packages/cross-chain/src/protocols/across/constants.ts
@@ -6,6 +6,9 @@ import type { NetworkAssets } from "../../core/types/assetDiscovery.js";
 export const ACROSS_ORDER_DATA_TYPE =
     "0x9df4b782e7bbc178b3b93bfe8aafb909e84e39484d7f3c59f400f1b4691f85e2";
 
+/** Bridge tracker base URL. Append `/${originTxHash}` for a per-order link. */
+export const ACROSS_EXPLORER_BASE_URL = "https://app.across.to/transactions";
+
 /**
  * Across Origin Settler contract addresses (ERC-7683 IOriginSettler implementation)
  * These contracts are used to create cross-chain intents

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -14,6 +14,7 @@ import type { Quote, QuoteFeeEntry } from "../../core/schemas/quote.js";
 import type { BuildQuoteRequest, QuoteRequest } from "../../core/schemas/quoteRequest.js";
 import { addressToBytes32 } from "../../core/utils/addressHelpers.js";
 import {
+    ACROSS_EXPLORER_BASE_URL,
     ACROSS_FILLED_RELAY_EVENT_ABI,
     ACROSS_SPOKE_POOL_ADDRESSES,
     ACROSS_SPOKE_POOL_DEPOSIT_ABI,
@@ -42,6 +43,7 @@ import {
     FillWatcherConfig,
     getAcrossApiUrl,
     GetFillParams,
+    GetOrderExplorersParams,
     HttpError,
     httpRequest,
     InvalidOpenEventError,
@@ -50,6 +52,7 @@ import {
     NetworkAssets,
     OpenedIntent,
     OpenedIntentParserConfig,
+    OrderExplorers,
     OrderFailureReason,
     OrderStatus,
     parseAbiEncodedFields,
@@ -778,6 +781,14 @@ export class AcrossProvider extends CrossChainProvider {
             },
             fillWatcherConfig,
         };
+    }
+
+    override getOrderExplorers(params: GetOrderExplorersParams): OrderExplorers {
+        const explorers = super.getOrderExplorers(params);
+        if (params.originTxHash) {
+            explorers.tracker = `${ACROSS_EXPLORER_BASE_URL}/${params.originTxHash}`;
+        }
+        return explorers;
     }
 
     override getDiscoveryConfig(): AssetDiscoveryConfig {

--- a/packages/cross-chain/src/protocols/bungee/constants.ts
+++ b/packages/cross-chain/src/protocols/bungee/constants.ts
@@ -9,3 +9,6 @@ export const BUNGEE_API_URLS: Record<BungeeApiTier, string> = {
 
 /** Default Bungee API base URL (public sandbox). */
 export const BUNGEE_API_URL = BUNGEE_API_URLS[BungeeApiTier.Sandbox];
+
+/** Bridge tracker base URL. Append `/${originTxHash}` for a per-order link. */
+export const BUNGEE_EXPLORER_BASE_URL = "https://www.socketscan.io/tx";

--- a/packages/cross-chain/src/protocols/bungee/provider.ts
+++ b/packages/cross-chain/src/protocols/bungee/provider.ts
@@ -5,8 +5,10 @@ import type { SubmissionMode } from "../../core/schemas/providerConfig.js";
 import type {
     AssetDiscoveryConfig,
     FillWatcherConfig,
+    GetOrderExplorersParams,
     HttpClient,
     OpenedIntentParserConfig,
+    OrderExplorers,
     Quote,
     QuoteRequest,
     SubmitOrderResponse,
@@ -29,7 +31,7 @@ import {
     extractOpenedIntent,
     parseBungeeTokenListResponse,
 } from "./adapters/index.js";
-import { BUNGEE_API_URLS } from "./constants.js";
+import { BUNGEE_API_URLS, BUNGEE_EXPLORER_BASE_URL } from "./constants.js";
 import { BungeeApiService } from "./services/index.js";
 import { BungeeApiTier, BungeeConfigSchema } from "./types.js";
 
@@ -171,6 +173,15 @@ export class BungeeProvider extends CrossChainProvider {
                 extractFillEvent,
             } as FillWatcherConfig,
         };
+    }
+
+    /** @inheritdoc Bungee orders are tracked through Socket scanner. */
+    override getOrderExplorers(params: GetOrderExplorersParams): OrderExplorers {
+        const explorers = super.getOrderExplorers(params);
+        if (params.originTxHash) {
+            explorers.tracker = `${BUNGEE_EXPLORER_BASE_URL}/${params.originTxHash}`;
+        }
+        return explorers;
     }
 
     /**

--- a/packages/cross-chain/test/protocols/bungee/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/provider.spec.ts
@@ -498,4 +498,23 @@ describe("BungeeProvider", () => {
             );
         });
     });
+
+    describe("getOrderExplorers()", () => {
+        it("returns the socketscan tracker URL alongside the chain explorer URLs", () => {
+            const explorers = provider.getOrderExplorers({
+                originChainId: 8453,
+                originTxHash: "0x9bdfe864",
+                destinationChainId: 42161,
+                destinationTxHash: "0xfeedface",
+            });
+            expect(explorers.tracker).toBe("https://www.socketscan.io/tx/0x9bdfe864");
+            expect(explorers.origin).toBe("https://basescan.org/tx/0x9bdfe864");
+            expect(explorers.destination).toBe("https://arbiscan.io/tx/0xfeedface");
+        });
+
+        it("returns an empty object when no tx hash is available", () => {
+            const explorers = provider.getOrderExplorers({ originChainId: 8453 });
+            expect(explorers).toEqual({});
+        });
+    });
 });

--- a/packages/cross-chain/test/providers/AcrossProvider.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.spec.ts
@@ -118,7 +118,7 @@ describe("AcrossProvider", () => {
                 destinationChainId: 42161,
                 destinationTxHash: "0xfeedface",
             });
-            expect(explorers.tracker).toBe("https://app.across.to/transactions/0xdeadbeef");
+            expect(explorers.tracker).toBe("https://app.across.to/transaction/0xdeadbeef");
             expect(explorers.origin).toBe("https://basescan.org/tx/0xdeadbeef");
             expect(explorers.destination).toBe("https://arbiscan.io/tx/0xfeedface");
         });

--- a/packages/cross-chain/test/providers/AcrossProvider.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.spec.ts
@@ -110,6 +110,25 @@ describe("AcrossProvider", () => {
         });
     });
 
+    describe("getOrderExplorers", () => {
+        it("returns the Across tracker URL alongside the chain explorer URLs", () => {
+            const explorers = provider.getOrderExplorers({
+                originChainId: 8453,
+                originTxHash: "0xdeadbeef",
+                destinationChainId: 42161,
+                destinationTxHash: "0xfeedface",
+            });
+            expect(explorers.tracker).toBe("https://app.across.to/transactions/0xdeadbeef");
+            expect(explorers.origin).toBe("https://basescan.org/tx/0xdeadbeef");
+            expect(explorers.destination).toBe("https://arbiscan.io/tx/0xfeedface");
+        });
+
+        it("returns an empty object when no tx hash is available", () => {
+            const explorers = provider.getOrderExplorers({ originChainId: 1 });
+            expect(explorers).toEqual({});
+        });
+    });
+
     describe("getTrackingConfig", () => {
         it("should return valid tracking configuration for all components", () => {
             const config = provider.getTrackingConfig();

--- a/packages/cross-chain/test/providers/LifiIntentsProvider.spec.ts
+++ b/packages/cross-chain/test/providers/LifiIntentsProvider.spec.ts
@@ -491,4 +491,28 @@ describe("LifiIntentsProvider", () => {
             expect(result.status).toBe(OrderStatus.Pending);
         });
     });
+
+    describe("getOrderExplorers", () => {
+        it("returns origin and destination chain explorer URLs (no bridge tracker)", () => {
+            const explorers = provider.getOrderExplorers({
+                originChainId: 8453,
+                originTxHash: "0xaaaa",
+                destinationChainId: 42161,
+                destinationTxHash: "0xbbbb",
+            });
+            expect(explorers.tracker).toBeUndefined();
+            expect(explorers.origin).toBe("https://basescan.org/tx/0xaaaa");
+            expect(explorers.destination).toBe("https://arbiscan.io/tx/0xbbbb");
+        });
+
+        it("omits destination until the fill tx hash is observed", () => {
+            const explorers = provider.getOrderExplorers({
+                originChainId: 8453,
+                originTxHash: "0xaaaa",
+                destinationChainId: 42161,
+            });
+            expect(explorers.origin).toBe("https://basescan.org/tx/0xaaaa");
+            expect(explorers.destination).toBeUndefined();
+        });
+    });
 });

--- a/packages/cross-chain/test/services/OrderTracker.spec.ts
+++ b/packages/cross-chain/test/services/OrderTracker.spec.ts
@@ -936,4 +936,51 @@ describe("OrderTracker", () => {
             expect(mockOnChainWatcher.getFill).not.toHaveBeenCalled();
         });
     });
+
+    describe("explorers enrichment", () => {
+        it("invokes getOrderExplorers with both legs' chain context once the fill is observed", async () => {
+            const getOrderExplorers = vi.fn();
+            const fillEvent = createMockFillEvent();
+
+            vi.mocked(mockOpenedIntentParser.getOpenedIntent).mockResolvedValue(
+                createMockOpenedIntent({
+                    fillInstructions: [
+                        {
+                            destinationChainId: mockDestinationChainId,
+                            destinationSettler: "0x00" as Hex,
+                            originData: "0x" as Hex,
+                        },
+                    ],
+                }),
+            );
+            vi.mocked(mockFillWatcher.waitForFill).mockResolvedValue(fillEvent);
+
+            const trackerWithExplorers = new OrderTracker(
+                mockOpenedIntentParser,
+                mockFillWatcher,
+                undefined,
+                undefined,
+                undefined,
+                getOrderExplorers,
+            );
+
+            const items: OrderTrackerYield[] = [];
+            for await (const item of trackerWithExplorers.watchOrder({
+                txHash: mockTxHash,
+                originChainId: mockOriginChainId,
+                destinationChainId: mockDestinationChainId,
+                timeout: 10000,
+            })) {
+                items.push(item);
+            }
+            expect(items.length).toBeGreaterThan(0);
+
+            expect(getOrderExplorers).toHaveBeenLastCalledWith({
+                originChainId: mockOriginChainId,
+                originTxHash: mockTxHash,
+                destinationChainId: mockDestinationChainId,
+                destinationTxHash: fillEvent.fillTxHash,
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Summary

The SDK now resolves explorer URLs per order and surfaces them on every `OrderTrackingUpdate` instead of asking each consumer to wire their own provider→URL mapping.

- `OrderTrackingUpdate` adds `explorers?: { tracker?, origin?, destination? }`, plus `originChainId` (required) and `destinationChainId`.
- `CrossChainProvider.getOrderExplorers(params)` returns chain block explorer URLs by default. Across and Bungee override it to also return their bridge tracker URL. LiFi Intents, OIF and Relay use the default until they have a public scanner.
- `OrderTracker` invokes the provider's resolver inside `createUpdate`, so consumers read `update.explorers.tracker ?? update.explorers.origin` instead of building URLs.

The examples UI now reads `state.update.explorers` directly. The previous `useOrderExplorers` hook is gone.

## Test plan

- Unit tests for the per-provider override (Across, Bungee) and default (LiFi) behaviors.
- Wiring test on `OrderTracker` that asserts the resolver receives the full chain context and both tx hashes once the fill is observed.
- Manual checks against examples/ui (Across mainnet, Bungee mainnet, LiFi mainnet, OIF testnet) to verify URLs render in Progress/Success/Error views.

Closes EFI-916