### PR TITLE
docs(cross-chain): correct ERC-7683 framing and adoption claims

### DIFF
--- a/.changeset/openedintentparser-completeness-docs.md
+++ b/.changeset/openedintentparser-completeness-docs.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Clarify the `OpenedIntentParser` interface JSDoc and the OIF constants header comment: on-chain event parsers (OIF, Across, LiFi Intents) return fully populated `OpenedIntent` fields, while API-based parsers (Relay, Bungee) return enough data to drive fill tracking and leave `maxSpent` / `minReceived` and some addresses as placeholders. No runtime behavior change.

--- a/apps/docs/pages/cross-chain/api.mdx
+++ b/apps/docs/pages/cross-chain/api.mdx
@@ -369,7 +369,7 @@ A factory for creating quote sorting strategies.
 
 ## Order Tracker
 
-A utility for tracking cross-chain orders from initiation to completion. Tracking uses ERC-7683 open-event parsing for providers that emit it (Across, OIF), a custom event for LiFi Intents, and provider status APIs for Relay and Bungee.
+A utility for tracking cross-chain orders from initiation to completion. Tracking uses provider-specific open-event parsing for Across (SpokePool `V3FundsDeposited`) and OIF (settler `Open` event) — each normalized into an ERC-7683/OIF-shaped `OpenedIntent` — a custom event for LiFi Intents, and provider status APIs for Relay and Bungee.
 
 ### Methods
 

--- a/apps/docs/pages/cross-chain/api.mdx
+++ b/apps/docs/pages/cross-chain/api.mdx
@@ -369,7 +369,7 @@ A factory for creating quote sorting strategies.
 
 ## Order Tracker
 
-A utility for tracking cross-chain orders from initiation to completion (ERC-7683 open event parsing + fill watching).
+A utility for tracking cross-chain orders from initiation to completion. Tracking uses ERC-7683 open-event parsing for providers that emit it (Across, OIF), a custom event for LiFi Intents, and provider status APIs for Relay and Bungee.
 
 ### Methods
 
@@ -743,5 +743,5 @@ Constraints:
 ## References
 
 -   [Cross-chain Protocol Standards](https://github.com/ethereum/ercs/blob/master/ERCS/erc-5164.md)
--   [EIP-7683: Cross Chain Intents](https://www.erc7683.org/)
+-   [ERC-7683: Cross Chain Intents](https://www.erc7683.org/)
 -   [Open Intents Framework](https://github.com/openintentsframework)

--- a/apps/docs/pages/cross-chain/concepts.mdx
+++ b/apps/docs/pages/cross-chain/concepts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Concepts
-description: The intent-based architecture behind the cross-chain package, the EIP-7683 standard, and how the SDK unifies multi-provider transfers.
+description: The intent-based architecture behind the cross-chain package and how the SDK unifies heterogeneous bridge providers behind a common interface.
 ---
 
 import { Mermaid } from "../../components/Mermaid";
@@ -21,15 +21,21 @@ The Interop SDK takes an **intent-based** approach instead. The user declares _w
 
 This separation of intent from execution means the same code works across different bridge protocols without provider-specific logic.
 
-## EIP-7683: Cross-Chain Intents
+## ERC-7683 and the OIF vocabulary
 
-The SDK follows [EIP-7683](https://www.erc7683.org/), which standardizes cross-chain intent structures. EIP-7683 defines:
+[ERC-7683](https://www.erc7683.org/) ("Cross-Chain Intents") defines a common order format, an "open" event on the origin chain, and a "fill" event on the destination chain. The [Open Intents Framework](https://github.com/openintentsframework) (OIF) builds on top of it with a concrete order-status vocabulary.
 
--   A common order format that any solver or bridge can fill
--   An "open" event on the origin chain that signals the intent is ready to be filled
--   A "fill" event on the destination chain that confirms execution
+The SDK borrows that vocabulary — `OrderStatus` values like `Created`, `Pending`, `Executing`, `Settling`, `Finalized` come from `@openintentsframework/oif-specs` — but **not every supported provider speaks ERC-7683 natively**:
 
-This standardization is what makes multi-provider aggregation possible — quotes from different providers share a common structure.
+| Provider     | Native protocol                              | How the SDK gets status                         |
+| ------------ | -------------------------------------------- | ----------------------------------------------- |
+| Across       | ERC-7683 open/fill events                    | Parses ERC-7683 open event + API/event watching |
+| OIF          | ERC-7683 (OIF is an ERC-7683 implementation) | Parses ERC-7683 open event + API/event watching |
+| Relay        | Relay's own intent API                       | Polls `/intents/status/v3`                      |
+| Bungee       | Bungee's own bridge / permit2 flow           | Polls Bungee's status API                       |
+| LiFi Intents | LI.FI's own resource-lock escrow             | Parses a custom LI.FI event + API watching      |
+
+What makes multi-provider aggregation possible is the SDK's adapter layer: each provider's native quote/order shape is normalized into the SDK's own `Quote` / `Order` / `OrderStatus` types — which are themselves ERC-7683/OIF-shaped where it makes sense. ERC-7683 is the vocabulary, not a precondition every provider has to meet.
 
 ## The transfer flow
 
@@ -121,12 +127,12 @@ Or: **Failed** / **Refunded**
 
 Tracking works through two mechanisms:
 
--   **Event-based**: Parse the ERC-7683 open event on the origin chain, then watch for the fill event on the destination chain. Requires RPC URLs for both chains.
+-   **Event-based**: Parse an open event on the origin chain (the ERC-7683 open event for Across and OIF; a custom event for LiFi Intents), then watch for the fill on the destination chain. Requires RPC URLs for both chains.
 -   **API-based**: Poll a provider's status endpoint. Simpler setup, no destination-chain RPC needed.
 
 The tracking mechanism is determined by the provider. See [Order Tracking](./intent-tracking) for usage details.
 
 ## References
 
--   [EIP-7683: Cross-Chain Intents](https://www.erc7683.org/)
+-   [ERC-7683: Cross-Chain Intents](https://www.erc7683.org/)
 -   [Open Intents Framework](https://github.com/openintentsframework)

--- a/apps/docs/pages/cross-chain/concepts.mdx
+++ b/apps/docs/pages/cross-chain/concepts.mdx
@@ -25,17 +25,17 @@ This separation of intent from execution means the same code works across differ
 
 [ERC-7683](https://www.erc7683.org/) ("Cross-Chain Intents") defines a common order format, an "open" event on the origin chain, and a "fill" event on the destination chain. The [Open Intents Framework](https://github.com/openintentsframework) (OIF) builds on top of it with a concrete order-status vocabulary.
 
-The SDK borrows that vocabulary — `OrderStatus` values like `Created`, `Pending`, `Executing`, `Settling`, `Finalized` come from `@openintentsframework/oif-specs` — but **not every supported provider speaks ERC-7683 natively**:
+The SDK borrows that vocabulary — `OrderStatus` values like `Created`, `Pending`, `Executing`, `Settling`, `Finalized` come from `@openintentsframework/oif-specs` — but **not every supported provider speaks ERC-7683 natively**, and even the ones that do emit provider-specific open events rather than the standard ERC-7683 Open event:
 
-| Provider     | Native protocol                              | How the SDK gets status                         |
-| ------------ | -------------------------------------------- | ----------------------------------------------- |
-| Across       | ERC-7683 open/fill events                    | Parses ERC-7683 open event + API/event watching |
-| OIF          | ERC-7683 (OIF is an ERC-7683 implementation) | Parses ERC-7683 open event + API/event watching |
-| Relay        | Relay's own intent API                       | Polls `/intents/status/v3`                      |
-| Bungee       | Bungee's own bridge / permit2 flow           | Polls Bungee's status API                       |
-| LiFi Intents | LI.FI's own resource-lock escrow             | Parses a custom LI.FI event + API watching      |
+| Provider     | Native protocol                                       | How the SDK gets status                                  |
+| ------------ | ----------------------------------------------------- | -------------------------------------------------------- |
+| Across       | UMA Across (ERC-7683-aligned order shape)             | Parses SpokePool `V3FundsDeposited` + API/event watching |
+| OIF          | Open Intents Framework (ERC-7683-aligned order shape) | Parses OIF settler `Open` event + API/event watching     |
+| Relay        | Relay's own intent API                                | Polls `/intents/status/v3`                               |
+| Bungee       | Bungee's own bridge / permit2 flow                    | Polls Bungee's status API                                |
+| LiFi Intents | LI.FI's own resource-lock escrow                      | Parses a custom LI.FI event + API watching               |
 
-What makes multi-provider aggregation possible is the SDK's adapter layer: each provider's native quote/order shape is normalized into the SDK's own `Quote` / `Order` / `OrderStatus` types — which are themselves ERC-7683/OIF-shaped where it makes sense. ERC-7683 is the vocabulary, not a precondition every provider has to meet.
+For Across and OIF the underlying events differ from the ERC-7683 standard Open event signature — the SDK maps each one into an ERC-7683/OIF-shaped `OpenedIntent`. What makes multi-provider aggregation possible is that adapter layer: each provider's native quote/order shape is normalized into the SDK's own `Quote` / `Order` / `OrderStatus` types. ERC-7683 is the vocabulary, not a precondition every provider has to meet.
 
 ## The transfer flow
 
@@ -127,7 +127,7 @@ Or: **Failed** / **Refunded**
 
 Tracking works through two mechanisms:
 
--   **Event-based**: Parse an open event on the origin chain (the ERC-7683 open event for Across and OIF; a custom event for LiFi Intents), then watch for the fill on the destination chain. Requires RPC URLs for both chains.
+-   **Event-based**: Parse an open event on the origin chain — a provider-specific event in every case (SpokePool `V3FundsDeposited` for Across, the OIF settler `Open` event for OIF, a custom event for LiFi Intents) — which the SDK maps into an ERC-7683/OIF-shaped `OpenedIntent`, then watch for the fill on the destination chain. Requires RPC URLs for both chains.
 -   **API-based**: Poll a provider's status endpoint. Simpler setup, no destination-chain RPC needed.
 
 The tracking mechanism is determined by the provider. See [Order Tracking](./intent-tracking) for usage details.

--- a/apps/docs/pages/cross-chain/concepts.mdx
+++ b/apps/docs/pages/cross-chain/concepts.mdx
@@ -127,7 +127,7 @@ Or: **Failed** / **Refunded**
 
 Tracking works through two mechanisms:
 
--   **Event-based**: Parse an open event on the origin chain — a provider-specific event in every case (SpokePool `V3FundsDeposited` for Across, the OIF settler `Open` event for OIF, a custom event for LiFi Intents) — which the SDK maps into an ERC-7683/OIF-shaped `OpenedIntent`, then watch for the fill on the destination chain. Requires RPC URLs for both chains.
+-   **Event-based**: Parse an open event on the origin chain — a provider-specific event in every case (SpokePool `V3FundsDeposited` for Across, the OIF settler `Open` event for OIF, a custom event for LiFi Intents) — which the SDK maps into an ERC-7683/OIF-shaped `OpenedIntent`. Fill detection may be on-chain or API-based depending on the provider, so an origin-chain RPC URL is always required, but a destination-chain RPC URL is only needed when the provider uses an on-chain fill watcher (e.g. Across testnet).
 -   **API-based**: Poll a provider's status endpoint. Simpler setup, no destination-chain RPC needed.
 
 The tracking mechanism is determined by the provider. See [Order Tracking](./intent-tracking) for usage details.

--- a/apps/docs/pages/cross-chain/example.mdx
+++ b/apps/docs/pages/cross-chain/example.mdx
@@ -203,5 +203,5 @@ main().catch(console.error);
 ## Next steps
 
 -   [Order Tracking](./intent-tracking) — monitor your transaction from initiation to completion
--   [Concepts](./concepts) — understand intent-based architecture and EIP-7683
+-   [Concepts](./concepts) — understand intent-based architecture and ERC-7683
 -   [API Reference](./api) — complete function signatures and types

--- a/apps/docs/pages/cross-chain/getting-started.mdx
+++ b/apps/docs/pages/cross-chain/getting-started.mdx
@@ -237,6 +237,6 @@ response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`)
 
 -   [Order Tracking](./intent-tracking) — monitor your transfer from initiation to completion
 -   [Supported Providers](./providers) — all providers and their configuration options
--   [Concepts](./concepts) — understand intent-based architecture and EIP-7683
+-   [Concepts](./concepts) — understand intent-based architecture and ERC-7683
 -   [Advanced Usage](./advanced-usage) — sorting strategies, timeouts, error handling
 -   [API Reference](./api) — complete function signatures and types

--- a/apps/docs/pages/cross-chain/index.mdx
+++ b/apps/docs/pages/cross-chain/index.mdx
@@ -14,7 +14,7 @@ Do not use this SDK in production or with real user value.
 
 The `cross-chain` package provides a standardized interface for cross-chain token transfers. It lets you fetch quotes from multiple bridge providers, execute transfers, and track orders through a unified API.
 
-Order shapes and the `OrderStatus` vocabulary are borrowed from [ERC-7683](https://www.erc7683.org/) and the [Open Intents Framework](https://github.com/openintentsframework). Some providers (Across, OIF) speak ERC-7683 natively; others (Relay, Bungee, LiFi Intents) have their own protocols and are normalized by the SDK into the same shape.
+Order shapes and the `OrderStatus` vocabulary are borrowed from [ERC-7683](https://www.erc7683.org/) and the [Open Intents Framework](https://github.com/openintentsframework). Across and OIF use ERC-7683-aligned order shapes (the SDK parses provider-specific open events and maps them into an ERC-7683/OIF-shaped intent); Relay, Bungee, and LiFi Intents have their own protocols and are normalized by the SDK into the same shape.
 
 ## What it does
 

--- a/apps/docs/pages/cross-chain/index.mdx
+++ b/apps/docs/pages/cross-chain/index.mdx
@@ -14,11 +14,11 @@ Do not use this SDK in production or with real user value.
 
 The `cross-chain` package provides a standardized interface for cross-chain token transfers. It lets you fetch quotes from multiple bridge providers, execute transfers, and track orders through a unified API.
 
-It follows [EIP-7683](https://www.erc7683.org/) for cross-chain intent structures.
+Order shapes and the `OrderStatus` vocabulary are borrowed from [ERC-7683](https://www.erc7683.org/) and the [Open Intents Framework](https://github.com/openintentsframework). Some providers (Across, OIF) speak ERC-7683 natively; others (Relay, Bungee, LiFi Intents) have their own protocols and are normalized by the SDK into the same shape.
 
 ## What it does
 
--   Fetch and compare quotes from multiple providers (Across, Relay, OIF, LiFi)
+-   Fetch and compare quotes from multiple providers (Across, Relay, OIF, Bungee, LiFi Intents)
 -   Execute cross-chain transfers via signature (gasless) or transaction
 -   Track orders from initiation to completion
 -   Aggregate quotes with configurable sorting strategies

--- a/apps/docs/pages/cross-chain/intent-tracking.mdx
+++ b/apps/docs/pages/cross-chain/intent-tracking.mdx
@@ -283,6 +283,7 @@ Explore more complex scenarios: [Advanced Usage](./advanced-usage)
 
 ## References
 
--   [EIP-7683: Open Intent Framework](https://www.erc7683.org/)
+-   [ERC-7683: Cross-Chain Intents](https://www.erc7683.org/)
+-   [Open Intents Framework](https://github.com/openintentsframework)
 -   [Order Tracking Types](./api#order-tracker)
 -   [Concepts](./concepts) — how intent-based transfers and tracking work

--- a/apps/docs/pages/cross-chain/oif-provider.mdx
+++ b/apps/docs/pages/cross-chain/oif-provider.mdx
@@ -174,6 +174,6 @@ See a complete working example: [Execute Intent](./example)
 ## References
 
 -   [Open Intents Framework](https://github.com/openintentsframework)
--   [EIP-7683: Cross Chain Intents](https://www.erc7683.org/)
+-   [ERC-7683: Cross Chain Intents](https://www.erc7683.org/)
 -   [API Reference](./api) — full type definitions for quotes, fees, and orders
 -   [Concepts](./concepts) — how intent-based transfers work

--- a/examples/ui/app/config/features.ts
+++ b/examples/ui/app/config/features.ts
@@ -16,7 +16,7 @@ export const APPS = [
     id: 'cross-chain',
     href: '/cross-chain',
     label: 'Cross-Chain',
-    badge: 'EIP-7683 & Intents',
+    badge: 'ERC-7683 & Intents',
     title: 'Cross-Chain Intent Swap',
     description: 'Experience seamless cross-chain transfers with intent-based routing',
   },

--- a/examples/ui/app/cross-chain/CrossChainClient.tsx
+++ b/examples/ui/app/cross-chain/CrossChainClient.tsx
@@ -175,7 +175,7 @@ export default function CrossChainClient() {
 
             <header className='flex flex-col items-center gap-4 text-center'>
               <div className='inline-flex items-center gap-2 px-3 py-1 rounded-full bg-accent-light text-accent text-xs font-medium'>
-                EIP-7683 & Intents
+                ERC-7683 & Intents
               </div>
               <h1 className='text-4xl sm:text-5xl md:text-6xl font-bold text-text-primary'>Cross-Chain Intent Swap</h1>
               <p className='text-lg sm:text-xl text-text-secondary'>

--- a/packages/cross-chain/src/core/interfaces/openedIntentParser.interface.ts
+++ b/packages/cross-chain/src/core/interfaces/openedIntentParser.interface.ts
@@ -8,7 +8,8 @@ import type { PublicClientManager } from "../utils/publicClientManager.js";
  * Implementations can parse from different sources (OIF events, custom events, APIs).
  *
  * All parsers return the full {@link OpenedIntent} type with complete data including
- * destination chain and amounts, as this data is available from the EIP-7683 Open event.
+ * destination chain and amounts, mapped into an ERC-7683/OIF-shaped intent from the
+ * provider's native open event (or API response).
  */
 export interface OpenedIntentParser {
     /**

--- a/packages/cross-chain/src/core/interfaces/openedIntentParser.interface.ts
+++ b/packages/cross-chain/src/core/interfaces/openedIntentParser.interface.ts
@@ -7,9 +7,12 @@ import type { PublicClientManager } from "../utils/publicClientManager.js";
  * Interface for parsing opened intent information from a transaction.
  * Implementations can parse from different sources (OIF events, custom events, APIs).
  *
- * All parsers return the full {@link OpenedIntent} type with complete data including
- * destination chain and amounts, mapped into an ERC-7683/OIF-shaped intent from the
- * provider's native open event (or API response).
+ * All parsers return an {@link OpenedIntent} in the same shape (ERC-7683/OIF-aligned),
+ * but completeness varies by source. Parsers that read an on-chain open event (OIF,
+ * Across, LiFi Intents) populate every field, including `maxSpent` / `minReceived` and
+ * the user/origin addresses. API-based parsers (e.g. Relay, Bungee) return enough to
+ * drive fill tracking — origin/destination chain, `orderId`, `txHash` — and leave the
+ * amount arrays empty and other addresses as placeholders.
  */
 export interface OpenedIntentParser {
     /**

--- a/packages/cross-chain/src/protocols/oif/constants.ts
+++ b/packages/cross-chain/src/protocols/oif/constants.ts
@@ -1,5 +1,5 @@
 /**
- * TypeScript types for decoded EIP-7683 Open event data
+ * TypeScript types for decoded OIF settler Open event data (ERC-7683-aligned order shape)
  */
 // =============================================================================
 // Canonical EIP-712 type definitions for OIF order signing


### PR DESCRIPTION
## Summary
- Spec is **ERC-7683** (application-level), not **EIP-7683** — renamed across every mention.
- The docs claimed the SDK "follows ERC-7683"; in reality only Across and OIF speak it natively. Relay and Bungee use their own status APIs; LiFi Intents parses a custom event. Reframe ERC-7683 as the source of the SDK's order-shape and `OrderStatus` vocabulary, and call out the adapter layer as what actually enables aggregation.
- Fix a factual error in `intent-tracking.mdx` references — ERC-7683 is "Cross-Chain Intents", not "Open Intent Framework" (OIF is a separate project that builds on it).
- Add Bungee to the providers list in `index.mdx` (was missing — Across/Relay/OIF/LiFi only).

## Test plan
- [ ] `pnpm --filter docs build` succeeds
- [ ] No "EIP-7683" mentions remain (`grep -r "EIP-7683" apps/docs/pages` returns nothing)
- [ ] `/cross-chain/concepts` shows the per-provider table; `/cross-chain` landing reflects the corrected framing and lists all five providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)