### PR TITLE
fix(cross-chain): expose post-fee expected and slippage floor on quote outputs

### DIFF
--- a/.changeset/bungee-quote-effective-amount.md
+++ b/.changeset/bungee-quote-effective-amount.md
@@ -1,0 +1,15 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Surface post-fee expected output and slippage floor on `Quote.preview.outputs` across providers.
+
+`QuotePreviewEntry` gains an optional `minAmount` field — the slippage floor guaranteed to the user after the provider's slippage tolerance is applied.
+
+Per-provider behavior:
+
+-   **Bungee** previously mapped `amount` (pre-fee optimistic) as the headline output. Wallets quoted that number and users saw less than promised once fees were deducted on fill. The adapter now uses `effectiveAmount ?? amount` for the headline (post-fee expected) with matching `effectiveValueInUsd ?? valueInUsd` for the USD value, and exposes `minAmountOut` as `minAmount`. Verified against a live Bungee quote (10 USDC Arbitrum → Base): pre-fee `amount` was 9.988676, `effectiveAmount` was 9.955638, `minAmountOut` was 9.954642. The headline now matches what the user actually receives.
+-   **Across** already mapped `expectedOutputAmount` (post-fee) for the headline. It now also exposes `minOutputAmount` as `minAmount`.
+-   **Relay** already mapped `currencyOut.amount` for the headline. It now also exposes `currencyOut.minimumAmount` as `minAmount`.
+
+Atomic intent providers (LiFi Intents, OIF) leave `minAmount` undefined and continue to set `amount` to the exact filled amount — there is no slippage in an atomic intent.

--- a/packages/cross-chain/src/core/schemas/quote.ts
+++ b/packages/cross-chain/src/core/schemas/quote.ts
@@ -8,7 +8,10 @@ export const QuotePreviewEntrySchema = z.object({
     chainId: chainIdSchema,
     accountAddress: addressString,
     assetAddress: addressString,
+    /** Expected amount post-fees. For slippage-based providers, actual delivered may be lower; see `minAmount`. */
     amount: amountSchema,
+    /** Slippage floor — guaranteed minimum after slippage tolerance. Only set when the provider exposes one. */
+    minAmount: amountSchema.optional(),
     amountUsd: amountUsdSchema,
 });
 

--- a/packages/cross-chain/src/core/schemas/quote.ts
+++ b/packages/cross-chain/src/core/schemas/quote.ts
@@ -8,9 +8,8 @@ export const QuotePreviewEntrySchema = z.object({
     chainId: chainIdSchema,
     accountAddress: addressString,
     assetAddress: addressString,
-    /** Expected amount post-fees. For slippage-based providers, actual delivered may be lower; see `minAmount`. */
     amount: amountSchema,
-    /** Slippage floor — guaranteed minimum after slippage tolerance. Only set when the provider exposes one. */
+    /** Outputs only: slippage floor when the provider exposes one. */
     minAmount: amountSchema.optional(),
     amountUsd: amountUsdSchema,
 });

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -266,6 +266,7 @@ export class AcrossProvider extends CrossChainProvider {
                         accountAddress: params.output.recipient ?? params.user,
                         assetAddress: response.outputToken.address,
                         amount: response.expectedOutputAmount,
+                        minAmount: response.minOutputAmount,
                     },
                 ],
             },

--- a/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
@@ -83,8 +83,13 @@ function adaptAutoRouteQuote(
                     chainId: autoRoute.output.token.chainId,
                     accountAddress: result.receiverAddress,
                     assetAddress: autoRoute.output.token.address,
-                    amount: autoRoute.output.amount,
-                    amountUsd: String(autoRoute.output.valueInUsd),
+                    // Use effectiveAmount (post-fee expected) over amount (pre-fee optimistic) so
+                    // the headline doesn't oversell. minAmountOut is the slippage floor.
+                    amount: autoRoute.output.effectiveAmount ?? autoRoute.output.amount,
+                    minAmount: autoRoute.output.minAmountOut,
+                    amountUsd: String(
+                        autoRoute.output.effectiveValueInUsd ?? autoRoute.output.valueInUsd,
+                    ),
                 },
             ],
         },

--- a/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
@@ -96,6 +96,7 @@ export function adaptQuote(
                     accountAddress: params.output.recipient ?? params.user,
                     assetAddress: currencyOut?.currency.address ?? params.output.assetAddress,
                     amount: currencyOut?.amount ?? params.output.amount ?? "0",
+                    minAmount: currencyOut?.minimumAmount,
                     amountUsd: currencyOut?.amountUsd,
                 },
             ],

--- a/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
@@ -180,6 +180,32 @@ describe("adaptQuotes", () => {
         expect(quote!.preview.outputs[0]!.chainId).toBe(10);
     });
 
+    it("exposes minAmountOut as the slippage floor on preview output", () => {
+        const response = buildBungeeQuoteResponse();
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+        if (!quote) throw new Error("expected a quote");
+
+        expect(quote.preview.outputs[0]?.minAmount).toBe("998000");
+    });
+
+    it("prefers effectiveAmount over amount when provider exposes it", () => {
+        const response = buildBungeeQuoteResponse();
+        response.result.autoRoute = buildAutoRoute({
+            output: {
+                ...buildAutoRoute().output,
+                effectiveAmount: "997500",
+                effectiveValueInUsd: 997.5,
+            },
+        });
+
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+        if (!quote) throw new Error("expected a quote");
+
+        expect(quote.preview.outputs[0]?.amount).toBe("997500");
+        expect(quote.preview.outputs[0]?.amountUsd).toBe("997.5");
+        expect(quote.preview.outputs[0]?.minAmount).toBe("998000");
+    });
+
     it("maps valueInUsd to preview.amountUsd as decimal string", () => {
         const response = buildBungeeQuoteResponse();
         const [quote] = adaptQuotes(response as never, PROVIDER_ID);

--- a/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
@@ -170,6 +170,29 @@ describe("adaptQuote", () => {
         expect(quote.preview.outputs[0]!.amountUsd).toBeUndefined();
     });
 
+    it("exposes currencyOut.minimumAmount as the slippage floor", () => {
+        const baseResponse = makeRelayQuoteResponse();
+        const { details } = baseResponse;
+        if (!details?.currencyOut) throw new Error("fixture is missing currencyOut");
+        const response: RelayQuoteResponse = {
+            ...baseResponse,
+            details: {
+                ...details,
+                currencyOut: { ...details.currencyOut, minimumAmount: "990000" },
+            },
+        };
+
+        const quote = adaptQuote(makeQuoteRequest(), response, PROVIDER_ID);
+
+        expect(quote.preview.outputs[0]?.minAmount).toBe("990000");
+    });
+
+    it("leaves minAmount undefined when the provider omits minimumAmount", () => {
+        const quote = adaptQuote(makeQuoteRequest(), makeRelayQuoteResponse(), PROVIDER_ID);
+
+        expect(quote.preview.outputs[0]?.minAmount).toBeUndefined();
+    });
+
     it("handles missing protocol.v2 gracefully", () => {
         const quote = adaptQuote(
             makeQuoteRequest(),

--- a/packages/cross-chain/test/providers/AcrossProvider.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.spec.ts
@@ -77,6 +77,30 @@ describe("AcrossProvider", () => {
             });
         });
 
+        it("exposes minOutputAmount as the slippage floor on preview output", async () => {
+            const quoteRequest: QuoteRequest = {
+                user: TEST_ADDRESSES.USER,
+                input: {
+                    chainId: CHAIN_IDS.SEPOLIA,
+                    assetAddress: TESTNET_TOKENS.WETH_SEPOLIA,
+                    amount: TEST_AMOUNTS.ONE_ETHER.toString(),
+                },
+                output: {
+                    chainId: CHAIN_IDS.BASE_SEPOLIA,
+                    assetAddress: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                    recipient: TEST_ADDRESSES.RECEIVER,
+                },
+                swapType: "exact-input",
+            };
+
+            const [quote] = await provider.getQuotes(quoteRequest);
+            if (!quote) throw new Error("expected a quote");
+
+            // From the mock fixture: expectedOutputAmount=990000…, minOutputAmount=980000…
+            expect(quote.preview.outputs[0]?.amount).toBe("990000000000000000");
+            expect(quote.preview.outputs[0]?.minAmount).toBe("980000000000000000");
+        });
+
         it("should handle exact-output swap type", async () => {
             const quoteRequest: QuoteRequest = {
                 user: TEST_ADDRESSES.USER,


### PR DESCRIPTION
## Summary

Bungee's API exposes three output amounts: pre-fee `amount`, post-fee `effectiveAmount`, and slippage floor `minAmountOut`. The adapter previously mapped only the pre-fee `amount` as the headline, so wallets quoted an optimistic number and users saw less than promised once fees were deducted on fill. Across and Relay had the right headline already but didn't surface their slippage floors at all.

This PR:

- Adds an optional `minAmount` field to `QuotePreviewEntry` for the guaranteed minimum after slippage tolerance.
- Bungee: headline `amount` is now `effectiveAmount ?? amount`, `amountUsd` follows `effectiveValueInUsd ?? valueInUsd`, `minAmount` carries `minAmountOut`.
- Across: exposes `minOutputAmount` as `minAmount` (headline `expectedOutputAmount` was already correct).
- Relay: exposes `currencyOut.minimumAmount` as `minAmount` (headline was already correct).
- LiFi Intents and OIF unchanged: atomic intents have no slippage, `minAmount` stays undefined and `amount` is the exact filled amount.

Verified against a live Bungee quote for 10 USDC Arbitrum → Base: pre-fee `amount` was 9.988676, `effectiveAmount` was 9.955638, `minAmountOut` was 9.954642. Wallets now show 9.955638 instead of 9.988676 — the ~0.33% gap between quoted and delivered that Ambire's users were hitting on Bungee bridges disappears.

Closes EFI-930

## Test plan

- 5 new unit tests covering the floor and post-fee preference across Bungee/Across/Relay adapters, all passing locally.