### PR TITLE
feat(benchmark): scaffold cross-chain quotes benchmark app

### DIFF
--- a/apps/benchmark/.gitignore
+++ b/apps/benchmark/.gitignore
@@ -1,0 +1,32 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files
+.env
+.env.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/apps/benchmark/.prettierrc
+++ b/apps/benchmark/.prettierrc
@@ -1,0 +1,10 @@
+{
+    "tabWidth": 2,
+    "printWidth": 120,
+    "singleQuote": true,
+    "jsxSingleQuote": true,
+    "bracketSpacing": true,
+    "arrowParens": "always",
+    "semi": true,
+    "trailingComma": "all"
+}

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -1,0 +1,13 @@
+# benchmark
+
+Next.js app that benchmarks cross-chain quote performance across providers via
+[`@wonderland/interop-cross-chain`](../../packages/cross-chain).
+
+## Development
+
+```bash
+pnpm install
+pnpm --filter benchmark dev
+```
+
+Open http://localhost:3000.

--- a/apps/benchmark/app/globals.css
+++ b/apps/benchmark/app/globals.css
@@ -1,0 +1,27 @@
+@import 'tailwindcss';
+
+:root {
+  --background: #0f172a;
+  --foreground: #f1f5f9;
+  --surface: #1e293b;
+  --border: #334155;
+  --accent: #818cf8;
+  --text-secondary: #cbd5e1;
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  --color-border: var(--border);
+  --color-accent: var(--accent);
+  --color-text-secondary: var(--text-secondary);
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
+}
+
+body {
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-geist-sans), system-ui, sans-serif;
+}

--- a/apps/benchmark/app/globals.d.ts
+++ b/apps/benchmark/app/globals.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/apps/benchmark/app/layout.tsx
+++ b/apps/benchmark/app/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next';
+import { Geist, Geist_Mono } from 'next/font/google';
+import './globals.css';
+
+const geistSans = Geist({
+  variable: '--font-geist-sans',
+  subsets: ['latin'],
+});
+
+const geistMono = Geist_Mono({
+  variable: '--font-geist-mono',
+  subsets: ['latin'],
+});
+
+export const metadata: Metadata = {
+  title: 'Interop Cross-Chain Benchmark',
+  description: 'Quote performance benchmark across cross-chain providers',
+};
+
+export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang='en'>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
+    </html>
+  );
+}

--- a/apps/benchmark/app/page.tsx
+++ b/apps/benchmark/app/page.tsx
@@ -1,0 +1,14 @@
+export default function Home() {
+  return (
+    <main className='min-h-screen flex items-center justify-center p-8'>
+      <div className='max-w-xl flex flex-col gap-4 text-center'>
+        <h1 className='text-3xl font-bold'>Cross-chain benchmark</h1>
+        <p className='text-text-secondary'>
+          Compare quote performance across providers using{' '}
+          <code className='font-mono'>@wonderland/interop-cross-chain</code>.
+        </p>
+        <p className='text-text-secondary text-sm'>Coming soon.</p>
+      </div>
+    </main>
+  );
+}

--- a/apps/benchmark/eslint.config.mjs
+++ b/apps/benchmark/eslint.config.mjs
@@ -1,0 +1,67 @@
+import { fixupConfigRules, fixupPluginRules } from '@eslint/compat';
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+import tsParser from '@typescript-eslint/parser';
+import importPlugin from 'eslint-plugin-import';
+import prettierPlugin from 'eslint-plugin-prettier';
+
+const compat = new FlatCompat({
+  baseDirectory: import.meta.dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
+});
+
+export default [
+  {
+    ignores: ['.next/**', 'out/**', 'build/**', 'next-env.d.ts'],
+  },
+  ...fixupConfigRules(
+    compat.extends(
+      'prettier',
+      'plugin:react/recommended',
+      'plugin:jsx-a11y/recommended',
+      'plugin:@typescript-eslint/recommended',
+      'plugin:import/typescript',
+      'plugin:react/jsx-runtime',
+      'plugin:react-hooks/recommended',
+      'plugin:@next/next/recommended',
+    ),
+  ),
+  {
+    files: ['**/*.{js,mjs,cjs,jsx,ts,tsx}'],
+    plugins: {
+      import: fixupPluginRules(importPlugin),
+      prettier: fixupPluginRules(prettierPlugin),
+    },
+    languageOptions: {
+      parser: tsParser,
+    },
+    rules: {
+      'import/order': [
+        'error',
+        {
+          'newlines-between': 'never',
+          alphabetize: {
+            order: 'asc',
+            caseInsensitive: false,
+          },
+          groups: ['external', 'builtin', 'parent', 'sibling', 'index', 'object', 'type', 'unknown'],
+          pathGroups: [
+            { pattern: 'react', group: 'external', position: 'before' },
+            { pattern: 'next', group: 'external', position: 'before' },
+            { pattern: 'next/**', group: 'external', position: 'before' },
+          ],
+          pathGroupsExcludedImportTypes: ['react'],
+        },
+      ],
+      'prettier/prettier': 'error',
+      '@typescript-eslint/no-empty-object-type': 'off',
+      '@typescript-eslint/no-empty-interface': 'off',
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+  },
+];

--- a/apps/benchmark/next.config.ts
+++ b/apps/benchmark/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/apps/benchmark/package.json
+++ b/apps/benchmark/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "benchmark",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Cross-chain quotes benchmark site using @wonderland/interop-cross-chain",
+  "license": "MIT",
+  "author": "Wonderland",
+  "type": "module",
+  "scripts": {
+    "build": "next build",
+    "dev": "next dev --turbopack",
+    "format": "prettier app --write",
+    "format:check": "prettier app --check",
+    "lint": "eslint app",
+    "lint:fix": "eslint app --fix",
+    "start": "next start"
+  },
+  "lint-staged": {
+    "app/**/*.{js,jsx,ts,tsx}": "eslint --cache --fix",
+    "app/**/*.{js,jsx,ts,tsx,css,scss,md,html}": "prettier --write --ignore-unknown"
+  },
+  "dependencies": {
+    "@wonderland/interop-addresses": "workspace:*",
+    "@wonderland/interop-cross-chain": "workspace:*",
+    "next": "16.1.0",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "viem": "2.37.0"
+  },
+  "devDependencies": {
+    "@eslint/compat": "2.0.0",
+    "@eslint/eslintrc": "3.3.3",
+    "@eslint/js": "9.39.2",
+    "@next/eslint-plugin-next": "15.3.3",
+    "@tailwindcss/postcss": "4.1.15",
+    "@types/node": "22.7.4",
+    "@types/react": "19.2.7",
+    "@types/react-dom": "19.2.3",
+    "@typescript-eslint/eslint-plugin": "8.50.0",
+    "@typescript-eslint/parser": "8.50.0",
+    "eslint": "9.39.2",
+    "eslint-config-prettier": "9.1.0",
+    "eslint-plugin-import": "2.31.0",
+    "eslint-plugin-jsx-a11y": "6.10.0",
+    "eslint-plugin-prettier": "5.2.1",
+    "eslint-plugin-react": "7.37.0",
+    "eslint-plugin-react-hooks": "5.2.0",
+    "prettier": "3.3.3",
+    "tailwindcss": "4.1.15",
+    "typescript": "5.6.2"
+  }
+}

--- a/apps/benchmark/postcss.config.mjs
+++ b/apps/benchmark/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};
+
+export default config;

--- a/apps/benchmark/tsconfig.json
+++ b/apps/benchmark/tsconfig.json
@@ -14,7 +14,10 @@
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "plugins": [{ "name": "next" }]
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "~/*": ["./app/*"]
+    }
   },
   "include": ["./app", "./next-env.d.ts", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
   "exclude": ["./node_modules"]

--- a/apps/benchmark/tsconfig.json
+++ b/apps/benchmark/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "allowJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["./app", "./next-env.d.ts", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
+  "exclude": ["./node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,88 @@ importers:
                 specifier: 5.6.2
                 version: 5.6.2
 
+    apps/benchmark:
+        dependencies:
+            "@wonderland/interop-addresses":
+                specifier: workspace:*
+                version: link:../../packages/addresses
+            "@wonderland/interop-cross-chain":
+                specifier: workspace:*
+                version: link:../../packages/cross-chain
+            next:
+                specifier: 16.1.0
+                version: 16.1.0(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+            react:
+                specifier: 19.1.0
+                version: 19.1.0
+            react-dom:
+                specifier: 19.1.0
+                version: 19.1.0(react@19.1.0)
+            viem:
+                specifier: 2.37.0
+                version: 2.37.0(bufferutil@4.0.9)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+        devDependencies:
+            "@eslint/compat":
+                specifier: 2.0.0
+                version: 2.0.0(eslint@9.39.2(jiti@2.6.1))
+            "@eslint/eslintrc":
+                specifier: 3.3.3
+                version: 3.3.3
+            "@eslint/js":
+                specifier: 9.39.2
+                version: 9.39.2
+            "@next/eslint-plugin-next":
+                specifier: 15.3.3
+                version: 15.3.3
+            "@tailwindcss/postcss":
+                specifier: 4.1.15
+                version: 4.1.15
+            "@types/node":
+                specifier: 22.7.4
+                version: 22.7.4
+            "@types/react":
+                specifier: 19.2.7
+                version: 19.2.7
+            "@types/react-dom":
+                specifier: 19.2.3
+                version: 19.2.3(@types/react@19.2.7)
+            "@typescript-eslint/eslint-plugin":
+                specifier: 8.50.0
+                version: 8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.6.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.6.2)
+            "@typescript-eslint/parser":
+                specifier: 8.50.0
+                version: 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.6.2)
+            eslint:
+                specifier: 9.39.2
+                version: 9.39.2(jiti@2.6.1)
+            eslint-config-prettier:
+                specifier: 9.1.0
+                version: 9.1.0(eslint@9.39.2(jiti@2.6.1))
+            eslint-plugin-import:
+                specifier: 2.31.0
+                version: 2.31.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.6.2))(eslint@9.39.2(jiti@2.6.1))
+            eslint-plugin-jsx-a11y:
+                specifier: 6.10.0
+                version: 6.10.0(eslint@9.39.2(jiti@2.6.1))
+            eslint-plugin-prettier:
+                specifier: 5.2.1
+                version: 5.2.1(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))(prettier@3.3.3)
+            eslint-plugin-react:
+                specifier: 7.37.0
+                version: 7.37.0(eslint@9.39.2(jiti@2.6.1))
+            eslint-plugin-react-hooks:
+                specifier: 5.2.0
+                version: 5.2.0(eslint@9.39.2(jiti@2.6.1))
+            prettier:
+                specifier: 3.3.3
+                version: 3.3.3
+            tailwindcss:
+                specifier: 4.1.15
+                version: 4.1.15
+            typescript:
+                specifier: 5.6.2
+                version: 5.6.2
+
     apps/docs:
         dependencies:
             "@docusaurus/core":
@@ -16693,12 +16775,6 @@ packages:
                 integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==,
             }
 
-    tslib@2.7.0:
-        resolution:
-            {
-                integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==,
-            }
-
     tslib@2.8.1:
         resolution:
             {
@@ -21118,11 +21194,11 @@ snapshots:
     "@eslint/eslintrc@2.1.4":
         dependencies:
             ajv: 6.12.6
-            debug: 4.3.7
+            debug: 4.4.3
             espree: 9.6.1
             globals: 13.24.0
             ignore: 5.3.2
-            import-fresh: 3.3.0
+            import-fresh: 3.3.1
             js-yaml: 4.1.1
             minimatch: 3.1.2
             strip-json-comments: 3.1.1
@@ -21217,7 +21293,7 @@ snapshots:
     "@humanwhocodes/config-array@0.11.14":
         dependencies:
             "@humanwhocodes/object-schema": 2.0.3
-            debug: 4.3.7
+            debug: 4.4.3
             minimatch: 3.1.2
         transitivePeerDependencies:
             - supports-color
@@ -21792,7 +21868,7 @@ snapshots:
             "@oclif/help": 1.0.15
             "@oclif/parser": 3.8.17
             debug: 4.4.3
-            semver: 7.7.3
+            semver: 7.7.4
         transitivePeerDependencies:
             - supports-color
 
@@ -21803,7 +21879,7 @@ snapshots:
             "@oclif/help": 1.0.15
             "@oclif/parser": 3.8.17
             debug: 4.4.3
-            semver: 7.7.3
+            semver: 7.7.4
         transitivePeerDependencies:
             - supports-color
 
@@ -25896,7 +25972,7 @@ snapshots:
     detect-port@1.6.1:
         dependencies:
             address: 1.2.2
-            debug: 4.3.7
+            debug: 4.4.3
         transitivePeerDependencies:
             - supports-color
 
@@ -30895,7 +30971,7 @@ snapshots:
     synckit@0.9.1:
         dependencies:
             "@pkgr/core": 0.1.1
-            tslib: 2.7.0
+            tslib: 2.8.1
 
     tailwind-merge@3.3.1: {}
 
@@ -31073,8 +31149,6 @@ snapshots:
             strip-bom: 3.0.0
 
     tslib@1.14.1: {}
-
-    tslib@2.7.0: {}
 
     tslib@2.8.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,5 @@ packages:
     - "apps/sdk"
     - "apps/docs"
     - "apps/addresses-landing-page"
+    - "apps/benchmark"
     - "examples/*"


### PR DESCRIPTION
Scaffolds a new Next.js + Tailwind app under `apps/benchmark` that will host the cross-chain quote benchmark site.

Same stack as `examples/ui` (Next 16, React 19, Tailwind 4, TS 5.6). No DB, no wallet integration yet — just a placeholder landing page so the app boots and is wired into the workspace.

Why a new app under `apps/` instead of `examples/ui` or a separate repo:
- `examples/ui` is a stateless SDK demo. The benchmark eventually needs cron + persistence, so it doesn't belong there.
- Same monorepo keeps `workspace:*` link to `@wonderland/interop-cross-chain` and shared tooling. Separate repo would be overkill at this stage.

Closes EFI-902