### PR TITLE
feat(ui): integrate OIF approval service flow

### DIFF
--- a/examples/ui/app/cross-chain/hooks/useOrderExecution.ts
+++ b/examples/ui/app/cross-chain/hooks/useOrderExecution.ts
@@ -1,12 +1,12 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { isSignatureOnlyOrder, type ExecutableQuote } from '@wonderland/interop-cross-chain';
+import { getSignatureSteps, type ExecutableQuote } from '@wonderland/interop-cross-chain';
 import { useAccount, useConfig, useSwitchChain } from 'wagmi';
 import {
   ensureCorrectChain,
   executeDirectTransaction,
-  submitOifSignableOrder,
+  submitSignableOrder,
   trackOrder,
 } from '../services/orderExecution';
 import { useBalanceStore } from '../stores/balanceStore';
@@ -97,9 +97,9 @@ export function useOrderExecution(): UseOrderExecutionReturn {
         );
         expectedWalletChainIdRef.current = null;
 
-        // Branch: signature-based (OIF escrow/3009) vs direct transaction
-        const isSignable = isSignatureOnlyOrder(quote.order);
-        const executeFlow = isSignable ? submitOifSignableOrder : executeDirectTransaction;
+        // Branch: signable orders (approvals + sign+submit) vs direct transaction orders.
+        const needsSignature = getSignatureSteps(quote.order).length > 0;
+        const executeFlow = needsSignature ? submitSignableOrder : executeDirectTransaction;
 
         const trackingId = await executeFlow({
           quote,

--- a/examples/ui/app/cross-chain/hooks/useOrderExecution.ts
+++ b/examples/ui/app/cross-chain/hooks/useOrderExecution.ts
@@ -105,9 +105,6 @@ export function useOrderExecution(): UseOrderExecutionReturn {
           quote,
           walletClient,
           publicClient,
-          ownerAddress: address,
-          inputTokenAddress,
-          inputAmount,
           chainContext,
           onStateChange: setState,
         });

--- a/examples/ui/app/cross-chain/services/orderExecution/approval.ts
+++ b/examples/ui/app/cross-chain/services/orderExecution/approval.ts
@@ -1,8 +1,8 @@
-import { erc20Abi, type Address, type Hex, type PublicClient } from 'viem';
 import { STEP, WALLET_ACTION, type BridgeState, type ChainContext } from '../../types/execution';
 import { waitForReceiptWithRetry } from '../../utils/transactionReceipt';
 import type { ConfiguredWalletClient } from './chainSetup';
 import type { TransactionStep } from '@wonderland/interop-cross-chain';
+import type { Address, Hex, PublicClient } from 'viem';
 
 export async function executeApprovalStep(
   publicClient: PublicClient,
@@ -30,41 +30,6 @@ export async function executeApprovalStep(
     txHash: approvalHash,
     ...chainContext,
   });
-
-  await waitForReceiptWithRetry(publicClient, approvalHash);
-}
-
-export async function handleTokenApproval(
-  publicClient: PublicClient,
-  walletClient: ConfiguredWalletClient,
-  userAddress: Address,
-  inputTokenAddress: Address,
-  spenderAddress: Address,
-  inputAmount: bigint,
-  chainContext: ChainContext,
-  onStateChange: (state: BridgeState) => void,
-): Promise<void> {
-  onStateChange({ step: STEP.WALLET, action: WALLET_ACTION.CHECKING, ...chainContext });
-
-  const allowance = await publicClient.readContract({
-    address: inputTokenAddress,
-    abi: erc20Abi,
-    functionName: 'allowance',
-    args: [userAddress, spenderAddress],
-  });
-
-  if (allowance >= inputAmount) return;
-
-  onStateChange({ step: STEP.WALLET, action: WALLET_ACTION.APPROVING, ...chainContext });
-
-  const approvalHash = await walletClient.writeContract({
-    address: inputTokenAddress,
-    abi: erc20Abi,
-    functionName: 'approve',
-    args: [spenderAddress, inputAmount],
-  });
-
-  onStateChange({ step: STEP.WALLET, action: WALLET_ACTION.APPROVING, txHash: approvalHash, ...chainContext });
 
   await waitForReceiptWithRetry(publicClient, approvalHash);
 }

--- a/examples/ui/app/cross-chain/services/orderExecution/flows.ts
+++ b/examples/ui/app/cross-chain/services/orderExecution/flows.ts
@@ -1,5 +1,4 @@
 import {
-  isNativeAddress,
   isApprovalStep,
   getApprovalSteps,
   getTransactionSteps,
@@ -7,20 +6,17 @@ import {
   type TrackingIdentifier,
 } from '@wonderland/interop-cross-chain';
 import { useCrossChainStore } from '../../stores/crossChainStore';
-import { executeApprovalStep, handleTokenApproval } from './approval';
+import { executeApprovalStep } from './approval';
 import { submitBridgeTransaction } from './bridge';
 import { signAndSubmitOrder } from './signing';
 import type { ConfiguredWalletClient } from './chainSetup';
 import type { BridgeState, ChainContext } from '../../types/execution';
-import type { Address, Hex, PublicClient } from 'viem';
+import type { Hex, PublicClient } from 'viem';
 
 interface FlowParams {
   quote: ExecutableQuote;
   walletClient: ConfiguredWalletClient;
   publicClient: PublicClient;
-  ownerAddress: Address;
-  inputTokenAddress: Address;
-  inputAmount: bigint;
   chainContext: ChainContext;
   onStateChange: (state: BridgeState) => void;
 }
@@ -29,27 +25,11 @@ export const submitOifSignableOrder = async ({
   quote,
   walletClient,
   publicClient,
-  ownerAddress,
-  inputTokenAddress,
-  inputAmount,
   chainContext,
   onStateChange,
 }: FlowParams): Promise<TrackingIdentifier> => {
-  // Permit2 approval for escrow lock orders (3009 doesn't need approval)
-  const isEscrowOrder = quote.order.lock?.type === 'oif-escrow';
-  const isNativeInput = isNativeAddress(inputTokenAddress, 'eip155');
-  if (isEscrowOrder && !isNativeInput) {
-    const PERMIT2 = '0x000000000022D473030F116dDEE9F6B43aC78BA3' as Address;
-    await handleTokenApproval(
-      publicClient,
-      walletClient,
-      ownerAddress,
-      inputTokenAddress,
-      PERMIT2,
-      inputAmount,
-      chainContext,
-      onStateChange,
-    );
+  for (const step of getApprovalSteps(quote.order)) {
+    await executeApprovalStep(publicClient, walletClient, step, chainContext, onStateChange);
   }
 
   const { orderId } = await signAndSubmitOrder({

--- a/examples/ui/app/cross-chain/services/orderExecution/flows.ts
+++ b/examples/ui/app/cross-chain/services/orderExecution/flows.ts
@@ -21,7 +21,7 @@ interface FlowParams {
   onStateChange: (state: BridgeState) => void;
 }
 
-export const submitOifSignableOrder = async ({
+export const submitSignableOrder = async ({
   quote,
   walletClient,
   publicClient,

--- a/examples/ui/app/cross-chain/services/orderExecution/index.ts
+++ b/examples/ui/app/cross-chain/services/orderExecution/index.ts
@@ -1,3 +1,3 @@
 export { ensureCorrectChain, type ChainClients, type ConfiguredWalletClient } from './chainSetup';
-export { submitOifSignableOrder, executeDirectTransaction } from './flows';
+export { submitSignableOrder, executeDirectTransaction } from './flows';
 export { trackOrder, TrackingError } from './tracking';


### PR DESCRIPTION
# 🤖 Linear

Closes EFI-884

## Description

The OIF signable order flow handled Permit2 approval inline: it read the allowance, sent the approve transaction, and skipped the path entirely for native inputs. The approval service now exposes the same approval steps that the direct transaction flow already consumes, so that custom branch is redundant.

This change drops the manual path and runs the same `getApprovalSteps` loop used by `executeDirectTransaction`. Escrow orders, 3009 orders and native inputs all go through one code path.

### Changes

- `services/orderExecution/flows.ts`: replace the Permit2 branch in `submitOifSignableOrder` with the `getApprovalSteps` loop. Remove `ownerAddress`, `inputTokenAddress` and `inputAmount` from `FlowParams`.
- `services/orderExecution/approval.ts`: delete `handleTokenApproval` and the `erc20Abi` import. `executeApprovalStep` covers every case.
- `hooks/useOrderExecution.ts`: stop forwarding the three removed arguments to `submitOifSignableOrder`.

## Test plan

Ran a couple of quotes through the OIF protocol and minted USDC end to end to confirm the approval step is picked up from `getApprovalSteps` and the order goes through.

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [ ] If it is a core feature, I have included comprehensive tests.