### PR TITLE
fix(cross-chain): preserve baseURL path prefix in FetchHttpClient

### DIFF
--- a/.changeset/fix-fetch-http-client-base-url.md
+++ b/.changeset/fix-fetch-http-client-base-url.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Fix `FetchHttpClient` dropping the path prefix of `baseURL` when the request path starts with `/`. The `URL` constructor treats leading-slash paths as absolute and discards the base path, so callers that point at a proxy or gateway (e.g. `https://proxy.example.com/relay-api/`) saw their requests hit the wrong endpoint and returned 404. `buildUrl` now normalizes `baseURL` to end with `/` and strips the leading `/` from the path before resolving.

--- a/packages/cross-chain/src/core/utils/httpClient.ts
+++ b/packages/cross-chain/src/core/utils/httpClient.ts
@@ -65,13 +65,20 @@ export class FetchHttpClient implements HttpClient {
     }
 
     private buildUrl(path: string, params?: Record<string, unknown>): string {
-        const url = new URL(path, this.config.baseURL);
+        const url = this.resolveUrl(path);
         if (params) {
             for (const [key, value] of Object.entries(params)) {
                 if (value != null) url.searchParams.set(key, String(value));
             }
         }
         return url.toString();
+    }
+
+    private resolveUrl(path: string): URL {
+        const { baseURL } = this.config;
+        const base = baseURL && !baseURL.endsWith("/") ? `${baseURL}/` : baseURL;
+        const resolvedPath = base ? path.replace(/^\//, "") : path;
+        return new URL(resolvedPath, base);
     }
 
     private buildRequestInit(options: HttpRequestOptions): Omit<RequestInit, "signal"> {

--- a/packages/cross-chain/test/utils/httpClient.spec.ts
+++ b/packages/cross-chain/test/utils/httpClient.spec.ts
@@ -69,6 +69,28 @@ describe("httpClient", () => {
             expect(fetchMock).toHaveBeenCalledWith("https://right.test/path", expect.anything());
         });
 
+        it("preserves baseURL path prefix when joining with leading-slash paths", async () => {
+            fetchMock.mockResolvedValueOnce(jsonResponse({}));
+            await new FetchHttpClient({ baseURL: "https://proxy.example.com/relay-api/" }).get(
+                "/quote/v2",
+            );
+            expect(fetchMock).toHaveBeenCalledWith(
+                "https://proxy.example.com/relay-api/quote/v2",
+                expect.anything(),
+            );
+        });
+
+        it("normalizes baseURL without trailing slash", async () => {
+            fetchMock.mockResolvedValueOnce(jsonResponse({}));
+            await new FetchHttpClient({ baseURL: "https://proxy.example.com/relay-api" }).get(
+                "/quote/v2",
+            );
+            expect(fetchMock).toHaveBeenCalledWith(
+                "https://proxy.example.com/relay-api/quote/v2",
+                expect.anything(),
+            );
+        });
+
         it("appends params and skips null/undefined", async () => {
             fetchMock.mockResolvedValueOnce(jsonResponse({}));
             await httpRequest("https://api.test/q", {


### PR DESCRIPTION
## Summary

`FetchHttpClient.buildUrl` resolved paths with `new URL(path, baseURL)`. When `path` starts with `/`, the `URL` constructor treats it as absolute and drops the base path. A baseURL like `https://proxy.example.com/relay-api/` plus path `/quote/v2` resolved to `https://proxy.example.com/quote/v2`, hitting the wrong endpoint and returning 404. The default baseURLs we ship (e.g. `https://api.relay.link`) have no path, so internal callers were fine, but external consumers using a proxy or gateway were not.

Extracted `resolveUrl(path)`: it normalizes `baseURL` to end with `/` and strips the leading `/` from the path before calling `new URL`. Absolute paths (`https://other.test/x`) and unset `baseURL` keep their previous behavior.

Linear: [EFI-917](https://linear.app/defi-wonderland/issue/EFI-917). Flagged by cubic on #303.

## Test plan
- [x] `pnpm --filter @wonderland/interop-cross-chain test test/utils/httpClient.spec.ts` (15/15 pass, 2 new)
- [x] `pnpm --filter @wonderland/interop-cross-chain build`
- [x] `pnpm --filter @wonderland/interop-cross-chain lint` (no new warnings)