### PR TITLE
fix(turbo): cache .vercel/output so Vocs docs deploy survives turbo replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ coverage
 # Turbo
 .turbo
 
+# Vercel
+.vercel
+
 # Foundry
 contracts/out
 contracts/cache

--- a/turbo.json
+++ b/turbo.json
@@ -24,7 +24,14 @@
         },
         "build": {
             "dependsOn": ["^build"],
-            "outputs": ["dist/**", "out/**", ".next/**", "!.next/cache/**", "build/**"],
+            "outputs": [
+                "dist/**",
+                "out/**",
+                ".next/**",
+                "!.next/cache/**",
+                "build/**",
+                ".vercel/output/**"
+            ],
             "inputs": ["$TURBO_DEFAULT$", "src/**/*.ts", "src/**/*.json"]
         },
         "dev": {

--- a/turbo.json
+++ b/turbo.json
@@ -32,7 +32,7 @@
                 "build/**",
                 ".vercel/output/**"
             ],
-            "inputs": ["$TURBO_DEFAULT$", "src/**/*.ts", "src/**/*.json"]
+            "inputs": ["$TURBO_DEFAULT$"]
         },
         "dev": {
             "cache": false


### PR DESCRIPTION
## Summary

Hotfix for the dev branch's docs deployment returning a 404 after the Vocs migration (#308) merged.

## Root cause

When running under Vercel, Vocs writes its build output straight to `.vercel/output/static/` via the Build Output API instead of `dist/`. Turbo's build `outputs` config in `turbo.json` only captured `dist/`, `build/`, `out/`, `.next/` — none of which Vocs touches on Vercel.

So when a Vercel build cache-hit Turbo on the dev branch, Turbo replayed the cached logs without restoring any files, and Vercel deployed an empty site:

```
docs:build:   [built] in 32.155s
Tasks:    1 successful, 1 total
Cached:    1 cached, 1 total
Time:    570ms >>> FULL TURBO
```

(The `[built] in 32.155s` line is from the cached run, not this one.)

Vercel then served whatever was in `.vercel/output` — nothing — and the deployed URLs returned 404.

## Fix

Add `.vercel/output/**` to the `build` task's `outputs` list. Now Turbo captures it on first run and restores it on cache hits, so subsequent deploys actually have artifacts to serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)