### PR TITLE
feat(benchmark): scaffold quote orchestration data layer

### DIFF
--- a/apps/benchmark/app/lib/aggregator.ts
+++ b/apps/benchmark/app/lib/aggregator.ts
@@ -1,0 +1,27 @@
+import {
+  createAggregator,
+  createCrossChainProvider,
+  LIFI_INTENTS_ORDER_SERVER_URL,
+  PROTOCOLS,
+} from '@wonderland/interop-cross-chain';
+import type { Aggregator, CrossChainProvider } from '@wonderland/interop-cross-chain';
+
+const OIF_SOLVER_URL = 'https://oif-api.openzeppelin.com/api';
+const OIF_SOLVER_ID = 'mainnet-solver';
+
+const providers: CrossChainProvider[] = [
+  createCrossChainProvider(PROTOCOLS.ACROSS, { providerId: 'across' }),
+  createCrossChainProvider(PROTOCOLS.OIF, {
+    providerId: 'oif',
+    solverId: OIF_SOLVER_ID,
+    url: OIF_SOLVER_URL,
+  }),
+  createCrossChainProvider(PROTOCOLS.LIFI_INTENTS, {
+    providerId: 'lifi-intents',
+    orderServerUrl: LIFI_INTENTS_ORDER_SERVER_URL,
+  }),
+  createCrossChainProvider(PROTOCOLS.RELAY, { providerId: 'relay' }),
+  createCrossChainProvider(PROTOCOLS.BUNGEE, { providerId: 'bungee' }),
+];
+
+export const aggregator: Aggregator = createAggregator({ providers });

--- a/apps/benchmark/app/lib/formatters.ts
+++ b/apps/benchmark/app/lib/formatters.ts
@@ -1,0 +1,38 @@
+import { formatUnits } from 'viem';
+
+const MAX_FRACTION_DIGITS = 4;
+
+export const truncateAddress = (address: string): string =>
+  address.length > 10 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address;
+
+export const formatEta = (seconds: number | undefined): string => {
+  if (seconds === undefined) return '—';
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return remainder === 0 ? `${minutes}m` : `${minutes}m ${remainder}s`;
+};
+
+export const formatLatency = (ms: number | undefined): string => {
+  if (ms === undefined) return '—';
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+};
+
+export const formatTokenAmount = (raw: string | undefined, decimals: number): string => {
+  if (!raw) return '—';
+  try {
+    const [whole, fraction = ''] = formatUnits(BigInt(raw), decimals).split('.');
+    const trimmed = fraction.slice(0, MAX_FRACTION_DIGITS).replace(/0+$/, '');
+    return trimmed ? `${whole}.${trimmed}` : whole;
+  } catch {
+    return raw;
+  }
+};
+
+export const formatUsd = (value: string | undefined): string => {
+  if (!value) return '—';
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) return '—';
+  return `$${parsed.toFixed(parsed < 1 ? 4 : 2)}`;
+};

--- a/apps/benchmark/app/lib/helpers/chains.ts
+++ b/apps/benchmark/app/lib/helpers/chains.ts
@@ -1,0 +1,8 @@
+import * as viemChains from 'viem/chains';
+import type { Chain } from 'viem';
+
+const CHAIN_NAME_BY_ID = new Map<number, string>(
+  (Object.values(viemChains) as Chain[]).map((chain) => [chain.id, chain.name]),
+);
+
+export const getChainName = (chainId: number): string => CHAIN_NAME_BY_ID.get(chainId) ?? `Chain ${chainId}`;

--- a/apps/benchmark/app/lib/helpers/index.ts
+++ b/apps/benchmark/app/lib/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './chains';

--- a/apps/benchmark/app/lib/interfaces/chainService.interface.ts
+++ b/apps/benchmark/app/lib/interfaces/chainService.interface.ts
@@ -1,0 +1,5 @@
+import type { NetworkAssets } from '@wonderland/interop-cross-chain';
+
+export interface ChainService {
+  getChains(): Promise<NetworkAssets[]>;
+}

--- a/apps/benchmark/app/lib/interfaces/index.ts
+++ b/apps/benchmark/app/lib/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './chainService.interface';
+export * from './quotesService.interface';

--- a/apps/benchmark/app/lib/interfaces/quotesService.interface.ts
+++ b/apps/benchmark/app/lib/interfaces/quotesService.interface.ts
@@ -1,0 +1,6 @@
+import type { QuoteBenchmarkResponse } from '../types/providerQuoteResult';
+import type { QuoteRequest } from '@wonderland/interop-cross-chain';
+
+export interface QuotesService {
+  getQuotes(request: QuoteRequest): Promise<QuoteBenchmarkResponse>;
+}

--- a/apps/benchmark/app/lib/services/index.ts
+++ b/apps/benchmark/app/lib/services/index.ts
@@ -1,0 +1,11 @@
+import { aggregator } from '../aggregator';
+import { SDKChainService } from './sdkChainService';
+import { SDKQuoteService } from './sdkQuoteService';
+import type { ChainService } from '../interfaces/chainService.interface';
+import type { QuotesService } from '../interfaces/quotesService.interface';
+
+export * from './sdkChainService';
+export * from './sdkQuoteService';
+
+export const chainService: ChainService = new SDKChainService(aggregator);
+export const quotesService: QuotesService = new SDKQuoteService(aggregator);

--- a/apps/benchmark/app/lib/services/index.ts
+++ b/apps/benchmark/app/lib/services/index.ts
@@ -1,4 +1,5 @@
 import { aggregator } from '../aggregator';
+import { SUPPORTED_CHAINS, SUPPORTED_SYMBOLS } from '../supportedAssets';
 import { SDKChainService } from './sdkChainService';
 import { SDKQuoteService } from './sdkQuoteService';
 import type { ChainService } from '../interfaces/chainService.interface';
@@ -7,5 +8,5 @@ import type { QuotesService } from '../interfaces/quotesService.interface';
 export * from './sdkChainService';
 export * from './sdkQuoteService';
 
-export const chainService: ChainService = new SDKChainService(aggregator);
+export const chainService: ChainService = new SDKChainService(aggregator, SUPPORTED_CHAINS, SUPPORTED_SYMBOLS);
 export const quotesService: QuotesService = new SDKQuoteService(aggregator);

--- a/apps/benchmark/app/lib/services/sdkChainService.ts
+++ b/apps/benchmark/app/lib/services/sdkChainService.ts
@@ -1,31 +1,32 @@
-import { getAddress } from 'viem';
+import { getAddress, type Chain } from 'viem';
 import type { ChainService } from '../interfaces/chainService.interface';
 import type { Aggregator, AssetInfo, DiscoveredAssets, NetworkAssets } from '@wonderland/interop-cross-chain';
 
 export class SDKChainService implements ChainService {
-  constructor(private readonly aggregator: Aggregator) {}
+  constructor(
+    private readonly aggregator: Aggregator,
+    private readonly chains: readonly Chain[],
+    private readonly symbols: readonly string[],
+  ) {}
 
   async getChains(): Promise<NetworkAssets[]> {
-    const assets = await this.aggregator.discoverAssets();
+    const chainIds = this.chains.map((chain) => chain.id);
+    const assets = await this.aggregator.discoverAssets({ chainIds });
     return this.toNetworkAssets(assets);
   }
 
   private toNetworkAssets(assets: DiscoveredAssets): NetworkAssets[] {
-    return Object.keys(assets.tokensByChain)
-      .map(Number)
-      .filter(Number.isFinite)
-      .sort((a, b) => a - b)
-      .map((chainId) => ({ chainId, assets: this.extractAssets(assets.tokenMetadata[chainId]) }))
+    return this.chains
+      .map((chain) => ({ chainId: chain.id, assets: this.extractAssets(assets.tokenMetadata[chain.id]) }))
       .filter((network) => network.assets.length > 0);
   }
 
   private extractAssets(metadata: DiscoveredAssets['tokenMetadata'][number] | undefined): AssetInfo[] {
     if (!metadata) return [];
-    const seen = new Set<string>();
+    const allowed = new Set(this.symbols);
     const result: AssetInfo[] = [];
     for (const raw of Object.values(metadata)) {
-      if (!raw.symbol || seen.has(raw.symbol)) continue;
-      seen.add(raw.symbol);
+      if (!allowed.has(raw.symbol)) continue;
       result.push({ ...raw, address: this.toChecksumAddress(raw.address) });
     }
     return result.sort((a, b) => a.symbol.localeCompare(b.symbol));

--- a/apps/benchmark/app/lib/services/sdkChainService.ts
+++ b/apps/benchmark/app/lib/services/sdkChainService.ts
@@ -10,33 +10,43 @@ export class SDKChainService implements ChainService {
   ) {}
 
   async getChains(): Promise<NetworkAssets[]> {
-    const chainIds = this.chains.map((chain) => chain.id);
-    const assets = await this.aggregator.discoverAssets({ chainIds });
-    return this.toNetworkAssets(assets);
+    const discovered = await this.discoverAssets();
+    return this.buildNetworks(discovered);
   }
 
-  private toNetworkAssets(assets: DiscoveredAssets): NetworkAssets[] {
+  private discoverAssets(): Promise<DiscoveredAssets> {
+    const chainIds = this.chains.map((chain) => chain.id);
+    return this.aggregator.discoverAssets({ chainIds });
+  }
+
+  private buildNetworks(discovered: DiscoveredAssets): NetworkAssets[] {
     return this.chains
-      .map((chain) => ({ chainId: chain.id, assets: this.extractAssets(assets.tokenMetadata[chain.id]) }))
+      .map((chain) => ({
+        chainId: chain.id,
+        assets: this.extractAssets(discovered.tokensByChain[chain.id] ?? [], discovered.tokenMetadata[chain.id] ?? {}),
+      }))
       .filter((network) => network.assets.length > 0);
   }
 
-  private extractAssets(metadata: DiscoveredAssets['tokenMetadata'][number] | undefined): AssetInfo[] {
-    if (!metadata) return [];
+  private extractAssets(
+    addresses: readonly string[],
+    metadata: DiscoveredAssets['tokenMetadata'][number],
+  ): AssetInfo[] {
     const allowed = new Set(this.symbols);
-    const result: AssetInfo[] = [];
-    for (const raw of Object.values(metadata)) {
-      if (!allowed.has(raw.symbol)) continue;
-      result.push({ ...raw, address: this.toChecksumAddress(raw.address) });
+    const bySymbol = new Map<string, AssetInfo>();
+    for (const addr of addresses) {
+      const meta = metadata[addr.toLowerCase()];
+      if (!meta || !allowed.has(meta.symbol) || bySymbol.has(meta.symbol)) continue;
+      bySymbol.set(meta.symbol, { ...meta, address: toChecksum(addr) });
     }
-    return result.sort((a, b) => a.symbol.localeCompare(b.symbol));
+    return [...bySymbol.values()].sort((a, b) => a.symbol.localeCompare(b.symbol));
   }
+}
 
-  private toChecksumAddress(address: string): string {
-    try {
-      return getAddress(address);
-    } catch {
-      return address;
-    }
+function toChecksum(address: string): string {
+  try {
+    return getAddress(address);
+  } catch {
+    return address;
   }
 }

--- a/apps/benchmark/app/lib/services/sdkChainService.ts
+++ b/apps/benchmark/app/lib/services/sdkChainService.ts
@@ -1,0 +1,41 @@
+import { getAddress } from 'viem';
+import type { ChainService } from '../interfaces/chainService.interface';
+import type { Aggregator, AssetInfo, DiscoveredAssets, NetworkAssets } from '@wonderland/interop-cross-chain';
+
+export class SDKChainService implements ChainService {
+  constructor(private readonly aggregator: Aggregator) {}
+
+  async getChains(): Promise<NetworkAssets[]> {
+    const assets = await this.aggregator.discoverAssets();
+    return this.toNetworkAssets(assets);
+  }
+
+  private toNetworkAssets(assets: DiscoveredAssets): NetworkAssets[] {
+    return Object.keys(assets.tokensByChain)
+      .map(Number)
+      .filter(Number.isFinite)
+      .sort((a, b) => a - b)
+      .map((chainId) => ({ chainId, assets: this.extractAssets(assets.tokenMetadata[chainId]) }))
+      .filter((network) => network.assets.length > 0);
+  }
+
+  private extractAssets(metadata: DiscoveredAssets['tokenMetadata'][number] | undefined): AssetInfo[] {
+    if (!metadata) return [];
+    const seen = new Set<string>();
+    const result: AssetInfo[] = [];
+    for (const raw of Object.values(metadata)) {
+      if (!raw.symbol || seen.has(raw.symbol)) continue;
+      seen.add(raw.symbol);
+      result.push({ ...raw, address: this.toChecksumAddress(raw.address) });
+    }
+    return result.sort((a, b) => a.symbol.localeCompare(b.symbol));
+  }
+
+  private toChecksumAddress(address: string): string {
+    try {
+      return getAddress(address);
+    } catch {
+      return address;
+    }
+  }
+}

--- a/apps/benchmark/app/lib/services/sdkQuoteService.ts
+++ b/apps/benchmark/app/lib/services/sdkQuoteService.ts
@@ -15,6 +15,8 @@ export class SDKQuoteService implements QuotesService {
 
   private toProviderQuoteResult(quote: ExecutableQuote): ProviderQuoteResult {
     const [output] = quote.preview.outputs;
+    const bridgeFeeUsd = quote.fees?.bridgeFee?.amountUsd;
+    const originGasUsd = quote.fees?.originGas?.amountUsd;
     return {
       providerId: quote._providerId,
       protocolName: quote.provider,
@@ -24,7 +26,9 @@ export class SDKQuoteService implements QuotesService {
       outputAmountUsd: output?.amountUsd,
       outputAssetAddress: output?.assetAddress,
       outputChainId: output?.chainId,
-      bridgeFeeUsd: quote.fees?.bridgeFee?.amountUsd,
+      bridgeFeeUsd,
+      originGasUsd,
+      totalFeeUsd: sumUsd([bridgeFeeUsd, originGasUsd]),
     };
   }
 
@@ -34,4 +38,12 @@ export class SDKQuoteService implements QuotesService {
       latencyMs: error.latencyMs,
     };
   }
+}
+
+function sumUsd(values: (string | undefined)[]): string | undefined {
+  const numbers = values
+    .map((value) => (value ? Number.parseFloat(value) : Number.NaN))
+    .filter((value) => Number.isFinite(value));
+  if (numbers.length === 0) return undefined;
+  return numbers.reduce((acc, value) => acc + value, 0).toString();
 }

--- a/apps/benchmark/app/lib/services/sdkQuoteService.ts
+++ b/apps/benchmark/app/lib/services/sdkQuoteService.ts
@@ -15,8 +15,6 @@ export class SDKQuoteService implements QuotesService {
 
   private toProviderQuoteResult(quote: ExecutableQuote): ProviderQuoteResult {
     const [output] = quote.preview.outputs;
-    const bridgeFeeUsd = quote.fees?.bridgeFee?.amountUsd;
-    const originGasUsd = quote.fees?.originGas?.amountUsd;
     return {
       providerId: quote._providerId,
       protocolName: quote.provider,
@@ -26,9 +24,8 @@ export class SDKQuoteService implements QuotesService {
       outputAmountUsd: output?.amountUsd,
       outputAssetAddress: output?.assetAddress,
       outputChainId: output?.chainId,
-      bridgeFeeUsd,
-      originGasUsd,
-      totalFeeUsd: sumUsd([bridgeFeeUsd, originGasUsd]),
+      bridgeFeeUsd: quote.fees?.bridgeFee?.amountUsd,
+      originGasUsd: quote.fees?.originGas?.amountUsd,
     };
   }
 
@@ -38,12 +35,4 @@ export class SDKQuoteService implements QuotesService {
       latencyMs: error.latencyMs,
     };
   }
-}
-
-function sumUsd(values: (string | undefined)[]): string | undefined {
-  const numbers = values
-    .map((value) => (value ? Number.parseFloat(value) : Number.NaN))
-    .filter((value) => Number.isFinite(value));
-  if (numbers.length === 0) return undefined;
-  return numbers.reduce((acc, value) => acc + value, 0).toString();
 }

--- a/apps/benchmark/app/lib/services/sdkQuoteService.ts
+++ b/apps/benchmark/app/lib/services/sdkQuoteService.ts
@@ -1,0 +1,37 @@
+import type { QuotesService } from '../interfaces/quotesService.interface';
+import type { ProviderQuoteError, ProviderQuoteResult, QuoteBenchmarkResponse } from '../types/providerQuoteResult';
+import type { Aggregator, ExecutableQuote, GetQuotesError, QuoteRequest } from '@wonderland/interop-cross-chain';
+
+export class SDKQuoteService implements QuotesService {
+  constructor(private readonly aggregator: Aggregator) {}
+
+  async getQuotes(request: QuoteRequest): Promise<QuoteBenchmarkResponse> {
+    const response = await this.aggregator.getQuotes(request);
+    return {
+      quotes: response.quotes.map((quote) => this.toProviderQuoteResult(quote)),
+      errors: response.errors.map((error) => this.toProviderQuoteError(error)),
+    };
+  }
+
+  private toProviderQuoteResult(quote: ExecutableQuote): ProviderQuoteResult {
+    const [output] = quote.preview.outputs;
+    return {
+      providerId: quote._providerId,
+      protocolName: quote.provider,
+      latencyMs: quote.latencyMs,
+      eta: quote.eta,
+      outputAmount: output?.amount,
+      outputAmountUsd: output?.amountUsd,
+      outputAssetAddress: output?.assetAddress,
+      outputChainId: output?.chainId,
+      bridgeFeeUsd: quote.fees?.bridgeFee?.amountUsd,
+    };
+  }
+
+  private toProviderQuoteError(error: GetQuotesError): ProviderQuoteError {
+    return {
+      errorMessage: error.errorMsg,
+      latencyMs: error.latencyMs,
+    };
+  }
+}

--- a/apps/benchmark/app/lib/supportedAssets.ts
+++ b/apps/benchmark/app/lib/supportedAssets.ts
@@ -1,0 +1,6 @@
+import { arbitrum, base, mainnet, optimism } from 'viem/chains';
+import type { Chain } from 'viem';
+
+export const SUPPORTED_CHAINS: readonly Chain[] = [mainnet, base, arbitrum, optimism];
+
+export const SUPPORTED_SYMBOLS: readonly string[] = ['USDC', 'WETH'];

--- a/apps/benchmark/app/lib/types/index.ts
+++ b/apps/benchmark/app/lib/types/index.ts
@@ -1,0 +1,1 @@
+export * from './providerQuoteResult';

--- a/apps/benchmark/app/lib/types/providerQuoteResult.ts
+++ b/apps/benchmark/app/lib/types/providerQuoteResult.ts
@@ -8,6 +8,8 @@ export interface ProviderQuoteResult {
   outputAssetAddress?: string;
   outputChainId?: number;
   bridgeFeeUsd?: string;
+  originGasUsd?: string;
+  totalFeeUsd?: string;
 }
 
 export interface ProviderQuoteError {

--- a/apps/benchmark/app/lib/types/providerQuoteResult.ts
+++ b/apps/benchmark/app/lib/types/providerQuoteResult.ts
@@ -9,7 +9,6 @@ export interface ProviderQuoteResult {
   outputChainId?: number;
   bridgeFeeUsd?: string;
   originGasUsd?: string;
-  totalFeeUsd?: string;
 }
 
 export interface ProviderQuoteError {

--- a/apps/benchmark/app/lib/types/providerQuoteResult.ts
+++ b/apps/benchmark/app/lib/types/providerQuoteResult.ts
@@ -1,0 +1,21 @@
+export interface ProviderQuoteResult {
+  providerId: string;
+  protocolName: string;
+  latencyMs?: number;
+  eta?: number;
+  outputAmount?: string;
+  outputAmountUsd?: string;
+  outputAssetAddress?: string;
+  outputChainId?: number;
+  bridgeFeeUsd?: string;
+}
+
+export interface ProviderQuoteError {
+  errorMessage: string;
+  latencyMs?: number;
+}
+
+export interface QuoteBenchmarkResponse {
+  quotes: ProviderQuoteResult[];
+  errors: ProviderQuoteError[];
+}


### PR DESCRIPTION
## Summary

Linear: [EFI-922](https://linear.app/defi-wonderland/issue/EFI-922)

Client-side data layer for the benchmark site. An `aggregator` module wires Across, OIF, LI.FI Intents, Relay and Bungee through `createCrossChainProvider`. `SDKChainService` returns the discovered chains and assets, and `SDKQuoteService` maps each `ExecutableQuote` to a flat shape with the provider id, ETA, latency, output amount, output USD value and bridge fee.

## Test plan

- [x] `pnpm --filter benchmark check-types` passes
- [x] Import `chainService` / `quotesService` from a client component and confirm both calls resolve against the live providers