### PR TITLE
fix(cross-chain): validate Across quote target against SpokePool registry

### DIFF
--- a/.changeset/across-trusted-spokepool-registry.md
+++ b/.changeset/across-trusted-spokepool-registry.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Across: validate quote target against the canonical SpokePool registry.

--- a/.changeset/across-trusted-spokepool-registry.md
+++ b/.changeset/across-trusted-spokepool-registry.md
@@ -2,4 +2,4 @@
 "@wonderland/interop-cross-chain": patch
 ---
 
-Across: validate quote target against the canonical SpokePool registry.
+Across: validate quote target against the canonical SpokePool registry and reject calldata that is not a SpokePool `deposit` or that carries a non-empty destination message. Quotes for chains absent from the registry fail closed.

--- a/packages/cross-chain/src/core/services/EventBasedFillWatcher.ts
+++ b/packages/cross-chain/src/core/services/EventBasedFillWatcher.ts
@@ -30,7 +30,7 @@ export interface EventBasedFillWatcherConfig {
     /** Discriminator for FillWatcher config union */
     type: "event-based";
     /** Contract addresses per chain ID where fill events are emitted */
-    contractAddresses: Partial<Record<number, Address>>;
+    contractAddresses: Record<number, Address>;
     /** Event ABI for the fill event */
     eventAbi: Abi;
     /** Function to build getLogs parameters from fill params */

--- a/packages/cross-chain/src/core/services/EventBasedFillWatcher.ts
+++ b/packages/cross-chain/src/core/services/EventBasedFillWatcher.ts
@@ -30,7 +30,7 @@ export interface EventBasedFillWatcherConfig {
     /** Discriminator for FillWatcher config union */
     type: "event-based";
     /** Contract addresses per chain ID where fill events are emitted */
-    contractAddresses: Record<number, Address>;
+    contractAddresses: Partial<Record<number, Address>>;
     /** Event ABI for the fill event */
     eventAbi: Abi;
     /** Function to build getLogs parameters from fill params */

--- a/packages/cross-chain/src/protocols/across/constants.ts
+++ b/packages/cross-chain/src/protocols/across/constants.ts
@@ -1,4 +1,4 @@
-import { getAddress, Hex } from "viem";
+import { Address, getAddress, Hex } from "viem";
 import { arbitrum, arbitrumSepolia, base, baseSepolia, optimism, sepolia } from "viem/chains";
 
 import type { NetworkAssets } from "../../core/types/assetDiscovery.js";
@@ -54,7 +54,7 @@ export { getAcrossApiUrl };
  * Supports both mainnet and testnet addresses
  * @see https://docs.across.to/reference/contract-addresses/
  */
-export const ACROSS_SPOKE_POOL_ADDRESSES: Record<number, Hex> = {
+export const ACROSS_SPOKE_POOL_ADDRESSES: Record<number, Address> = {
     // Mainnet addresses
     [optimism.id]: getAddress("0x6f26Bf09B1C792e3228e5467807a900A503c0281"),
     [base.id]: getAddress("0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64"),

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -286,16 +286,12 @@ export class AcrossProvider extends CrossChainProvider {
 
     /** Whether `target` is the canonical Across SpokePool registered for the given chain. */
     private isTrustedSpokePool(chainId: number, target: Address): boolean {
-        const trusted = ACROSS_SPOKE_POOL_ADDRESSES[chainId];
-        return !!trusted && isAddressEqual(target, trusted as Address);
+        const trusted = ACROSS_SPOKE_POOL_ADDRESSES[chainId] as Address | undefined;
+        if (!trusted) return false;
+        return isAddressEqual(target, trusted);
     }
 
-    /**
-     * Validate that the decoded Across deposit calldata matches the user's
-     * QuoteRequest. Returns false when the decoder rejects the calldata or
-     * when the deposit carries a message (complex destination action we
-     * can't audit without an allowlist of trusted handlers).
-     */
+    /** Validate decoded Across deposit calldata matches the QuoteRequest; reject deposits with a non-empty message (destination handler not auditable). */
     private validateCalldata(params: QuoteRequest, data: Hex): boolean {
         const result = decodeAcrossCalldata(data);
         if (!result.success) return false;
@@ -313,12 +309,10 @@ export class AcrossProvider extends CrossChainProvider {
             ? (ACROSS_WRAPPED_NATIVE_ADDRESSES[output.chainId] ?? output.assetAddress)
             : output.assetAddress;
 
-        if (!isAddressEqual(decoded.depositor as Address, params.user as Address)) return false;
-        if (!isAddressEqual(decoded.inputToken as Address, inputTokenForCalldata as Address))
-            return false;
-        if (!isAddressEqual(decoded.outputToken as Address, outputTokenForCalldata as Address))
-            return false;
-        if (!isAddressEqual(decoded.recipient as Address, recipient as Address)) return false;
+        if (!isAddressEqual(decoded.depositor, params.user as Address)) return false;
+        if (!isAddressEqual(decoded.inputToken, inputTokenForCalldata as Address)) return false;
+        if (!isAddressEqual(decoded.outputToken, outputTokenForCalldata as Address)) return false;
+        if (!isAddressEqual(decoded.recipient, recipient as Address)) return false;
         if (decoded.destinationChainId !== BigInt(output.chainId)) return false;
 
         if (input.amount !== undefined) {

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -291,6 +291,13 @@ export class AcrossProvider extends CrossChainProvider {
         return isAddressEqual(target, trusted);
     }
 
+    /** Whether the Across swapTx targets the trusted SpokePool on the requested input chain and the calldata matches the user's intent. */
+    private isSafeQuote(params: QuoteRequest, swapTx: AcrossGetQuoteResponse["swapTx"]): boolean {
+        if (swapTx.chainId !== params.input.chainId) return false;
+        if (!this.isTrustedSpokePool(params.input.chainId, swapTx.to as Address)) return false;
+        return this.validateCalldata(params, swapTx.data as Hex);
+    }
+
     /** Validate decoded Across deposit calldata matches the QuoteRequest; reject deposits with a non-empty message (destination handler not auditable). */
     private validateCalldata(params: QuoteRequest, data: Hex): boolean {
         const result = decodeAcrossCalldata(data);
@@ -331,14 +338,8 @@ export class AcrossProvider extends CrossChainProvider {
         try {
             const acrossParams = this.toAcrossParams(params);
             const acrossResponse = await this.getAcrossQuote(acrossParams);
-            const { swapTx } = acrossResponse;
 
-            const isSafeQuote =
-                swapTx.chainId === params.input.chainId &&
-                this.isTrustedSpokePool(params.input.chainId, swapTx.to as Address) &&
-                this.validateCalldata(params, swapTx.data as Hex);
-
-            if (!isSafeQuote) {
+            if (!this.isSafeQuote(params, acrossResponse.swapTx)) {
                 throw new ProviderGetQuoteFailure(
                     "Across quote validation failed",
                     "Quote must target the trusted Across SpokePool and match the requested intent",

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -286,7 +286,7 @@ export class AcrossProvider extends CrossChainProvider {
 
     /** Whether `target` is the canonical Across SpokePool registered for the given chain. */
     private isTrustedSpokePool(chainId: number, target: Address): boolean {
-        const trusted = ACROSS_SPOKE_POOL_ADDRESSES[chainId] as Address | undefined;
+        const trusted = ACROSS_SPOKE_POOL_ADDRESSES[chainId];
         if (!trusted) return false;
         return isAddressEqual(target, trusted);
     }

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -291,16 +291,15 @@ export class AcrossProvider extends CrossChainProvider {
     }
 
     /**
-     * Validate that Across calldata matches the user's QuoteRequest.
-     * Reuses the existing calldata decoder but compares against SDK types directly.
+     * Validate that the decoded Across deposit calldata matches the user's
+     * QuoteRequest. Returns false when the decoder rejects the calldata or
+     * when the deposit carries a message (complex destination action we
+     * can't audit without an allowlist of trusted handlers).
      */
     private validateCalldata(params: QuoteRequest, data: Hex): boolean {
         const result = decodeAcrossCalldata(data);
-        if (!result.success) {
-            // "unsupported" selector (e.g. complex swap) — can't validate, allow through
-            // "invalid" calldata — reject
-            return result.reason === "unsupported";
-        }
+        if (!result.success) return false;
+        if (result.hasMessage) return false;
 
         const decoded = result.params;
         const { input, output } = params;

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -284,6 +284,12 @@ export class AcrossProvider extends CrossChainProvider {
         };
     }
 
+    /** Whether `target` is the canonical Across SpokePool registered for the given chain. */
+    private isTrustedSpokePool(chainId: number, target: Address): boolean {
+        const trusted = ACROSS_SPOKE_POOL_ADDRESSES[chainId];
+        return !!trusted && isAddressEqual(target, trusted as Address);
+    }
+
     /**
      * Validate that Across calldata matches the user's QuoteRequest.
      * Reuses the existing calldata decoder but compares against SDK types directly.
@@ -332,16 +338,21 @@ export class AcrossProvider extends CrossChainProvider {
         try {
             const acrossParams = this.toAcrossParams(params);
             const acrossResponse = await this.getAcrossQuote(acrossParams);
-            const quote = this.toSdkQuote(params, acrossResponse);
+            const { swapTx } = acrossResponse;
 
-            if (!this.validateCalldata(params, acrossResponse.swapTx.data as Hex)) {
+            const isSafeQuote =
+                swapTx.chainId === params.input.chainId &&
+                this.isTrustedSpokePool(params.input.chainId, swapTx.to as Address) &&
+                this.validateCalldata(params, swapTx.data as Hex);
+
+            if (!isSafeQuote) {
                 throw new ProviderGetQuoteFailure(
-                    "Across calldata validation failed",
-                    "Decoded deposit calldata does not match the requested intent",
+                    "Across quote validation failed",
+                    "Quote must target the trusted Across SpokePool and match the requested intent",
                 );
             }
 
-            return [quote];
+            return [this.toSdkQuote(params, acrossResponse)];
         } catch (error) {
             if (
                 error instanceof ProviderGetQuoteFailure ||

--- a/packages/cross-chain/src/protocols/across/utils.ts
+++ b/packages/cross-chain/src/protocols/across/utils.ts
@@ -4,7 +4,7 @@
  * deposit with a non-empty message decodes normally and surfaces
  * `hasMessage: true` so the caller can decide whether to accept the route.
  */
-import { decodeFunctionData, Hex, slice, toFunctionSelector } from "viem";
+import { Address, decodeFunctionData, Hex, slice, toFunctionSelector } from "viem";
 
 import { bytes32ToAddress } from "../../core/utils/addressHelpers.js";
 import { ACROSS_SPOKE_POOL_DEPOSIT_ABI } from "./constants.js";
@@ -12,10 +12,10 @@ import { ACROSS_SPOKE_POOL_DEPOSIT_ABI } from "./constants.js";
 const DEPOSIT_SELECTOR = toFunctionSelector(ACROSS_SPOKE_POOL_DEPOSIT_ABI[0]);
 
 export interface DecodedAcrossParams {
-    depositor: string;
-    recipient: string;
-    inputToken: string;
-    outputToken: string;
+    depositor: Address;
+    recipient: Address;
+    inputToken: Address;
+    outputToken: Address;
     inputAmount: bigint;
     outputAmount: bigint;
     destinationChainId: bigint;
@@ -54,10 +54,10 @@ export function decodeAcrossCalldata(data: Hex): DecodeResult {
             success: true,
             hasMessage: message.length > 2,
             params: {
-                depositor: bytes32ToAddress(depositor).toLowerCase(),
-                recipient: bytes32ToAddress(recipient).toLowerCase(),
-                inputToken: bytes32ToAddress(inputToken).toLowerCase(),
-                outputToken: bytes32ToAddress(outputToken).toLowerCase(),
+                depositor: bytes32ToAddress(depositor).toLowerCase() as Address,
+                recipient: bytes32ToAddress(recipient).toLowerCase() as Address,
+                inputToken: bytes32ToAddress(inputToken).toLowerCase() as Address,
+                outputToken: bytes32ToAddress(outputToken).toLowerCase() as Address,
                 inputAmount,
                 outputAmount,
                 destinationChainId,

--- a/packages/cross-chain/src/protocols/across/utils.ts
+++ b/packages/cross-chain/src/protocols/across/utils.ts
@@ -1,9 +1,8 @@
 /**
- * Decodes Across deposit calldata to validate user intent.
- *
- * Only supports simple same-token bridges (deposit without message).
- * Complex operations (destination swaps, DeFi actions) have a message
- * that we can't validate - we don't know which DEX/protocol will be used.
+ * Decode an Across SpokePool `deposit` calldata so callers can match it
+ * against the user's QuoteRequest. Non-deposit selectors are rejected; a
+ * deposit with a non-empty message decodes normally and surfaces
+ * `hasMessage: true` so the caller can decide whether to accept the route.
  */
 import { decodeFunctionData, Hex, slice, toFunctionSelector } from "viem";
 
@@ -13,36 +12,33 @@ import { ACROSS_SPOKE_POOL_DEPOSIT_ABI } from "./constants.js";
 const DEPOSIT_SELECTOR = toFunctionSelector(ACROSS_SPOKE_POOL_DEPOSIT_ABI[0]);
 
 export interface DecodedAcrossParams {
+    depositor: string;
+    recipient: string;
     inputToken: string;
     outputToken: string;
     inputAmount: bigint;
     outputAmount: bigint;
-    recipient: string;
     destinationChainId: bigint;
-    depositor: string;
 }
 
 export type DecodeResult =
-    | { success: true; params: DecodedAcrossParams }
-    | { success: false; reason: "unsupported" | "invalid"; error: string };
+    | { success: true; params: DecodedAcrossParams; hasMessage: boolean }
+    | { success: false; reason: "invalid"; error: string };
+
+const invalid = (error: string): DecodeResult => ({ success: false, reason: "invalid", error });
 
 export function decodeAcrossCalldata(data: Hex): DecodeResult {
-    const selector = slice(data, 0, 4);
+    if (!data || data.length < 10) {
+        return invalid("Calldata is empty or shorter than a function selector.");
+    }
 
+    const selector = slice(data, 0, 4);
     if (selector !== DEPOSIT_SELECTOR) {
-        return {
-            success: false,
-            reason: "unsupported",
-            error: `Unsupported selector: ${selector}. Only deposit (${DEPOSIT_SELECTOR}) is supported.`,
-        };
+        return invalid(`Unexpected selector ${selector}; expected deposit ${DEPOSIT_SELECTOR}.`);
     }
 
     try {
-        const decoded = decodeFunctionData({
-            abi: ACROSS_SPOKE_POOL_DEPOSIT_ABI,
-            data,
-        });
-
+        const { args } = decodeFunctionData({ abi: ACROSS_SPOKE_POOL_DEPOSIT_ABI, data });
         const [
             depositor,
             recipient,
@@ -51,37 +47,23 @@ export function decodeAcrossCalldata(data: Hex): DecodeResult {
             inputAmount,
             outputAmount,
             destinationChainId,
-        ] = decoded.args;
-        const message = decoded.args[11] as Hex;
-
-        // Only support simple bridges (no message)
-        // Complex operations have a message with DEX/protocol calls we can't validate
-        const hasMessage = message && message.length > 2;
-        if (hasMessage) {
-            return {
-                success: false,
-                reason: "unsupported",
-                error: "Deposit with message not supported. Cannot validate complex operations.",
-            };
-        }
+        ] = args;
+        const message = args[11] as Hex;
 
         return {
             success: true,
+            hasMessage: message.length > 2,
             params: {
+                depositor: bytes32ToAddress(depositor).toLowerCase(),
+                recipient: bytes32ToAddress(recipient).toLowerCase(),
                 inputToken: bytes32ToAddress(inputToken).toLowerCase(),
                 outputToken: bytes32ToAddress(outputToken).toLowerCase(),
                 inputAmount,
                 outputAmount,
-                recipient: bytes32ToAddress(recipient).toLowerCase(),
                 destinationChainId,
-                depositor: bytes32ToAddress(depositor).toLowerCase(),
             },
         };
     } catch (e) {
-        return {
-            success: false,
-            reason: "invalid",
-            error: `Failed to decode deposit: ${e instanceof Error ? e.message : String(e)}`,
-        };
+        return invalid(`Failed to decode deposit: ${e instanceof Error ? e.message : String(e)}`);
     }
 }

--- a/packages/cross-chain/src/protocols/across/validator.ts
+++ b/packages/cross-chain/src/protocols/across/validator.ts
@@ -5,12 +5,7 @@ import { isAddressEqual } from "viem";
 
 import { decodeAcrossCalldata, DecodedAcrossParams } from "./utils.js";
 
-/**
- * Validates Across calldata matches user intent. Rejects anything we can't
- * fully audit: malformed calldata, non-deposit selectors, and deposits with
- * a non-empty message (complex routes whose destination handler we can't
- * verify against the user's intent).
- */
+/** Validate Across calldata matches user intent; reject malformed calldata, non-deposit selectors, and deposits with a non-empty message. */
 export async function validateAcrossPayload(
     userIntent: GetQuoteRequest,
     data: Hex,
@@ -43,11 +38,11 @@ async function validateDecodedParams(
     };
 
     // Validate all fields for simple bridges
-    if (!isAddressEqual(calldata.recipient as Address, trusted.recipient)) return false;
-    if (!isAddressEqual(calldata.outputToken as Address, trusted.outputToken)) return false;
+    if (!isAddressEqual(calldata.recipient, trusted.recipient)) return false;
+    if (!isAddressEqual(calldata.outputToken, trusted.outputToken)) return false;
     if (calldata.destinationChainId !== trusted.destinationChain) return false;
-    if (!isAddressEqual(calldata.depositor as Address, trusted.depositor)) return false;
-    if (!isAddressEqual(calldata.inputToken as Address, trusted.inputToken)) return false;
+    if (!isAddressEqual(calldata.depositor, trusted.depositor)) return false;
+    if (!isAddressEqual(calldata.inputToken, trusted.inputToken)) return false;
 
     if (trusted.inputAmount !== undefined) {
         if (calldata.inputAmount !== trusted.inputAmount) return false;

--- a/packages/cross-chain/src/protocols/across/validator.ts
+++ b/packages/cross-chain/src/protocols/across/validator.ts
@@ -6,10 +6,10 @@ import { isAddressEqual } from "viem";
 import { decodeAcrossCalldata, DecodedAcrossParams } from "./utils.js";
 
 /**
- * Validates Across calldata matches user intent.
- *
- * Only validates simple same-token bridges (deposit without message).
- * Complex operations (swaps, DeFi actions) return true - we can't validate them.
+ * Validates Across calldata matches user intent. Rejects anything we can't
+ * fully audit: malformed calldata, non-deposit selectors, and deposits with
+ * a non-empty message (complex routes whose destination handler we can't
+ * verify against the user's intent).
  */
 export async function validateAcrossPayload(
     userIntent: GetQuoteRequest,
@@ -18,12 +18,8 @@ export async function validateAcrossPayload(
     if (!data) return false;
 
     const decodeResult = decodeAcrossCalldata(data);
-
-    if (!decodeResult.success) {
-        // "unsupported" = can't validate, allow through
-        // "invalid" = malformed data, reject
-        return decodeResult.reason === "unsupported";
-    }
+    if (!decodeResult.success) return false;
+    if (decodeResult.hasMessage) return false;
 
     return validateDecodedParams(userIntent, decodeResult.params);
 }

--- a/packages/cross-chain/test/mocks/acrossApi.ts
+++ b/packages/cross-chain/test/mocks/acrossApi.ts
@@ -1,5 +1,36 @@
+import { encodeFunctionData, Hex, pad } from "viem";
+
+import { addressToBytes32 } from "../../src/core/utils/addressHelpers.js";
 import { AcrossGetQuoteResponse } from "../../src/internal.js";
-import { ACROSS_CONTRACTS, CHAIN_IDS, TEST_AMOUNTS, TESTNET_TOKENS } from "./fixtures.js";
+import { ACROSS_SPOKE_POOL_DEPOSIT_ABI } from "../../src/protocols/across/constants.js";
+import {
+    ACROSS_CONTRACTS,
+    CHAIN_IDS,
+    TEST_ADDRESSES,
+    TEST_AMOUNTS,
+    TESTNET_TOKENS,
+} from "./fixtures.js";
+
+const ZERO_BYTES32 = pad("0x00" as Hex, { size: 32 });
+
+const DEFAULT_DEPOSIT_CALLDATA: Hex = encodeFunctionData({
+    abi: ACROSS_SPOKE_POOL_DEPOSIT_ABI,
+    functionName: "deposit",
+    args: [
+        addressToBytes32(TEST_ADDRESSES.USER),
+        addressToBytes32(TEST_ADDRESSES.RECEIVER),
+        addressToBytes32(TESTNET_TOKENS.WETH_SEPOLIA),
+        addressToBytes32(TESTNET_TOKENS.WETH_BASE_SEPOLIA),
+        TEST_AMOUNTS.ONE_ETHER,
+        990_000_000_000_000_000n,
+        BigInt(CHAIN_IDS.BASE_SEPOLIA),
+        ZERO_BYTES32,
+        0,
+        0,
+        0,
+        "0x",
+    ],
+});
 
 export const getMockedAcrossApiResponse = (
     override?: Partial<AcrossGetQuoteResponse>,
@@ -34,7 +65,7 @@ export const getMockedAcrossApiResponse = (
             simulationSuccess: true,
             chainId: CHAIN_IDS.SEPOLIA,
             to: ACROSS_CONTRACTS.SPOKE_POOL_SEPOLIA,
-            data: "0x1234567890abcdef",
+            data: DEFAULT_DEPOSIT_CALLDATA,
             gas: "250000",
             maxFeePerGas: "100000000000",
             maxPriorityFeePerGas: "2000000000",

--- a/packages/cross-chain/test/providers/AcrossProvider.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.spec.ts
@@ -1,10 +1,12 @@
 import type viem from "viem";
-import { Address, createPublicClient, PublicClient } from "viem";
+import { Address, createPublicClient, encodeFunctionData, Hex, pad, PublicClient } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { QuoteRequest } from "../../src/core/schemas/quoteRequest.js";
+import { addressToBytes32 } from "../../src/core/utils/addressHelpers.js";
 import { httpRequest } from "../../src/core/utils/httpClient.js";
 import { AcrossProvider, ProviderGetQuoteFailure } from "../../src/external.js";
+import { ACROSS_SPOKE_POOL_DEPOSIT_ABI } from "../../src/protocols/across/constants.js";
 import { getMockedAcrossApiResponse } from "../mocks/acrossApi.js";
 import { CHAIN_IDS, TEST_ADDRESSES, TEST_AMOUNTS, TESTNET_TOKENS } from "../mocks/fixtures.js";
 
@@ -294,6 +296,49 @@ describe("AcrossProvider", () => {
             vi.mocked(httpRequest).mockResolvedValueOnce(
                 mockResponseWith({
                     swapTx: { ...mockAcrossApiResponse.swapTx, chainId: CHAIN_IDS.BASE_SEPOLIA },
+                }),
+            );
+
+            await expectRejection(baseQuoteRequest);
+        });
+
+        it("rejects quote when swapTx.data does not target the deposit selector", async () => {
+            vi.mocked(httpRequest).mockResolvedValueOnce(
+                mockResponseWith({
+                    swapTx: {
+                        ...mockAcrossApiResponse.swapTx,
+                        data: "0xdeadbeef00000000" as Hex,
+                    },
+                }),
+            );
+
+            await expectRejection(baseQuoteRequest);
+        });
+
+        it("rejects quote when deposit calldata carries a non-empty message", async () => {
+            const ZERO_BYTES32 = pad("0x00" as Hex, { size: 32 });
+            const calldataWithMessage: Hex = encodeFunctionData({
+                abi: ACROSS_SPOKE_POOL_DEPOSIT_ABI,
+                functionName: "deposit",
+                args: [
+                    addressToBytes32(TEST_ADDRESSES.USER),
+                    addressToBytes32(TEST_ADDRESSES.RECEIVER),
+                    addressToBytes32(TESTNET_TOKENS.WETH_SEPOLIA),
+                    addressToBytes32(TESTNET_TOKENS.WETH_BASE_SEPOLIA),
+                    TEST_AMOUNTS.ONE_ETHER,
+                    990_000_000_000_000_000n,
+                    BigInt(CHAIN_IDS.BASE_SEPOLIA),
+                    ZERO_BYTES32,
+                    0,
+                    0,
+                    0,
+                    "0xcafebabe",
+                ],
+            });
+
+            vi.mocked(httpRequest).mockResolvedValueOnce(
+                mockResponseWith({
+                    swapTx: { ...mockAcrossApiResponse.swapTx, data: calldataWithMessage },
                 }),
             );
 

--- a/packages/cross-chain/test/providers/AcrossProvider.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.spec.ts
@@ -1,10 +1,10 @@
 import type viem from "viem";
-import { createPublicClient, PublicClient } from "viem";
+import { Address, createPublicClient, PublicClient } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { QuoteRequest } from "../../src/core/schemas/quoteRequest.js";
 import { httpRequest } from "../../src/core/utils/httpClient.js";
-import { AcrossProvider } from "../../src/external.js";
+import { AcrossProvider, ProviderGetQuoteFailure } from "../../src/external.js";
 import { getMockedAcrossApiResponse } from "../mocks/acrossApi.js";
 import { CHAIN_IDS, TEST_ADDRESSES, TEST_AMOUNTS, TESTNET_TOKENS } from "../mocks/fixtures.js";
 
@@ -227,6 +227,77 @@ describe("AcrossProvider", () => {
                 assetAddress: intermediateToken,
                 amount: "999000000",
             });
+        });
+    });
+
+    describe("trusted SpokePool registry guard", () => {
+        const baseQuoteRequest: QuoteRequest = {
+            user: TEST_ADDRESSES.USER,
+            input: {
+                chainId: CHAIN_IDS.SEPOLIA,
+                assetAddress: TESTNET_TOKENS.WETH_SEPOLIA,
+                amount: TEST_AMOUNTS.ONE_ETHER.toString(),
+            },
+            output: {
+                chainId: CHAIN_IDS.BASE_SEPOLIA,
+                assetAddress: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                recipient: TEST_ADDRESSES.RECEIVER,
+            },
+            swapType: "exact-input",
+        };
+
+        type MockedHttpResponse = {
+            status: number;
+            data: ReturnType<typeof getMockedAcrossApiResponse>;
+            headers: Headers;
+        };
+
+        const mockResponseWith = (
+            override: Parameters<typeof getMockedAcrossApiResponse>[0],
+        ): MockedHttpResponse => ({
+            status: 200,
+            data: getMockedAcrossApiResponse(override),
+            headers: new Headers(),
+        });
+
+        const expectRejection = async (request: QuoteRequest): Promise<void> => {
+            await expect(provider.getQuotes(request)).rejects.toBeInstanceOf(
+                ProviderGetQuoteFailure,
+            );
+        };
+
+        it("rejects quote when swapTx.to is not the canonical SpokePool", async () => {
+            const ATTACKER = "0x1111111111111111111111111111111111111111" as Address;
+            vi.mocked(httpRequest).mockResolvedValueOnce(
+                mockResponseWith({ swapTx: { ...mockAcrossApiResponse.swapTx, to: ATTACKER } }),
+            );
+
+            await expectRejection(baseQuoteRequest);
+        });
+
+        it("rejects quote for chain not in registry (fail-closed)", async () => {
+            const unknownChainId = 999_999;
+            vi.mocked(httpRequest).mockResolvedValueOnce(
+                mockResponseWith({
+                    swapTx: { ...mockAcrossApiResponse.swapTx, chainId: unknownChainId },
+                    inputToken: { ...mockAcrossApiResponse.inputToken, chainId: unknownChainId },
+                }),
+            );
+
+            await expectRejection({
+                ...baseQuoteRequest,
+                input: { ...baseQuoteRequest.input, chainId: unknownChainId },
+            });
+        });
+
+        it("rejects quote when swapTx.chainId differs from input.chainId", async () => {
+            vi.mocked(httpRequest).mockResolvedValueOnce(
+                mockResponseWith({
+                    swapTx: { ...mockAcrossApiResponse.swapTx, chainId: CHAIN_IDS.BASE_SEPOLIA },
+                }),
+            );
+
+            await expectRejection(baseQuoteRequest);
         });
     });
 

--- a/packages/cross-chain/test/validators/acrossPayloadValidator.spec.ts
+++ b/packages/cross-chain/test/validators/acrossPayloadValidator.spec.ts
@@ -1,8 +1,10 @@
 import { GetQuoteRequest } from "@openintentsframework/oif-specs";
 import { encodeAddress } from "@wonderland/interop-addresses";
-import { Address, Hex } from "viem";
+import { Address, encodeFunctionData, Hex, pad } from "viem";
 import { describe, expect, it } from "vitest";
 
+import { addressToBytes32 } from "../../src/core/utils/addressHelpers.js";
+import { ACROSS_SPOKE_POOL_DEPOSIT_ABI } from "../../src/protocols/across/constants.js";
 import { validateAcrossPayload } from "../../src/protocols/across/validator.js";
 import { ACROSS_DEPOSIT_FIXTURE, CHAIN_IDS, MAINNET_TOKENS } from "../mocks/fixtures.js";
 
@@ -111,7 +113,7 @@ describe("validateAcrossPayload", () => {
             expect(await validateAcrossPayload(intent, "" as Hex)).toBe(false);
         });
 
-        it("returns true for unsupported selectors (cannot validate, allow through)", async () => {
+        it("rejects calldata whose selector is not deposit", async () => {
             const intent: GetQuoteRequest = {
                 user: "test",
                 intent: {
@@ -122,7 +124,53 @@ describe("validateAcrossPayload", () => {
                 supportedTypes: ["across"],
             };
             // 0x12345678 is not a known Across selector
-            expect(await validateAcrossPayload(intent, "0x12345678")).toBe(true);
+            expect(await validateAcrossPayload(intent, "0x12345678")).toBe(false);
+        });
+
+        it("rejects deposit calldata that carries a non-empty message", async () => {
+            const FIXTURE = ACROSS_DEPOSIT_FIXTURE;
+            const user = interopAddress(CHAIN_IDS.ETHEREUM, FIXTURE.depositor);
+            const intent: GetQuoteRequest = {
+                user,
+                intent: {
+                    intentType: "oif-swap",
+                    inputs: [
+                        {
+                            user,
+                            asset: interopAddress(CHAIN_IDS.ETHEREUM, FIXTURE.inputToken),
+                            amount: FIXTURE.inputAmount,
+                        },
+                    ],
+                    outputs: [
+                        {
+                            receiver: user,
+                            asset: interopAddress(FIXTURE.destinationChainId, FIXTURE.outputToken),
+                        },
+                    ],
+                },
+                supportedTypes: ["across"],
+            };
+
+            const calldataWithMessage = encodeFunctionData({
+                abi: ACROSS_SPOKE_POOL_DEPOSIT_ABI,
+                functionName: "deposit",
+                args: [
+                    addressToBytes32(FIXTURE.depositor),
+                    addressToBytes32(FIXTURE.depositor),
+                    addressToBytes32(FIXTURE.inputToken),
+                    addressToBytes32(FIXTURE.outputToken),
+                    BigInt(FIXTURE.inputAmount),
+                    BigInt(FIXTURE.inputAmount),
+                    BigInt(FIXTURE.destinationChainId),
+                    pad("0x00" as Hex, { size: 32 }),
+                    0,
+                    0,
+                    0,
+                    "0xdeadbeef",
+                ],
+            });
+
+            expect(await validateAcrossPayload(intent, calldataWithMessage)).toBe(false);
         });
 
         it("returns false when intent has no outputs", async () => {


### PR DESCRIPTION
## Summary
- `AcrossProvider.getQuotes` now refuses a quote unless `swapTx.to` matches the canonical SpokePool for the request's input chain, the SpokePool registry knows that chain, and `swapTx.chainId` matches the requested input chain.
- `decodeAcrossCalldata` rejects any selector other than the SpokePool `deposit`, and surfaces `hasMessage` so the provider can refuse deposits whose destination handler can't be audited.
- Decoded address fields are typed as `Address`, which removes a fistful of `as Address` casts at the call sites and makes `isAddressEqual` use them directly.

## Changes
- `packages/cross-chain/src/protocols/across/provider.ts`
  - `isTrustedSpokePool(chainId, target)` looks `target` up in `ACROSS_SPOKE_POOL_ADDRESSES` and fails closed when the chain isn't registered.
  - `getQuotes` gates acceptance behind `swapTx.chainId === input.chainId && isTrustedSpokePool && validateCalldata` before building the SDK quote.
  - `validateCalldata` rejects deposits with a non-empty message and keeps the field-by-field intent check against the `QuoteRequest`.
- `packages/cross-chain/src/protocols/across/utils.ts`
  - `decodeAcrossCalldata` returns early when the selector is not `deposit`, exposes `hasMessage`, and yields `DecodedAcrossParams` whose addresses are typed as `Address`.
- `packages/cross-chain/src/protocols/across/validator.ts`
  - `validateAcrossPayload` rejects malformed calldata, non-deposit selectors, and deposits with a message before comparing fields against the user intent.
- `packages/cross-chain/test/providers/AcrossProvider.spec.ts`
  - New `trusted SpokePool registry guard` suite covering: untrusted target, chain absent from the registry, mismatched `swapTx.chainId`, non-deposit selector, deposit with a message.
- `packages/cross-chain/test/validators/acrossPayloadValidator.spec.ts`
  - Coverage for non-deposit selector and deposit-with-message rejection paths.
- `packages/cross-chain/test/mocks/acrossApi.ts`
  - Mock now lets each test override `swapTx` fields to exercise the new guards.
- `.changeset/across-trusted-spokepool-registry.md`
  - Patch changeset describing registry validation, calldata selector rejection, and message rejection.

## Test plan
- [ ] `pnpm --filter @wonderland/interop-cross-chain test`
- [ ] `pnpm check-types`

Closes EFI-932.