### PR TITLE
feat(cross-chain): add enableMultipleRoutes config to Bungee provider

### DIFF
--- a/.changeset/bungee-enable-multiple-routes.md
+++ b/.changeset/bungee-enable-multiple-routes.md
@@ -1,0 +1,14 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Add `enableMultipleRoutes` to the Bungee provider config.
+
+When set to `true`, Bungee returns several route alternatives per quote
+request (for example one optimised for the highest output, another for the
+fastest fill) and the SDK emits one `Quote` per alternative. Defaults to
+`false`, which keeps a single recommended route per request.
+
+This replaces the previous behaviour, which always asked Bungee for multiple
+routes — opt back in by setting `enableMultipleRoutes: true`. The option is
+named generically so other providers with a similar concept can adopt it.

--- a/apps/docs/docs/cross-chain/bungee-provider.md
+++ b/apps/docs/docs/cross-chain/bungee-provider.md
@@ -22,18 +22,19 @@ See [Bungee's API access docs](https://docs.bungee.exchange/integrate/get-api-ac
 
 ## Configuration
 
-| Field             | Type            | Required | Description                                                                                                                   |
-| ----------------- | --------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `tier`            | `BungeeApiTier` | No       | API tier: `"sandbox"`, `"dedicated"`, or `"frontend"` (default: `"sandbox"`)                                                  |
-| `baseUrl`         | string          | No       | Custom API base URL. Overrides the URL derived from `tier`                                                                    |
-| `providerId`      | string          | No       | Custom provider identifier (default: `"bungee"`)                                                                              |
-| `apiKey`          | string          | No       | API key for dedicated backend (sent via `x-api-key` header)                                                                   |
-| `affiliateId`     | string          | No       | Affiliate ID for tracking (sent via `affiliate` header)                                                                       |
-| `feeBps`          | string          | No       | Convenience fee in basis points (e.g. `"50"` for 0.5%)                                                                        |
-| `feeTakerAddress` | string          | No       | Address to receive the convenience fee. Required when `feeBps` is set                                                         |
-| `submissionModes` | string[]        | No       | Transaction submission modes: `"user-transaction"` (onchain) and/or `"gasless"` (permit2). Defaults to `["user-transaction"]` |
-| `slippage`        | string          | No       | Default slippage tolerance (e.g. `"0.5"` for 0.5%)                                                                            |
-| `refuel`          | boolean         | No       | Enable native gas refueling on the destination chain                                                                          |
+| Field                  | Type            | Required | Description                                                                                                                                                                          |
+| ---------------------- | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `tier`                 | `BungeeApiTier` | No       | API tier: `"sandbox"`, `"dedicated"`, or `"frontend"` (default: `"sandbox"`)                                                                                                         |
+| `baseUrl`              | string          | No       | Custom API base URL. Overrides the URL derived from `tier`                                                                                                                           |
+| `providerId`           | string          | No       | Custom provider identifier (default: `"bungee"`)                                                                                                                                     |
+| `apiKey`               | string          | No       | API key for dedicated backend (sent via `x-api-key` header)                                                                                                                          |
+| `affiliateId`          | string          | No       | Affiliate ID for tracking (sent via `affiliate` header)                                                                                                                              |
+| `feeBps`               | string          | No       | Convenience fee in basis points (e.g. `"50"` for 0.5%)                                                                                                                               |
+| `feeTakerAddress`      | string          | No       | Address to receive the convenience fee. Required when `feeBps` is set                                                                                                                |
+| `submissionModes`      | string[]        | No       | Transaction submission modes: `"user-transaction"` (onchain) and/or `"gasless"` (permit2). Defaults to `["user-transaction"]`                                                        |
+| `slippage`             | string          | No       | Default slippage tolerance (e.g. `"0.5"` for 0.5%)                                                                                                                                   |
+| `refuel`               | boolean         | No       | Enable native gas refueling on the destination chain                                                                                                                                 |
+| `enableMultipleRoutes` | boolean         | No       | Ask the provider for several route alternatives per quote (e.g. one optimised for max output, another for the fastest fill) instead of only the recommended one. Defaults to `false` |
 
 :::info Gasless is opt-in — the default is `["user-transaction"]` only
 
@@ -182,6 +183,18 @@ const bungeeProvider = createCrossChainProvider("bungee", {
     refuel: true,
 });
 ```
+
+### Multiple route alternatives
+
+By default the SDK only asks for the recommended route, so each quote request returns a single `Quote`. If you want the aggregator to compare more options — for example one optimised for the highest output and another for the fastest fill — opt in:
+
+```typescript
+const bungeeProvider = createCrossChainProvider("bungee", {
+    enableMultipleRoutes: true,
+});
+```
+
+The flag is named generically on purpose: if another provider adds the same idea of returning more than one route per request, it can reuse the same option.
 
 ### With Custom Base URL
 

--- a/apps/docs/docs/cross-chain/providers.md
+++ b/apps/docs/docs/cross-chain/providers.md
@@ -42,13 +42,13 @@ createCrossChainProvider("bungee", {
 });
 ```
 
-| Provider       | Required Config   | Optional Config                                                                                       |
-| -------------- | ----------------- | ----------------------------------------------------------------------------------------------------- |
-| `across`       | (none)            | `isTestnet`                                                                                           |
-| `relay`        | (none)            | `apiKey`, `isTestnet`                                                                                 |
-| `oif`          | `solverId`, `url` | —                                                                                                     |
-| `lifi-intents` | `orderServerUrl`  | `providerId`, `headers`                                                                               |
-| `bungee`       | (none)            | `tier`, `apiKey`, `affiliateId`, `feeBps`, `feeTakerAddress`, `submissionModes`, `slippage`, `refuel` |
+| Provider       | Required Config   | Optional Config                                                                                                               |
+| -------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `across`       | (none)            | `isTestnet`                                                                                                                   |
+| `relay`        | (none)            | `apiKey`, `isTestnet`                                                                                                         |
+| `oif`          | `solverId`, `url` | —                                                                                                                             |
+| `lifi-intents` | `orderServerUrl`  | `providerId`, `headers`                                                                                                       |
+| `bungee`       | (none)            | `tier`, `apiKey`, `affiliateId`, `feeBps`, `feeTakerAddress`, `submissionModes`, `slippage`, `refuel`, `enableMultipleRoutes` |
 
 ## `isTestnet` semantics
 

--- a/packages/cross-chain/README.md
+++ b/packages/cross-chain/README.md
@@ -254,6 +254,7 @@ const provider = createCrossChainProvider("bungee", {
     slippage: "0.5", // 0.5% slippage tolerance
     refuel: true, // native gas on destination chain
     affiliateId: "your-affiliate-id",
+    enableMultipleRoutes: true, // return several route alternatives per quote (default: false)
 });
 ```
 

--- a/packages/cross-chain/src/protocols/bungee/adapters/quoteRequestAdapter.ts
+++ b/packages/cross-chain/src/protocols/bungee/adapters/quoteRequestAdapter.ts
@@ -13,6 +13,7 @@ export interface BungeeQuoteOptions extends FeeConfig {
     submissionMode?: SubmissionMode;
     slippage?: string;
     refuel?: boolean;
+    enableMultipleRoutes?: boolean;
 }
 
 /**
@@ -49,7 +50,6 @@ export function adaptQuoteRequest(
             "eip155",
             NATIVE_ASSET_ADDRESS,
         ),
-        enableMultipleAutoRoutes: "true",
     };
 
     if (options.feeBps) request.feeBps = options.feeBps;
@@ -57,6 +57,7 @@ export function adaptQuoteRequest(
     if (options.submissionMode === "user-transaction") request.useInbox = "true";
     if (options.slippage) request.slippage = options.slippage;
     if (options.refuel) request.refuel = "true";
+    if (options.enableMultipleRoutes) request.enableMultipleAutoRoutes = "true";
 
     return BungeeQuoteRequestSchema.parse(request);
 }

--- a/packages/cross-chain/src/protocols/bungee/provider.ts
+++ b/packages/cross-chain/src/protocols/bungee/provider.ts
@@ -77,6 +77,7 @@ export class BungeeProvider extends CrossChainProvider {
                 feeTakerAddress: parsed.feeTakerAddress,
                 slippage: parsed.slippage,
                 refuel: parsed.refuel,
+                enableMultipleRoutes: parsed.enableMultipleRoutes,
             };
 
             this.http = new FetchHttpClient({

--- a/packages/cross-chain/src/protocols/bungee/types.ts
+++ b/packages/cross-chain/src/protocols/bungee/types.ts
@@ -36,6 +36,14 @@ export const BungeeConfigSchema = z
         slippage: z.string().optional(),
         /** Enable native gas refueling on the destination chain. */
         refuel: z.boolean().optional(),
+        /**
+         * Ask the provider to return multiple route alternatives per quote request — for example one
+         * optimised for the highest output, another for the fastest fill — instead of only the
+         * recommended route. Defaults to `false`, which returns just the recommended route.
+         *
+         * The flag is named generically so other providers with a similar concept can adopt it.
+         */
+        enableMultipleRoutes: z.boolean().optional(),
     })
     .merge(FeeConfigSchema)
     .refine(feeConfigRefinement, FEE_CONFIG_REFINEMENT_ERROR);

--- a/packages/cross-chain/src/protocols/bungee/types.ts
+++ b/packages/cross-chain/src/protocols/bungee/types.ts
@@ -36,13 +36,7 @@ export const BungeeConfigSchema = z
         slippage: z.string().optional(),
         /** Enable native gas refueling on the destination chain. */
         refuel: z.boolean().optional(),
-        /**
-         * Ask the provider to return multiple route alternatives per quote request — for example one
-         * optimised for the highest output, another for the fastest fill — instead of only the
-         * recommended route. Defaults to `false`, which returns just the recommended route.
-         *
-         * The flag is named generically so other providers with a similar concept can adopt it.
-         */
+        /** Return multiple route alternatives per quote (e.g. max-output, fastest) instead of just the recommended one. Defaults to `false`. */
         enableMultipleRoutes: z.boolean().optional(),
     })
     .merge(FeeConfigSchema)

--- a/packages/cross-chain/test/protocols/bungee/adapters/quoteRequestAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/adapters/quoteRequestAdapter.spec.ts
@@ -99,6 +99,27 @@ describe("adaptQuoteRequest", () => {
         expect(result.refuel).toBe("true");
     });
 
+    it("does not request multiple routes by default", () => {
+        const request = buildQuoteRequest();
+        const result = adaptQuoteRequest(request);
+
+        expect(result.enableMultipleAutoRoutes).toBeUndefined();
+    });
+
+    it("requests multiple routes when enableMultipleRoutes is true", () => {
+        const request = buildQuoteRequest();
+        const result = adaptQuoteRequest(request, { enableMultipleRoutes: true });
+
+        expect(result.enableMultipleAutoRoutes).toBe("true");
+    });
+
+    it("omits enableMultipleAutoRoutes when enableMultipleRoutes is false", () => {
+        const request = buildQuoteRequest();
+        const result = adaptQuoteRequest(request, { enableMultipleRoutes: false });
+
+        expect(result.enableMultipleAutoRoutes).toBeUndefined();
+    });
+
     it("omits optional fields when options are not provided", () => {
         const request = buildQuoteRequest();
         const result = adaptQuoteRequest(request);

--- a/packages/cross-chain/test/protocols/bungee/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/provider.spec.ts
@@ -298,6 +298,37 @@ describe("BungeeProvider", () => {
             );
         });
 
+        it("does not request multiple routes by default", async () => {
+            mockGet.mockResolvedValue({
+                status: 200,
+                data: makeBungeeQuoteResponse(),
+                headers: new Headers(),
+            });
+            await provider.getQuotes(makeQuoteRequest());
+
+            const [, options] = mockGet.mock.calls[0] as [
+                string,
+                { params: Record<string, string> },
+            ];
+            expect(options.params.enableMultipleAutoRoutes).toBeUndefined();
+        });
+
+        it("requests multiple routes when enableMultipleRoutes is true", async () => {
+            const multiRouteProvider = new BungeeProvider({ enableMultipleRoutes: true });
+            mockGet.mockResolvedValue({
+                status: 200,
+                data: makeBungeeQuoteResponse(),
+                headers: new Headers(),
+            });
+            await multiRouteProvider.getQuotes(makeQuoteRequest());
+
+            const [, options] = mockGet.mock.calls[0] as [
+                string,
+                { params: Record<string, string> },
+            ];
+            expect(options.params.enableMultipleAutoRoutes).toBe("true");
+        });
+
         it("returns an empty array when every mode responds with no routes", async () => {
             const emptyResponse = makeBungeeQuoteResponse({
                 result: {


### PR DESCRIPTION
Closes [EFI-924](https://linear.app/defi-wonderland/issue/EFI-924).

## Summary

Bungee quotes now return only the recommended route by default. Set `enableMultipleRoutes: true` on the provider config to receive every route alternative (one `Quote` per route), restoring the previous behaviour.

## Test plan

- [x] `getQuotes` with a USDC → USDC request and no extra config returns a single recommended route.