### PR TITLE
fix(cross-chain): guard missing destinationChainId on API tracking

### DIFF
--- a/.changeset/guard-watch-order-destination-chain.md
+++ b/.changeset/guard-watch-order-destination-chain.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+`OrderTracker.watchOrder` now throws a typed `MissingDestinationChainId` from the entrypoint when `destinationChainId` is missing on the API tracking path, instead of letting the call surface as a confusing failure inside the fill watcher. The same error class also replaces the generic throw used by the on-chain path when a parsed intent has no destination chain in `fillInstructions`.

--- a/.changeset/guard-watch-order-destination-chain.md
+++ b/.changeset/guard-watch-order-destination-chain.md
@@ -2,4 +2,4 @@
 "@wonderland/interop-cross-chain": patch
 ---
 
-`OrderTracker.watchOrder` now throws a typed `MissingDestinationChainId` from the entrypoint when `destinationChainId` is missing on the API tracking path, instead of letting the call surface as a confusing failure inside the fill watcher. The same error class also replaces the generic throw used by the on-chain path when a parsed intent has no destination chain in `fillInstructions`.
+`OrderTracker.watchOrder` now fails fast with a typed `MissingDestinationChainId` when the destination chain id cannot be determined, instead of bubbling up from internals or throwing a plain `Error`. Both the API and on-chain paths use the same error so callers can handle the case once.

--- a/examples/ui/app/cross-chain/utils/errorMessages.ts
+++ b/examples/ui/app/cross-chain/utils/errorMessages.ts
@@ -133,6 +133,13 @@ const ERROR_PATTERNS: Array<{ pattern: RegExp; result: ParsedError }> = [
     },
   },
   {
+    pattern: /MissingDestinationChainId|destinationChainId.*for API tracking|no destination chain in fillInstructions/i,
+    result: {
+      title: 'Missing Destination Chain',
+      message: 'Destination chain is required to track this order. Please retry from the quote step.',
+    },
+  },
+  {
     pattern: /execution reverted/i,
     result: {
       title: 'Transaction Failed',

--- a/packages/cross-chain/src/core/errors/MissingDestinationChainId.exception.ts
+++ b/packages/cross-chain/src/core/errors/MissingDestinationChainId.exception.ts
@@ -1,9 +1,4 @@
-/**
- * Thrown when `OrderTracker.watchOrder` is called on the API tracking path
- * without a `destinationChainId`. The fill watcher requires it to query the
- * destination leg, so we fail fast at the entrypoint with a clear message
- * instead of surfacing a confusing error from deep inside the watcher.
- */
+/** Thrown when the destination chain id is required but cannot be resolved. */
 export class MissingDestinationChainId extends Error {
     constructor(reason: "api-tracking" | "order-fill-instructions") {
         const detail =

--- a/packages/cross-chain/src/core/errors/MissingDestinationChainId.exception.ts
+++ b/packages/cross-chain/src/core/errors/MissingDestinationChainId.exception.ts
@@ -1,0 +1,16 @@
+/**
+ * Thrown when `OrderTracker.watchOrder` is called on the API tracking path
+ * without a `destinationChainId`. The fill watcher requires it to query the
+ * destination leg, so we fail fast at the entrypoint with a clear message
+ * instead of surfacing a confusing error from deep inside the watcher.
+ */
+export class MissingDestinationChainId extends Error {
+    constructor(reason: "api-tracking" | "order-fill-instructions") {
+        const detail =
+            reason === "api-tracking"
+                ? "watchOrder requires `destinationChainId` for API tracking. Pass it explicitly when using tracking: 'api' or orderId-based tracking."
+                : "Order has no destination chain in fillInstructions";
+        super(detail);
+        this.name = "MissingDestinationChainId";
+    }
+}

--- a/packages/cross-chain/src/core/errors/index.ts
+++ b/packages/cross-chain/src/core/errors/index.ts
@@ -17,6 +17,7 @@ export * from "./APIRequestFailure.exception.js";
 export * from "./ZeroAmount.exception.js";
 export * from "./InsufficientFee.exception.js";
 export * from "./InvalidDeadline.exception.js";
+export * from "./MissingDestinationChainId.exception.js";
 export * from "./DifferentAssetNotAllowed.exception.js";
 export * from "./SameChainIntentNotAllowed.exception.js";
 export * from "./UnsupportedAsset.exception.js";

--- a/packages/cross-chain/src/core/services/OrderTracker.ts
+++ b/packages/cross-chain/src/core/services/OrderTracker.ts
@@ -14,6 +14,7 @@ import type {
     WatchOrderByTxHash,
     WatchOrderParams,
 } from "../types/orderTracking.js";
+import { MissingDestinationChainId } from "../errors/MissingDestinationChainId.exception.js";
 import { OpenedIntentNotFoundError } from "../errors/OpenedIntentNotFound.exception.js";
 import { OrderTrackerEvent } from "../interfaces/orderTracker.interface.js";
 import { OrderFailureReason, OrderStatus, OrderTrackerYieldType } from "../types/orderTracking.js";
@@ -170,6 +171,11 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
             const openTxHash =
                 ("openTxHash" in params ? params.openTxHash : undefined) ??
                 ("txHash" in params ? params.txHash : undefined);
+
+            if (!params.destinationChainId) {
+                throw new MissingDestinationChainId("api-tracking");
+            }
+
             yield* this.watchOrderByOrderId({
                 ...(params as WatchOrderByOrderId),
                 openTxHash,
@@ -232,7 +238,7 @@ export class OrderTracker extends TypedEventEmitter<OrderTrackerEvents> {
 
         const destinationChainId = openedIntent.fillInstructions[0]?.destinationChainId;
         if (!destinationChainId) {
-            throw new Error("Order has no destination chain in fillInstructions");
+            throw new MissingDestinationChainId("order-fill-instructions");
         }
 
         lastUpdate = this.createUpdate({

--- a/packages/cross-chain/test/services/OrderTracker.spec.ts
+++ b/packages/cross-chain/test/services/OrderTracker.spec.ts
@@ -2,6 +2,7 @@ import { Hex } from "viem";
 import { baseSepolia, sepolia } from "viem/chains";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { MissingDestinationChainId } from "../../src/core/errors/MissingDestinationChainId.exception.js";
 import { FillTimeoutError } from "../../src/core/services/EventBasedFillWatcher.js";
 import {
     FillWatcher,
@@ -933,6 +934,19 @@ describe("OrderTracker", () => {
                 destinationChainId: mockDestinationChainId,
             });
             expect(mockFillWatcher.getFill).toHaveBeenCalled();
+            expect(mockOnChainWatcher.getFill).not.toHaveBeenCalled();
+        });
+
+        it("explicit + tracking: 'api' without destinationChainId → throws MissingDestinationChainId", async () => {
+            const generator = tracker.watchOrder({
+                txHash: mockTxHash,
+                orderId,
+                tracking: "api",
+                originChainId: mockOriginChainId,
+            } as unknown as WatchOrderParams);
+
+            await expect(generator.next()).rejects.toBeInstanceOf(MissingDestinationChainId);
+            expect(mockFillWatcher.getFill).not.toHaveBeenCalled();
             expect(mockOnChainWatcher.getFill).not.toHaveBeenCalled();
         });
     });

--- a/packages/cross-chain/test/services/OrderTracker.spec.ts
+++ b/packages/cross-chain/test/services/OrderTracker.spec.ts
@@ -937,7 +937,7 @@ describe("OrderTracker", () => {
             expect(mockOnChainWatcher.getFill).not.toHaveBeenCalled();
         });
 
-        it("explicit + tracking: 'api' without destinationChainId → throws MissingDestinationChainId", async () => {
+        it("throws MissingDestinationChainId when tracking by order id without destinationChainId", async () => {
             const generator = tracker.watchOrder({
                 txHash: mockTxHash,
                 orderId,


### PR DESCRIPTION
# 🤖 Linear

Closes EFI-918

## Description

`OrderTracker.watchOrder` had a footgun: `WatchOrderExplicit.destinationChainId` is optional, but the API tracking path forwards to `apiFillWatcher.getFill`, which requires it. A consumer using `tracking: 'api'` without `destinationChainId` got a confusing failure from deep inside the fill watcher.

Now `watchOrder` throws a typed `MissingDestinationChainId` at the entrypoint with a clear message. The same class also replaces the generic `throw new Error("Order has no destination chain in fillInstructions")` in the on-chain path when a parsed intent has no destination chain.

### Changes

- New exception class `MissingDestinationChainId` in `packages/cross-chain/src/core/errors/`, exported from the public barrel.
- `OrderTracker.watchOrder` throws it on the API tracking path when `destinationChainId` is missing.
- `OrderTracker.watchOrderByTxHash` throws the same class when the parsed `OpenedIntent` has no destination chain in `fillInstructions`.
- Example UI's `errorMessages.ts` parser maps the new class to a user-friendly "Missing Destination Chain" message.
- Test for the API guard, plus a changeset (patch bump).

No internal caller hits this today. This is a DX fix for external integrators.

## Test Plan

I have performed some cross-chain transactions, such as swapping USDC to USDC, as well as USDC to Ethereum and USDC to WETH.

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [ ] If it is a core feature, I have included comprehensive tests.