### PR TITLE
fix(cross-chain): pin Permit2 spender to canonical address (EFI-945)

### DIFF
--- a/.changeset/permit2-spender-pinned.md
+++ b/.changeset/permit2-spender-pinned.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Pin Permit2 typed-data to the canonical contract and validate permitted/spender against the user's intent.

--- a/packages/cross-chain/src/core/constants/index.ts
+++ b/packages/cross-chain/src/core/constants/index.ts
@@ -1,1 +1,2 @@
 export * from "./tokens.js";
+export * from "./permit2.js";

--- a/packages/cross-chain/src/core/constants/permit2.ts
+++ b/packages/cross-chain/src/core/constants/permit2.ts
@@ -1,0 +1,18 @@
+import { getAddress } from "viem";
+
+/** Permit2 is deployed at the same address on every supported EVM chain. */
+export const CANONICAL_PERMIT2_ADDRESS = getAddress("0x000000000022D473030F116dDEE9F6B43aC78BA3");
+
+/** EIP-712 primaryType strings that target the Permit2 contract. */
+export const PERMIT2_PRIMARY_TYPES: ReadonlySet<string> = new Set([
+    "PermitTransferFrom",
+    "PermitWitnessTransferFrom",
+    "PermitBatchTransferFrom",
+    "PermitBatchWitnessTransferFrom",
+]);
+
+/** Subset of {@link PERMIT2_PRIMARY_TYPES} whose `permitted` is a batch array. */
+export const PERMIT2_BATCH_PRIMARY_TYPES: ReadonlySet<string> = new Set([
+    "PermitBatchTransferFrom",
+    "PermitBatchWitnessTransferFrom",
+]);

--- a/packages/cross-chain/src/core/errors/Permit2ValidationFailure.exception.ts
+++ b/packages/cross-chain/src/core/errors/Permit2ValidationFailure.exception.ts
@@ -1,0 +1,27 @@
+import { BaseError } from "./BaseError.exception.js";
+
+/** Why a Permit2 signature payload was rejected. */
+export type Permit2ValidationReason =
+    | "verifying-contract"
+    | "non-permit2-canonical"
+    | "permitted-token"
+    | "permitted-amount"
+    | "spender";
+
+export class Permit2ValidationFailure extends BaseError {
+    public readonly reason: Permit2ValidationReason;
+    public readonly providerId: string;
+
+    constructor(
+        reason: Permit2ValidationReason,
+        providerId: string,
+        message: string,
+        cause?: string,
+        stack?: string,
+    ) {
+        super(message, cause, stack);
+        this.reason = reason;
+        this.providerId = providerId;
+        this.name = "Permit2ValidationFailure";
+    }
+}

--- a/packages/cross-chain/src/core/errors/Permit2ValidationFailure.exception.ts
+++ b/packages/cross-chain/src/core/errors/Permit2ValidationFailure.exception.ts
@@ -4,6 +4,7 @@ import { BaseError } from "./BaseError.exception.js";
 export type Permit2ValidationReason =
     | "verifying-contract"
     | "non-permit2-canonical"
+    | "permitted-empty"
     | "permitted-token"
     | "permitted-amount"
     | "spender";

--- a/packages/cross-chain/src/core/errors/Permit2ValidationFailure.exception.ts
+++ b/packages/cross-chain/src/core/errors/Permit2ValidationFailure.exception.ts
@@ -7,6 +7,8 @@ export type Permit2ValidationReason =
     | "permitted-empty"
     | "permitted-token"
     | "permitted-amount"
+    | "requested-amount"
+    | "chain-id"
     | "spender";
 
 export class Permit2ValidationFailure extends BaseError {

--- a/packages/cross-chain/src/core/errors/index.ts
+++ b/packages/cross-chain/src/core/errors/index.ts
@@ -24,3 +24,4 @@ export * from "./UnsupportedAsset.exception.js";
 export * from "./HttpError.exception.js";
 export * from "./HttpTimeout.exception.js";
 export * from "./HttpNetworkError.exception.js";
+export * from "./Permit2ValidationFailure.exception.js";

--- a/packages/cross-chain/src/core/utils/index.ts
+++ b/packages/cross-chain/src/core/utils/index.ts
@@ -10,3 +10,4 @@ export * from "./typedEventEmitter.js";
 export * from "./interopAccountId.js";
 export * from "./stepHelpers.js";
 export * from "./httpClient.js";
+export * from "./permit2.js";

--- a/packages/cross-chain/src/core/utils/permit2.ts
+++ b/packages/cross-chain/src/core/utils/permit2.ts
@@ -1,0 +1,30 @@
+import type { Address } from "viem";
+import { getAddress, isAddress } from "viem";
+
+import { PERMIT2_BATCH_PRIMARY_TYPES, PERMIT2_PRIMARY_TYPES } from "../constants/permit2.js";
+
+export interface Permit2TokenPermission {
+    token: string;
+    amount: string;
+}
+
+/** Normalize a Permit2 `message.permitted` (single object or batch array) into an array. */
+export function readPermittedEntries(primaryType: string, raw: unknown): Permit2TokenPermission[] {
+    if (PERMIT2_BATCH_PRIMARY_TYPES.has(primaryType)) {
+        return Array.isArray(raw) ? (raw as Permit2TokenPermission[]) : [];
+    }
+    if (
+        PERMIT2_PRIMARY_TYPES.has(primaryType) &&
+        raw !== null &&
+        typeof raw === "object" &&
+        "token" in raw
+    ) {
+        return [raw as Permit2TokenPermission];
+    }
+    return [];
+}
+
+/** Best-effort address parser: returns a checksummed Address or null if `raw` is not one. */
+export function toAddressOrNull(raw: unknown): Address | null {
+    return typeof raw === "string" && isAddress(raw) ? getAddress(raw) : null;
+}

--- a/packages/cross-chain/src/core/validators/index.ts
+++ b/packages/cross-chain/src/core/validators/index.ts
@@ -1,2 +1,3 @@
 export * from "./settlerIntentValidator.js";
 export * from "./buildQuoteValidator.js";
+export * from "./permit2Validator.js";

--- a/packages/cross-chain/src/core/validators/permit2Validator.ts
+++ b/packages/cross-chain/src/core/validators/permit2Validator.ts
@@ -34,7 +34,7 @@ export class Permit2SignatureValidator {
         if (!isPermit2Type) return;
 
         const permitted = readPermittedEntries(primaryType, message["permitted"]);
-        this.assertPermittedMatchesRequest(permitted, context);
+        this.assertPermittedMatchesRequest(permitted, primaryType, context);
         this.assertSpenderInExpectedList(message["spender"], context);
     }
 
@@ -68,8 +68,17 @@ export class Permit2SignatureValidator {
 
     private assertPermittedMatchesRequest(
         permitted: readonly Permit2TokenPermission[],
+        primaryType: string,
         context: Permit2ValidationContext,
     ): void {
+        if (permitted.length === 0) {
+            throw new Permit2ValidationFailure(
+                "permitted-empty",
+                context.providerId,
+                `permit message.permitted is empty or malformed for Permit2 primaryType "${primaryType}"`,
+            );
+        }
+
         const requestedToken = getAddress(context.request.input.assetAddress);
         const requestedAmount = BigInt(context.request.input.amount ?? "0");
 

--- a/packages/cross-chain/src/core/validators/permit2Validator.ts
+++ b/packages/cross-chain/src/core/validators/permit2Validator.ts
@@ -80,7 +80,16 @@ export class Permit2SignatureValidator {
         }
 
         const requestedToken = getAddress(context.request.input.assetAddress);
-        const requestedAmount = BigInt(context.request.input.amount ?? "0");
+        const rawAmount = context.request.input.amount;
+        if (rawAmount === undefined || BigInt(rawAmount) <= 0n) {
+            throw new Permit2ValidationFailure(
+                "requested-amount",
+                context.providerId,
+                `Permit2 primaryType "${primaryType}" requires a positive request.input.amount as the permitted cap`,
+                `got=${String(rawAmount)}`,
+            );
+        }
+        const requestedAmount = BigInt(rawAmount);
 
         let total = 0n;
         for (const entry of permitted) {
@@ -95,7 +104,7 @@ export class Permit2SignatureValidator {
             total += BigInt(entry.amount);
         }
 
-        if (requestedAmount > 0n && total > requestedAmount) {
+        if (total > requestedAmount) {
             throw new Permit2ValidationFailure(
                 "permitted-amount",
                 context.providerId,

--- a/packages/cross-chain/src/core/validators/permit2Validator.ts
+++ b/packages/cross-chain/src/core/validators/permit2Validator.ts
@@ -1,14 +1,12 @@
 import type { Address } from "viem";
-import { getAddress, isAddress } from "viem";
+import { getAddress, isAddressEqual } from "viem";
 
 import type { SignatureStep } from "../schemas/order.js";
 import type { QuoteRequest } from "../schemas/quoteRequest.js";
-import {
-    CANONICAL_PERMIT2_ADDRESS,
-    PERMIT2_BATCH_PRIMARY_TYPES,
-    PERMIT2_PRIMARY_TYPES,
-} from "../constants/permit2.js";
+import type { Permit2TokenPermission } from "../utils/permit2.js";
+import { CANONICAL_PERMIT2_ADDRESS, PERMIT2_PRIMARY_TYPES } from "../constants/permit2.js";
 import { Permit2ValidationFailure } from "../errors/Permit2ValidationFailure.exception.js";
+import { readPermittedEntries, toAddressOrNull } from "../utils/permit2.js";
 
 /** Inputs required to decide whether a Permit2 signature is safe to surface. */
 export interface Permit2ValidationContext {
@@ -17,55 +15,59 @@ export interface Permit2ValidationContext {
     expectedSpenders?: readonly Address[];
 }
 
-interface TokenPermission {
-    token: string;
-    amount: string;
-}
-
 /**
  * Guards Permit2 EIP-712 payloads against solver tampering (audit V12 #6).
- *
- * The contract is fail-closed: any deviation from the user's intent or the
- * canonical Permit2 anchor raises {@link Permit2ValidationFailure}.
+ * Fail-closed: any deviation from the canonical anchor or the user's intent
+ * raises {@link Permit2ValidationFailure}.
  */
 export class Permit2SignatureValidator {
     public validate(step: SignatureStep, context: Permit2ValidationContext): void {
-        const { signaturePayload } = step;
-        const { primaryType, domain, message } = signaturePayload;
-        const looksLikePermit2 = PERMIT2_PRIMARY_TYPES.has(primaryType);
+        const { primaryType, domain, message } = step.signaturePayload;
+        const isPermit2Type = PERMIT2_PRIMARY_TYPES.has(primaryType);
 
-        const verifyingContract = readAddress(domain["verifyingContract"]);
-        const canonicalMatch = verifyingContract === CANONICAL_PERMIT2_ADDRESS;
+        this.assertVerifyingContract(
+            domain["verifyingContract"],
+            primaryType,
+            isPermit2Type,
+            context,
+        );
+        if (!isPermit2Type) return;
 
-        if (looksLikePermit2 && !canonicalMatch) {
+        const permitted = readPermittedEntries(primaryType, message["permitted"]);
+        this.assertPermittedMatchesRequest(permitted, context);
+        this.assertSpenderInExpectedList(message["spender"], context);
+    }
+
+    private assertVerifyingContract(
+        raw: unknown,
+        primaryType: string,
+        isPermit2Type: boolean,
+        context: Permit2ValidationContext,
+    ): void {
+        const verifyingContract = toAddressOrNull(raw);
+        const isCanonical =
+            verifyingContract !== null &&
+            isAddressEqual(verifyingContract, CANONICAL_PERMIT2_ADDRESS);
+
+        if (isPermit2Type && !isCanonical) {
             throw new Permit2ValidationFailure(
                 "verifying-contract",
                 context.providerId,
-                `Permit2 primaryType "${primaryType}" but verifyingContract is not the canonical Permit2 address`,
-                `got=${String(domain["verifyingContract"])} expected=${CANONICAL_PERMIT2_ADDRESS}`,
+                `Permit2 primaryType "${primaryType}" with non-canonical verifyingContract`,
+                `got=${String(raw)} expected=${CANONICAL_PERMIT2_ADDRESS}`,
             );
         }
-
-        if (!looksLikePermit2 && canonicalMatch) {
+        if (!isPermit2Type && isCanonical) {
             throw new Permit2ValidationFailure(
                 "non-permit2-canonical",
                 context.providerId,
-                `verifyingContract is canonical Permit2 but primaryType "${primaryType}" is not a Permit2 type`,
+                `Non-Permit2 primaryType "${primaryType}" signed against canonical Permit2`,
             );
-        }
-
-        if (!looksLikePermit2) return;
-
-        const permitted = normalizePermitted(primaryType, message["permitted"]);
-        this.assertPermittedMatchesRequest(permitted, context);
-
-        if (context.expectedSpenders && context.expectedSpenders.length > 0) {
-            this.assertSpenderAllowed(message["spender"], context);
         }
     }
 
     private assertPermittedMatchesRequest(
-        permitted: readonly TokenPermission[],
+        permitted: readonly Permit2TokenPermission[],
         context: Permit2ValidationContext,
     ): void {
         const requestedToken = getAddress(context.request.input.assetAddress);
@@ -73,18 +75,12 @@ export class Permit2SignatureValidator {
 
         let total = 0n;
         for (const entry of permitted) {
-            if (!isAddress(entry.token)) {
+            const token = toAddressOrNull(entry.token);
+            if (!token || !isAddressEqual(token, requestedToken)) {
                 throw new Permit2ValidationFailure(
                     "permitted-token",
                     context.providerId,
-                    `permitted token "${entry.token}" is not a valid address`,
-                );
-            }
-            if (getAddress(entry.token) !== requestedToken) {
-                throw new Permit2ValidationFailure(
-                    "permitted-token",
-                    context.providerId,
-                    `permitted token ${entry.token} does not match the requested input token ${requestedToken}`,
+                    `permitted token ${entry.token} does not match the requested input ${requestedToken}`,
                 );
             }
             total += BigInt(entry.amount);
@@ -94,47 +90,32 @@ export class Permit2SignatureValidator {
             throw new Permit2ValidationFailure(
                 "permitted-amount",
                 context.providerId,
-                `permitted total ${total} exceeds requested input amount ${requestedAmount}`,
+                `permitted total ${total} exceeds requested input ${requestedAmount}`,
             );
         }
     }
 
-    private assertSpenderAllowed(rawSpender: unknown, context: Permit2ValidationContext): void {
-        const spender = readAddress(rawSpender);
+    private assertSpenderInExpectedList(raw: unknown, context: Permit2ValidationContext): void {
+        const { expectedSpenders, providerId } = context;
+        if (!expectedSpenders?.length) return;
+
+        const spender = toAddressOrNull(raw);
         if (!spender) {
             throw new Permit2ValidationFailure(
                 "spender",
-                context.providerId,
-                `permit message.spender "${String(rawSpender)}" is not a valid address`,
+                providerId,
+                `permit message.spender "${String(raw)}" is not a valid address`,
             );
         }
-
-        const allowed = context.expectedSpenders!.map((s) => getAddress(s));
-        if (!allowed.includes(spender)) {
+        if (!expectedSpenders.some((s) => isAddressEqual(spender, s))) {
             throw new Permit2ValidationFailure(
                 "spender",
-                context.providerId,
+                providerId,
                 `permit message.spender ${spender} is not in the expected list`,
-                `expected one of [${allowed.join(", ")}]`,
+                `expected one of [${expectedSpenders.join(", ")}]`,
             );
         }
     }
 }
 
 export const permit2SignatureValidator = new Permit2SignatureValidator();
-
-function readAddress(value: unknown): Address | null {
-    if (typeof value !== "string" || !isAddress(value)) return null;
-    return getAddress(value);
-}
-
-function normalizePermitted(primaryType: string, raw: unknown): readonly TokenPermission[] {
-    if (PERMIT2_BATCH_PRIMARY_TYPES.has(primaryType)) {
-        if (!Array.isArray(raw)) return [];
-        return raw as TokenPermission[];
-    }
-    if (raw && typeof raw === "object" && "token" in (raw as object)) {
-        return [raw as TokenPermission];
-    }
-    return [];
-}

--- a/packages/cross-chain/src/core/validators/permit2Validator.ts
+++ b/packages/cross-chain/src/core/validators/permit2Validator.ts
@@ -1,0 +1,140 @@
+import type { Address } from "viem";
+import { getAddress, isAddress } from "viem";
+
+import type { SignatureStep } from "../schemas/order.js";
+import type { QuoteRequest } from "../schemas/quoteRequest.js";
+import {
+    CANONICAL_PERMIT2_ADDRESS,
+    PERMIT2_BATCH_PRIMARY_TYPES,
+    PERMIT2_PRIMARY_TYPES,
+} from "../constants/permit2.js";
+import { Permit2ValidationFailure } from "../errors/Permit2ValidationFailure.exception.js";
+
+/** Inputs required to decide whether a Permit2 signature is safe to surface. */
+export interface Permit2ValidationContext {
+    providerId: string;
+    request: QuoteRequest;
+    expectedSpenders?: readonly Address[];
+}
+
+interface TokenPermission {
+    token: string;
+    amount: string;
+}
+
+/**
+ * Guards Permit2 EIP-712 payloads against solver tampering (audit V12 #6).
+ *
+ * The contract is fail-closed: any deviation from the user's intent or the
+ * canonical Permit2 anchor raises {@link Permit2ValidationFailure}.
+ */
+export class Permit2SignatureValidator {
+    public validate(step: SignatureStep, context: Permit2ValidationContext): void {
+        const { signaturePayload } = step;
+        const { primaryType, domain, message } = signaturePayload;
+        const looksLikePermit2 = PERMIT2_PRIMARY_TYPES.has(primaryType);
+
+        const verifyingContract = readAddress(domain["verifyingContract"]);
+        const canonicalMatch = verifyingContract === CANONICAL_PERMIT2_ADDRESS;
+
+        if (looksLikePermit2 && !canonicalMatch) {
+            throw new Permit2ValidationFailure(
+                "verifying-contract",
+                context.providerId,
+                `Permit2 primaryType "${primaryType}" but verifyingContract is not the canonical Permit2 address`,
+                `got=${String(domain["verifyingContract"])} expected=${CANONICAL_PERMIT2_ADDRESS}`,
+            );
+        }
+
+        if (!looksLikePermit2 && canonicalMatch) {
+            throw new Permit2ValidationFailure(
+                "non-permit2-canonical",
+                context.providerId,
+                `verifyingContract is canonical Permit2 but primaryType "${primaryType}" is not a Permit2 type`,
+            );
+        }
+
+        if (!looksLikePermit2) return;
+
+        const permitted = normalizePermitted(primaryType, message["permitted"]);
+        this.assertPermittedMatchesRequest(permitted, context);
+
+        if (context.expectedSpenders && context.expectedSpenders.length > 0) {
+            this.assertSpenderAllowed(message["spender"], context);
+        }
+    }
+
+    private assertPermittedMatchesRequest(
+        permitted: readonly TokenPermission[],
+        context: Permit2ValidationContext,
+    ): void {
+        const requestedToken = getAddress(context.request.input.assetAddress);
+        const requestedAmount = BigInt(context.request.input.amount ?? "0");
+
+        let total = 0n;
+        for (const entry of permitted) {
+            if (!isAddress(entry.token)) {
+                throw new Permit2ValidationFailure(
+                    "permitted-token",
+                    context.providerId,
+                    `permitted token "${entry.token}" is not a valid address`,
+                );
+            }
+            if (getAddress(entry.token) !== requestedToken) {
+                throw new Permit2ValidationFailure(
+                    "permitted-token",
+                    context.providerId,
+                    `permitted token ${entry.token} does not match the requested input token ${requestedToken}`,
+                );
+            }
+            total += BigInt(entry.amount);
+        }
+
+        if (requestedAmount > 0n && total > requestedAmount) {
+            throw new Permit2ValidationFailure(
+                "permitted-amount",
+                context.providerId,
+                `permitted total ${total} exceeds requested input amount ${requestedAmount}`,
+            );
+        }
+    }
+
+    private assertSpenderAllowed(rawSpender: unknown, context: Permit2ValidationContext): void {
+        const spender = readAddress(rawSpender);
+        if (!spender) {
+            throw new Permit2ValidationFailure(
+                "spender",
+                context.providerId,
+                `permit message.spender "${String(rawSpender)}" is not a valid address`,
+            );
+        }
+
+        const allowed = context.expectedSpenders!.map((s) => getAddress(s));
+        if (!allowed.includes(spender)) {
+            throw new Permit2ValidationFailure(
+                "spender",
+                context.providerId,
+                `permit message.spender ${spender} is not in the expected list`,
+                `expected one of [${allowed.join(", ")}]`,
+            );
+        }
+    }
+}
+
+export const permit2SignatureValidator = new Permit2SignatureValidator();
+
+function readAddress(value: unknown): Address | null {
+    if (typeof value !== "string" || !isAddress(value)) return null;
+    return getAddress(value);
+}
+
+function normalizePermitted(primaryType: string, raw: unknown): readonly TokenPermission[] {
+    if (PERMIT2_BATCH_PRIMARY_TYPES.has(primaryType)) {
+        if (!Array.isArray(raw)) return [];
+        return raw as TokenPermission[];
+    }
+    if (raw && typeof raw === "object" && "token" in (raw as object)) {
+        return [raw as TokenPermission];
+    }
+    return [];
+}

--- a/packages/cross-chain/src/protocols/bungee/constants.ts
+++ b/packages/cross-chain/src/protocols/bungee/constants.ts
@@ -1,3 +1,5 @@
+import type { Address } from "viem";
+
 import { BungeeApiTier } from "./types.js";
 
 /** Base URLs for each Bungee API tier. */
@@ -12,3 +14,21 @@ export const BUNGEE_API_URL = BUNGEE_API_URLS[BungeeApiTier.Sandbox];
 
 /** Bridge tracker base URL. Append `/${originTxHash}` for a per-order link. */
 export const BUNGEE_EXPLORER_BASE_URL = "https://www.socketscan.io/tx";
+
+/**
+ * Canonical BungeeGateway contract per origin chain — the only address the
+ * settler may set as `message.spender` in a Permit2 payload. Source:
+ * https://docs.bungee.exchange/integrate/contract-addresses.md.
+ * Chains absent from this map are not validated; the provider rejects
+ * gasless quotes on them (fail-closed, audit V12 #6).
+ */
+export const BUNGEE_GATEWAY_BY_CHAIN: Record<number, Address> = {
+    1: "0xe772551F88E2c14aEcC880dF6b7CBd574561bf82", // Ethereum
+    10: "0x09dABDD517FF1E155DeDeF64Ec629cA0285A31AF", // Optimism
+    56: "0x9aF2b913679049c966b77934af4CbE7Bb36Cf9D3", // BNB Smart Chain
+    100: "0x5e01dbBBe59F8987673FAdD1469DdD2Be71e00af", // Gnosis
+    8453: "0x84F06fBaCc4b64CA2f72a4B26191DAD97f2b52BA", // Base
+    42161: "0xCdEa28Ee7BD5bf7710B294d9391e1b6A318d809a", // Arbitrum
+    43114: "0xfe191a43dc4F3d57d7D942717D259005967e4e0D", // Avalanche
+    81457: "0x5525e0700390A12995aC181eFF656E4aC0246b29", // Blast
+};

--- a/packages/cross-chain/src/protocols/bungee/provider.ts
+++ b/packages/cross-chain/src/protocols/bungee/provider.ts
@@ -33,7 +33,7 @@ import {
     extractOpenedIntent,
     parseBungeeTokenListResponse,
 } from "./adapters/index.js";
-import { BUNGEE_API_URLS, BUNGEE_EXPLORER_BASE_URL } from "./constants.js";
+import { BUNGEE_API_URLS, BUNGEE_EXPLORER_BASE_URL, BUNGEE_GATEWAY_BY_CHAIN } from "./constants.js";
 import { BungeeApiService } from "./services/index.js";
 import { BungeeApiTier, BungeeConfigSchema } from "./types.js";
 
@@ -242,12 +242,18 @@ export class BungeeProvider extends CrossChainProvider {
     private isQuoteSignaturePayloadSafe(quote: Quote, request: QuoteRequest): boolean {
         for (const step of quote.order.steps) {
             if (step.kind !== "signature") continue;
-            const expected = readBungeeGateway(step.signaturePayload.message);
+            const canonicalGateway = BUNGEE_GATEWAY_BY_CHAIN[step.chainId];
+            if (!canonicalGateway) {
+                console.warn(
+                    `${PERMIT2_LOG_PREFIX} No canonical Bungee gateway registered for chain ${step.chainId}; rejecting quote`,
+                );
+                return false;
+            }
             try {
                 permit2SignatureValidator.validate(step, {
                     providerId: this.providerId,
                     request,
-                    expectedSpenders: expected ? [expected] : undefined,
+                    expectedSpenders: [canonicalGateway],
                 });
             } catch (err) {
                 if (err instanceof Permit2ValidationFailure) {
@@ -261,15 +267,4 @@ export class BungeeProvider extends CrossChainProvider {
         }
         return true;
     }
-}
-
-/** Extracts the gateway address bound inside the Bungee witness, when present. */
-function readBungeeGateway(message: Record<string, unknown>): `0x${string}` | null {
-    const witness = message["witness"];
-    if (!witness || typeof witness !== "object") return null;
-    const basicReq = (witness as Record<string, unknown>)["basicReq"];
-    if (!basicReq || typeof basicReq !== "object") return null;
-    const gateway = (basicReq as Record<string, unknown>)["bungeeGateway"];
-    if (typeof gateway !== "string" || !gateway.startsWith("0x")) return null;
-    return gateway as `0x${string}`;
 }

--- a/packages/cross-chain/src/protocols/bungee/provider.ts
+++ b/packages/cross-chain/src/protocols/bungee/provider.ts
@@ -18,6 +18,8 @@ import type { BungeeConfigs } from "./types.js";
 import {
     CrossChainProvider,
     FetchHttpClient,
+    permit2SignatureValidator,
+    Permit2ValidationFailure,
     ProviderConfigFailure,
     ProviderExecuteFailure,
     ProviderGetQuoteFailure,
@@ -36,6 +38,8 @@ import { BungeeApiService } from "./services/index.js";
 import { BungeeApiTier, BungeeConfigSchema } from "./types.js";
 
 const DEFAULT_SUBMISSION_MODES: SubmissionMode[] = ["user-transaction"];
+
+const PERMIT2_LOG_PREFIX = "[BungeeProvider]";
 
 /**
  * A {@link CrossChainProvider} implementation for the Bungee protocol.
@@ -220,7 +224,8 @@ export class BungeeProvider extends CrossChainProvider {
             const options: BungeeQuoteOptions = { ...this.quoteOptions, submissionMode: mode };
             const bungeeParams = adaptQuoteRequest(params, options);
             const response = await this.apiService.getQuote(bungeeParams);
-            return adaptQuotes(response, this.providerId);
+            const quotes = adaptQuotes(response, this.providerId);
+            return quotes.filter((quote) => this.isQuoteSignaturePayloadSafe(quote, params));
         } catch (error) {
             if (error instanceof ProviderGetQuoteFailure) {
                 throw error;
@@ -232,4 +237,39 @@ export class BungeeProvider extends CrossChainProvider {
             );
         }
     }
+
+    /** True if every signature step in the quote is safe per Permit2 rules (V12 #6). */
+    private isQuoteSignaturePayloadSafe(quote: Quote, request: QuoteRequest): boolean {
+        for (const step of quote.order.steps) {
+            if (step.kind !== "signature") continue;
+            const expected = readBungeeGateway(step.signaturePayload.message);
+            try {
+                permit2SignatureValidator.validate(step, {
+                    providerId: this.providerId,
+                    request,
+                    expectedSpenders: expected ? [expected] : undefined,
+                });
+            } catch (err) {
+                if (err instanceof Permit2ValidationFailure) {
+                    console.warn(
+                        `${PERMIT2_LOG_PREFIX} Rejecting quote (${err.reason}): ${err.message}`,
+                    );
+                    return false;
+                }
+                throw err;
+            }
+        }
+        return true;
+    }
+}
+
+/** Extracts the gateway address bound inside the Bungee witness, when present. */
+function readBungeeGateway(message: Record<string, unknown>): `0x${string}` | null {
+    const witness = message["witness"];
+    if (!witness || typeof witness !== "object") return null;
+    const basicReq = (witness as Record<string, unknown>)["basicReq"];
+    if (!basicReq || typeof basicReq !== "object") return null;
+    const gateway = (basicReq as Record<string, unknown>)["bungeeGateway"];
+    if (typeof gateway !== "string" || !gateway.startsWith("0x")) return null;
+    return gateway as `0x${string}`;
 }

--- a/packages/cross-chain/src/protocols/bungee/provider.ts
+++ b/packages/cross-chain/src/protocols/bungee/provider.ts
@@ -240,12 +240,19 @@ export class BungeeProvider extends CrossChainProvider {
 
     /** True if every signature step in the quote is safe per Permit2 rules (V12 #6). */
     private isQuoteSignaturePayloadSafe(quote: Quote, request: QuoteRequest): boolean {
+        const requestedChainId = request.input.chainId;
+        const canonicalGateway = BUNGEE_GATEWAY_BY_CHAIN[requestedChainId];
+        if (!canonicalGateway) {
+            console.warn(
+                `${PERMIT2_LOG_PREFIX} No canonical Bungee gateway registered for chain ${requestedChainId}; rejecting quote`,
+            );
+            return false;
+        }
         for (const step of quote.order.steps) {
             if (step.kind !== "signature") continue;
-            const canonicalGateway = BUNGEE_GATEWAY_BY_CHAIN[step.chainId];
-            if (!canonicalGateway) {
+            if (step.chainId !== requestedChainId) {
                 console.warn(
-                    `${PERMIT2_LOG_PREFIX} No canonical Bungee gateway registered for chain ${step.chainId}; rejecting quote`,
+                    `${PERMIT2_LOG_PREFIX} step.chainId ${step.chainId} does not match request.input.chainId ${requestedChainId}; rejecting quote`,
                 );
                 return false;
             }

--- a/packages/cross-chain/src/protocols/oif/adapters/permit2AllowanceExtractor.ts
+++ b/packages/cross-chain/src/protocols/oif/adapters/permit2AllowanceExtractor.ts
@@ -12,40 +12,37 @@ import type { Address } from "viem";
 import { getAddress } from "viem";
 
 import type { AllowanceCheck } from "../../../core/interfaces/approval.interface.js";
-import { CANONICAL_PERMIT2_ADDRESS } from "../../../core/constants/permit2.js";
+import type { Permit2TokenPermission } from "../../../core/utils/permit2.js";
+import {
+    CANONICAL_PERMIT2_ADDRESS,
+    PERMIT2_PRIMARY_TYPES,
+} from "../../../core/constants/permit2.js";
+import { readPermittedEntries } from "../../../core/utils/permit2.js";
 
 const LOG_PREFIX = "[permit2AllowanceExtractor]";
 
-const SINGLE_PERMIT_TYPES: ReadonlySet<string> = new Set([
-    "PermitTransferFrom",
-    "PermitWitnessTransferFrom",
-]);
-
-const BATCH_PERMIT_TYPES: ReadonlySet<string> = new Set([
-    "PermitBatchTransferFrom",
-    "PermitBatchWitnessTransferFrom",
-]);
-
 type EscrowPayload = OifEscrowOrder["payload"];
-
-interface TokenPermission {
-    token: string;
-    amount: string;
-}
 
 /** Extracts the ERC-20 allowances from a validated Permit2 escrow payload. */
 export function extractPermit2Allowances(
     payload: EscrowPayload,
     signer: Address,
 ): AllowanceCheck[] {
-    const permitted = readPermittedEntries(payload);
+    if (!PERMIT2_PRIMARY_TYPES.has(payload.primaryType)) {
+        console.warn(`${LOG_PREFIX} Unknown primaryType: ${payload.primaryType}`);
+        return [];
+    }
+
+    const permitted = readPermittedEntries(
+        payload.primaryType,
+        (payload.message as { permitted: unknown }).permitted,
+    );
     if (permitted.length === 0) return [];
 
     const chainId = Number((payload.domain as { chainId: number | string }).chainId);
     const owner = getAddress(signer);
-    const totalsByToken = sumAmountsByToken(permitted);
 
-    return Array.from(totalsByToken, ([tokenAddress, required]) => ({
+    return Array.from(sumAmountsByToken(permitted), ([tokenAddress, required]) => ({
         chainId,
         tokenAddress,
         owner,
@@ -55,22 +52,7 @@ export function extractPermit2Allowances(
     }));
 }
 
-// ── helpers ─────────────────────────────────────────────
-
-function readPermittedEntries(payload: EscrowPayload): TokenPermission[] {
-    const { primaryType } = payload;
-    const { permitted } = payload.message as {
-        permitted: TokenPermission | TokenPermission[];
-    };
-
-    if (SINGLE_PERMIT_TYPES.has(primaryType)) return [permitted as TokenPermission];
-    if (BATCH_PERMIT_TYPES.has(primaryType)) return permitted as TokenPermission[];
-
-    console.warn(`${LOG_PREFIX} Unknown primaryType: ${primaryType}`);
-    return [];
-}
-
-function sumAmountsByToken(permitted: TokenPermission[]): Map<Address, bigint> {
+function sumAmountsByToken(permitted: readonly Permit2TokenPermission[]): Map<Address, bigint> {
     const totals = new Map<Address, bigint>();
     for (const { token, amount } of permitted) {
         const checksummed = getAddress(token);

--- a/packages/cross-chain/src/protocols/oif/adapters/permit2AllowanceExtractor.ts
+++ b/packages/cross-chain/src/protocols/oif/adapters/permit2AllowanceExtractor.ts
@@ -12,9 +12,7 @@ import type { Address } from "viem";
 import { getAddress } from "viem";
 
 import type { AllowanceCheck } from "../../../core/interfaces/approval.interface.js";
-
-/** Permit2 is deployed at the same address on every EVM chain. */
-const PERMIT2_ADDRESS = getAddress("0x000000000022D473030F116dDEE9F6B43aC78BA3");
+import { CANONICAL_PERMIT2_ADDRESS } from "../../../core/constants/permit2.js";
 
 const LOG_PREFIX = "[permit2AllowanceExtractor]";
 
@@ -51,7 +49,7 @@ export function extractPermit2Allowances(
         chainId,
         tokenAddress,
         owner,
-        spender: PERMIT2_ADDRESS,
+        spender: CANONICAL_PERMIT2_ADDRESS,
         required: required.toString(),
         preferInfinite: true,
     }));

--- a/packages/cross-chain/src/protocols/oif/provider.ts
+++ b/packages/cross-chain/src/protocols/oif/provider.ts
@@ -33,6 +33,8 @@ import {
     OpenedIntentParserConfig,
     OrderFailureReason,
     OrderStatus,
+    permit2SignatureValidator,
+    Permit2ValidationFailure,
     ProviderConfigFailure,
     ProviderExecuteFailure,
     ProviderExecuteNotImplemented,
@@ -52,6 +54,8 @@ import {
     OUTPUT_FILLED_EVENT_ABI,
     STANDARD_ORDER_OPEN_ABI,
 } from "./constants.js";
+
+const PERMIT2_LOG_PREFIX = "[OifProvider]";
 
 /**
  * OIF Provider implementation
@@ -147,15 +151,19 @@ export class OifProvider extends CrossChainProvider {
                 };
             });
 
-            // 3. Convert to SDK quotes, stashing originals in metadata
-            return providerQuotes.map((pq) => {
+            // 3. Convert to SDK quotes, stashing originals in metadata, dropping any that fail Permit2 validation
+            const sdkQuotes: Quote[] = [];
+            for (const pq of providerQuotes) {
                 const sdkQuote = adaptQuote(pq);
                 sdkQuote.metadata = {
                     ...sdkQuote.metadata,
                     _oifProviderQuote: pq,
                 };
-                return sdkQuote;
-            });
+                if (this.isQuoteSignaturePayloadSafe(sdkQuote, params)) {
+                    sdkQuotes.push(sdkQuote);
+                }
+            }
+            return sdkQuotes;
         } catch (error) {
             if (error instanceof HttpError) {
                 const errorData = error.data as { message?: string } | undefined;
@@ -480,5 +488,29 @@ export class OifProvider extends CrossChainProvider {
                 headers: this.headers,
             },
         };
+    }
+
+    /** True if every signature step in the quote is safe per Permit2 rules (V12 #6). */
+    private isQuoteSignaturePayloadSafe(quote: Quote, request: QuoteRequest): boolean {
+        for (const step of quote.order.steps) {
+            if (step.kind !== "signature") continue;
+            const expected = OIF_INPUT_SETTLER_ESCROW_BY_CHAIN[step.chainId];
+            try {
+                permit2SignatureValidator.validate(step, {
+                    providerId: this.providerId,
+                    request,
+                    expectedSpenders: expected ? [expected] : undefined,
+                });
+            } catch (err) {
+                if (err instanceof Permit2ValidationFailure) {
+                    console.warn(
+                        `${PERMIT2_LOG_PREFIX} Rejecting quote (${err.reason}): ${err.message}`,
+                    );
+                    return false;
+                }
+                throw err;
+            }
+        }
+        return true;
     }
 }

--- a/packages/cross-chain/src/protocols/relay/provider.ts
+++ b/packages/cross-chain/src/protocols/relay/provider.ts
@@ -16,6 +16,8 @@ import type { RelayConfigs } from "./types.js";
 import {
     CrossChainProvider,
     FetchHttpClient,
+    permit2SignatureValidator,
+    Permit2ValidationFailure,
     ProviderConfigFailure,
     ProviderGetQuoteFailure,
 } from "../../internal.js";
@@ -31,6 +33,8 @@ import {
 import { getRelayApiUrl, RELAY_TESTNET_TOKENS } from "./constants.js";
 import { RelayApiService } from "./services/index.js";
 import { RelayConfigSchema } from "./types.js";
+
+const PERMIT2_LOG_PREFIX = "[RelayProvider]";
 
 /**
  * A {@link CrossChainProvider} implementation for the Relay protocol.
@@ -186,7 +190,13 @@ export class RelayProvider extends CrossChainProvider {
     ): Promise<Quote> {
         const relayParams = adaptQuoteRequest(params, { submissionMode: mode });
         const response = await this.apiService.getQuote(relayParams);
-        return adaptQuote(params, response, this.providerId);
+        const quote = adaptQuote(params, response, this.providerId);
+        if (!this.isQuoteSignaturePayloadSafe(quote, params)) {
+            throw new ProviderGetQuoteFailure(
+                `Rejected Relay ${mode} quote: failed Permit2 validation`,
+            );
+        }
+        return quote;
     }
 
     /** Collect successful quotes. Re-throws the first error if all modes failed. */
@@ -207,5 +217,27 @@ export class RelayProvider extends CrossChainProvider {
             undefined,
             reason instanceof Error ? reason.stack : undefined,
         );
+    }
+
+    /** True if every signature step in the quote is safe per Permit2 rules (V12 #6). */
+    private isQuoteSignaturePayloadSafe(quote: Quote, request: QuoteRequest): boolean {
+        for (const step of quote.order.steps) {
+            if (step.kind !== "signature") continue;
+            try {
+                permit2SignatureValidator.validate(step, {
+                    providerId: this.providerId,
+                    request,
+                });
+            } catch (err) {
+                if (err instanceof Permit2ValidationFailure) {
+                    console.warn(
+                        `${PERMIT2_LOG_PREFIX} Rejecting quote (${err.reason}): ${err.message}`,
+                    );
+                    return false;
+                }
+                throw err;
+            }
+        }
+        return true;
     }
 }

--- a/packages/cross-chain/test/core/validators/permit2Validator.spec.ts
+++ b/packages/cross-chain/test/core/validators/permit2Validator.spec.ts
@@ -1,0 +1,243 @@
+import type { Address } from "viem";
+import { describe, expect, it } from "vitest";
+
+import type { SignatureStep } from "../../../src/core/schemas/order.js";
+import type { QuoteRequest } from "../../../src/core/schemas/quoteRequest.js";
+import { CANONICAL_PERMIT2_ADDRESS } from "../../../src/core/constants/permit2.js";
+import { Permit2ValidationFailure } from "../../../src/core/errors/Permit2ValidationFailure.exception.js";
+import {
+    Permit2SignatureValidator,
+    permit2SignatureValidator,
+} from "../../../src/core/validators/permit2Validator.js";
+
+const PROVIDER_ID = "test-provider";
+const USER = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" as Address;
+const TOKEN_USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const TOKEN_USDT = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+const SETTLER = "0x2778258002a69a0cB1DfD29b360a0bB1654C8652";
+const ATTACKER = "0x000000000000000000000000000000000000bEEF";
+
+function makeRequest(overrides?: Partial<QuoteRequest>): QuoteRequest {
+    return {
+        user: USER,
+        input: { chainId: 1, assetAddress: TOKEN_USDC, amount: "10000000" },
+        output: { chainId: 8453, assetAddress: TOKEN_USDC, recipient: USER },
+        ...overrides,
+    };
+}
+
+function makePermit2Step(overrides?: {
+    primaryType?: string;
+    verifyingContract?: string;
+    spender?: string;
+    permitted?: unknown;
+}): SignatureStep {
+    return {
+        kind: "signature",
+        chainId: 1,
+        signaturePayload: {
+            signatureType: "eip712",
+            primaryType: overrides?.primaryType ?? "PermitWitnessTransferFrom",
+            domain: {
+                name: "Permit2",
+                chainId: 1,
+                verifyingContract: overrides?.verifyingContract ?? CANONICAL_PERMIT2_ADDRESS,
+            },
+            types: {
+                PermitWitnessTransferFrom: [
+                    { name: "permitted", type: "TokenPermissions" },
+                    { name: "spender", type: "address" },
+                    { name: "nonce", type: "uint256" },
+                    { name: "deadline", type: "uint256" },
+                ],
+            },
+            message: {
+                permitted: overrides?.permitted ?? { token: TOKEN_USDC, amount: "10000000" },
+                spender: overrides?.spender ?? SETTLER,
+                nonce: "1",
+                deadline: "1779129331",
+            },
+        },
+    };
+}
+
+describe("Permit2SignatureValidator", () => {
+    describe("verifyingContract guard", () => {
+        it("rejects when primaryType is Permit2 but verifyingContract is not canonical", () => {
+            const step = makePermit2Step({ verifyingContract: ATTACKER });
+
+            expect(() =>
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                }),
+            ).toThrow(Permit2ValidationFailure);
+            try {
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                });
+            } catch (err) {
+                expect((err as Permit2ValidationFailure).reason).toBe("verifying-contract");
+            }
+        });
+
+        it("rejects when verifyingContract is canonical Permit2 but primaryType is unknown", () => {
+            const step = makePermit2Step({ primaryType: "ReceiveWithAuthorization" });
+
+            try {
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                });
+                expect.fail("expected throw");
+            } catch (err) {
+                expect(err).toBeInstanceOf(Permit2ValidationFailure);
+                expect((err as Permit2ValidationFailure).reason).toBe("non-permit2-canonical");
+            }
+        });
+
+        it("accepts an EIP-712 signature that is not Permit2 and not against the canonical address", () => {
+            const step = makePermit2Step({
+                primaryType: "ReceiveWithAuthorization",
+                verifyingContract: TOKEN_USDC,
+            });
+
+            expect(() =>
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                }),
+            ).not.toThrow();
+        });
+    });
+
+    describe("permitted guard", () => {
+        it("rejects when permitted contains a token different from the request input", () => {
+            const step = makePermit2Step({
+                permitted: { token: TOKEN_USDT, amount: "10000000" },
+            });
+
+            try {
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                });
+                expect.fail("expected throw");
+            } catch (err) {
+                expect((err as Permit2ValidationFailure).reason).toBe("permitted-token");
+            }
+        });
+
+        it("rejects when permitted total amount exceeds the request input amount", () => {
+            const step = makePermit2Step({
+                permitted: { token: TOKEN_USDC, amount: "99999999999" },
+            });
+
+            try {
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                });
+                expect.fail("expected throw");
+            } catch (err) {
+                expect((err as Permit2ValidationFailure).reason).toBe("permitted-amount");
+            }
+        });
+
+        it("accepts a batch permit summing matching tokens within the requested amount", () => {
+            const step = makePermit2Step({
+                primaryType: "PermitBatchWitnessTransferFrom",
+                permitted: [
+                    { token: TOKEN_USDC, amount: "6000000" },
+                    { token: TOKEN_USDC, amount: "4000000" },
+                ],
+            });
+
+            expect(() =>
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                }),
+            ).not.toThrow();
+        });
+
+        it("rejects a batch permit when one token does not match the request input", () => {
+            const step = makePermit2Step({
+                primaryType: "PermitBatchWitnessTransferFrom",
+                permitted: [
+                    { token: TOKEN_USDC, amount: "6000000" },
+                    { token: TOKEN_USDT, amount: "4000000" },
+                ],
+            });
+
+            try {
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                });
+                expect.fail("expected throw");
+            } catch (err) {
+                expect((err as Permit2ValidationFailure).reason).toBe("permitted-token");
+            }
+        });
+    });
+
+    describe("spender guard", () => {
+        it("rejects when spender is not in the expected list", () => {
+            const step = makePermit2Step({ spender: ATTACKER });
+
+            try {
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                    expectedSpenders: [SETTLER as Address],
+                });
+                expect.fail("expected throw");
+            } catch (err) {
+                expect((err as Permit2ValidationFailure).reason).toBe("spender");
+            }
+        });
+
+        it("accepts when spender matches one of the expected addresses (case-insensitive)", () => {
+            const step = makePermit2Step({ spender: SETTLER.toLowerCase() });
+
+            expect(() =>
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                    expectedSpenders: [SETTLER as Address],
+                }),
+            ).not.toThrow();
+        });
+
+        it("skips spender check when expectedSpenders is not provided", () => {
+            const step = makePermit2Step({ spender: ATTACKER });
+
+            expect(() =>
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                }),
+            ).not.toThrow();
+        });
+    });
+
+    describe("happy path", () => {
+        it("accepts a canonical single Permit2 transfer", () => {
+            const step = makePermit2Step();
+
+            expect(() =>
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                    expectedSpenders: [SETTLER as Address],
+                }),
+            ).not.toThrow();
+        });
+    });
+
+    it("exposes a singleton instance", () => {
+        expect(permit2SignatureValidator).toBeInstanceOf(Permit2SignatureValidator);
+    });
+});

--- a/packages/cross-chain/test/core/validators/permit2Validator.spec.ts
+++ b/packages/cross-chain/test/core/validators/permit2Validator.spec.ts
@@ -145,6 +145,46 @@ describe("Permit2SignatureValidator", () => {
             }
         });
 
+        it("rejects a Permit2 payload when request.input.amount is missing (exact-output flow)", () => {
+            const step = makePermit2Step({
+                permitted: { token: TOKEN_USDC, amount: "99999999999" },
+            });
+            const request = makeRequest({
+                input: { chainId: 1, assetAddress: TOKEN_USDC },
+                output: { chainId: 8453, assetAddress: TOKEN_USDC, amount: "5000000" },
+                swapType: "exact-output",
+            });
+
+            try {
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request,
+                });
+                expect.fail("expected throw");
+            } catch (err) {
+                expect((err as Permit2ValidationFailure).reason).toBe("requested-amount");
+            }
+        });
+
+        it("rejects a Permit2 payload when request.input.amount is zero", () => {
+            const step = makePermit2Step({
+                permitted: { token: TOKEN_USDC, amount: "99999999999" },
+            });
+            const request = makeRequest({
+                input: { chainId: 1, assetAddress: TOKEN_USDC, amount: "0" },
+            });
+
+            try {
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request,
+                });
+                expect.fail("expected throw");
+            } catch (err) {
+                expect((err as Permit2ValidationFailure).reason).toBe("requested-amount");
+            }
+        });
+
         it("accepts a batch permit summing matching tokens within the requested amount", () => {
             const step = makePermit2Step({
                 primaryType: "PermitBatchWitnessTransferFrom",

--- a/packages/cross-chain/test/core/validators/permit2Validator.spec.ts
+++ b/packages/cross-chain/test/core/validators/permit2Validator.spec.ts
@@ -162,6 +162,40 @@ describe("Permit2SignatureValidator", () => {
             ).not.toThrow();
         });
 
+        it("rejects when permitted is an empty array on a batch Permit2 type", () => {
+            const step = makePermit2Step({
+                primaryType: "PermitBatchWitnessTransferFrom",
+                permitted: [],
+            });
+
+            try {
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                });
+                expect.fail("expected throw");
+            } catch (err) {
+                expect((err as Permit2ValidationFailure).reason).toBe("permitted-empty");
+            }
+        });
+
+        it("rejects when permitted is malformed (string instead of array/object)", () => {
+            const step = makePermit2Step({
+                primaryType: "PermitBatchWitnessTransferFrom",
+                permitted: "not-an-array",
+            });
+
+            try {
+                permit2SignatureValidator.validate(step, {
+                    providerId: PROVIDER_ID,
+                    request: makeRequest(),
+                });
+                expect.fail("expected throw");
+            } catch (err) {
+                expect((err as Permit2ValidationFailure).reason).toBe("permitted-empty");
+            }
+        });
+
         it("rejects a batch permit when one token does not match the request input", () => {
             const step = makePermit2Step({
                 primaryType: "PermitBatchWitnessTransferFrom",

--- a/packages/cross-chain/test/protocols/bungee/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/provider.spec.ts
@@ -385,18 +385,21 @@ describe("BungeeProvider", () => {
     });
 
     describe("Permit2 validation (audit V12 #6)", () => {
-        function respondWithAutoRoute(autoRouteOverrides: Record<string, unknown>): void {
+        function respondWithAutoRoute(
+            autoRouteOverrides: Record<string, unknown>,
+            originChainOverride: number = ORIGIN_CHAIN_ID,
+        ): void {
             mockGet.mockResolvedValue({
                 status: 200,
                 data: makeBungeeQuoteResponse({
                     result: {
-                        originChainId: ORIGIN_CHAIN_ID,
+                        originChainId: originChainOverride,
                         destinationChainId: DESTINATION_CHAIN_ID,
                         userAddress: VALID_ADDRESS,
                         receiverAddress: VALID_ADDRESS,
                         input: {
                             token: {
-                                chainId: ORIGIN_CHAIN_ID,
+                                chainId: originChainOverride,
                                 address: VALID_ADDRESS,
                                 name: "USDC",
                                 symbol: "USDC",
@@ -430,7 +433,7 @@ describe("BungeeProvider", () => {
             expect(quotes).toEqual([]);
         });
 
-        it("rejects an autoRoute whose witness.basicReq.bungeeGateway does not match message.spender", async () => {
+        it("rejects an autoRoute whose message.spender does not match the canonical Bungee gateway for the chain", async () => {
             const base = makeAutoRoute().signTypedData!;
             respondWithAutoRoute({
                 signTypedData: {
@@ -440,6 +443,44 @@ describe("BungeeProvider", () => {
                         ...base.values,
                         spender: "0x000000000000000000000000000000000000bEEF",
                     },
+                },
+            });
+            const quotes = await provider.getQuotes(makeQuoteRequest());
+            expect(quotes).toEqual([]);
+        });
+
+        it("rejects a quote on a chain with no registered canonical Bungee gateway", async () => {
+            const unsupportedChain = 137; // Polygon — not in BUNGEE_GATEWAY_BY_CHAIN today
+            const base = makeAutoRoute().signTypedData!;
+            respondWithAutoRoute(
+                {
+                    signTypedData: {
+                        domain: { ...base.domain, chainId: unsupportedChain },
+                        types: base.types,
+                        values: base.values,
+                    },
+                },
+                unsupportedChain,
+            );
+            const quotes = await provider.getQuotes(
+                makeQuoteRequest({
+                    input: {
+                        chainId: unsupportedChain,
+                        assetAddress: VALID_ADDRESS,
+                        amount: INPUT_AMOUNT,
+                    },
+                }),
+            );
+            expect(quotes).toEqual([]);
+        });
+
+        it("rejects an autoRoute whose permitted entries are empty (Permit2 type with no token list)", async () => {
+            const base = makeAutoRoute().signTypedData!;
+            respondWithAutoRoute({
+                signTypedData: {
+                    domain: base.domain,
+                    types: base.types,
+                    values: { ...base.values, permitted: [] },
                 },
             });
             const quotes = await provider.getQuotes(makeQuoteRequest());

--- a/packages/cross-chain/test/protocols/bungee/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/provider.spec.ts
@@ -6,6 +6,7 @@ import type {
     BungeeAutoRoute,
     BungeeQuoteResponse,
 } from "../../../src/protocols/bungee/schemas.js";
+import { CANONICAL_PERMIT2_ADDRESS } from "../../../src/core/constants/permit2.js";
 import { HttpError } from "../../../src/core/errors/HttpError.exception.js";
 import { ProviderConfigFailure } from "../../../src/core/errors/ProviderConfigFailure.exception.js";
 import { ProviderExecuteFailure } from "../../../src/core/errors/ProviderExecuteFailure.exception.js";
@@ -16,6 +17,7 @@ import { BungeeProvider } from "../../../src/protocols/bungee/provider.js";
 // ── Constants ────────────────────────────────────────────
 
 const VALID_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+const BUNGEE_GATEWAY = "0xe772551f88e2c14aecc880df6b7cbd574561bf82";
 const ORIGIN_CHAIN_ID = 1;
 const DESTINATION_CHAIN_ID = 10;
 const INPUT_AMOUNT = "1000000";
@@ -63,9 +65,26 @@ function makeAutoRoute(overrides: Record<string, unknown> = {}): BungeeAutoRoute
         },
         requestType: "SINGLE_OUTPUT_REQUEST",
         signTypedData: {
-            domain: { name: "Permit2" },
-            types: {},
-            values: { witness: { field: "value" } },
+            domain: {
+                name: "Permit2",
+                chainId: ORIGIN_CHAIN_ID,
+                verifyingContract: CANONICAL_PERMIT2_ADDRESS,
+            },
+            types: {
+                PermitWitnessTransferFrom: [
+                    { name: "permitted", type: "TokenPermissions" },
+                    { name: "spender", type: "address" },
+                    { name: "nonce", type: "uint256" },
+                    { name: "deadline", type: "uint256" },
+                ],
+            },
+            values: {
+                permitted: { token: VALID_ADDRESS, amount: INPUT_AMOUNT },
+                spender: BUNGEE_GATEWAY,
+                nonce: "1",
+                deadline: "1779129331",
+                witness: { basicReq: { bungeeGateway: BUNGEE_GATEWAY } },
+            },
         },
         gasFee: {
             gasToken: {
@@ -365,6 +384,111 @@ describe("BungeeProvider", () => {
         });
     });
 
+    describe("Permit2 validation (audit V12 #6)", () => {
+        function respondWithAutoRoute(autoRouteOverrides: Record<string, unknown>): void {
+            mockGet.mockResolvedValue({
+                status: 200,
+                data: makeBungeeQuoteResponse({
+                    result: {
+                        originChainId: ORIGIN_CHAIN_ID,
+                        destinationChainId: DESTINATION_CHAIN_ID,
+                        userAddress: VALID_ADDRESS,
+                        receiverAddress: VALID_ADDRESS,
+                        input: {
+                            token: {
+                                chainId: ORIGIN_CHAIN_ID,
+                                address: VALID_ADDRESS,
+                                name: "USDC",
+                                symbol: "USDC",
+                                decimals: 6,
+                            },
+                            amount: INPUT_AMOUNT,
+                            priceInUsd: 1,
+                            valueInUsd: 1,
+                        },
+                        autoRoute: makeAutoRoute(autoRouteOverrides),
+                        manualRoutes: [],
+                    },
+                }),
+                headers: new Headers(),
+            });
+        }
+
+        it("rejects an autoRoute whose signTypedData.domain.verifyingContract is tampered", async () => {
+            respondWithAutoRoute({
+                signTypedData: {
+                    domain: {
+                        name: "Permit2",
+                        chainId: ORIGIN_CHAIN_ID,
+                        verifyingContract: "0x000000000000000000000000000000000000bEEF",
+                    },
+                    types: makeAutoRoute().signTypedData!.types,
+                    values: makeAutoRoute().signTypedData!.values,
+                },
+            });
+            const quotes = await provider.getQuotes(makeQuoteRequest());
+            expect(quotes).toEqual([]);
+        });
+
+        it("rejects an autoRoute whose witness.basicReq.bungeeGateway does not match message.spender", async () => {
+            const base = makeAutoRoute().signTypedData!;
+            respondWithAutoRoute({
+                signTypedData: {
+                    domain: base.domain,
+                    types: base.types,
+                    values: {
+                        ...base.values,
+                        spender: "0x000000000000000000000000000000000000bEEF",
+                    },
+                },
+            });
+            const quotes = await provider.getQuotes(makeQuoteRequest());
+            expect(quotes).toEqual([]);
+        });
+
+        it("rejects an autoRoute that smuggles a permitted token outside the requested input", async () => {
+            const base = makeAutoRoute().signTypedData!;
+            respondWithAutoRoute({
+                signTypedData: {
+                    domain: base.domain,
+                    types: base.types,
+                    values: {
+                        ...base.values,
+                        permitted: {
+                            token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                            amount: INPUT_AMOUNT,
+                        },
+                    },
+                },
+            });
+            const quotes = await provider.getQuotes(makeQuoteRequest());
+            expect(quotes).toEqual([]);
+        });
+
+        it("rejects an autoRoute whose permitted amount exceeds the requested input", async () => {
+            const base = makeAutoRoute().signTypedData!;
+            respondWithAutoRoute({
+                signTypedData: {
+                    domain: base.domain,
+                    types: base.types,
+                    values: {
+                        ...base.values,
+                        permitted: { token: VALID_ADDRESS, amount: "99999999999" },
+                    },
+                },
+            });
+            const quotes = await provider.getQuotes(makeQuoteRequest());
+            expect(quotes).toEqual([]);
+        });
+
+        it("accepts a canonical Bungee permit2 autoRoute", async () => {
+            respondWithAutoRoute({});
+            const quotes = await provider.getQuotes(makeQuoteRequest());
+            expect(quotes).toHaveLength(1);
+            expect(quotes[0]!.order.steps).toHaveLength(1);
+        });
+    });
+
     describe("submitOrder()", () => {
         it("extracts witness from bungeeAutoRoute metadata and submits order", async () => {
             const quoteResponse = makeBungeeQuoteResponse();
@@ -388,7 +512,7 @@ describe("BungeeProvider", () => {
             expect(mockPost).toHaveBeenCalledWith(
                 "/api/v1/bungee/submit",
                 expect.objectContaining({
-                    request: { field: "value" },
+                    request: { basicReq: { bungeeGateway: BUNGEE_GATEWAY } },
                     userSignature: "0xsignature",
                     requestType: "SINGLE_OUTPUT_REQUEST",
                     quoteId: "quote-123",
@@ -407,9 +531,29 @@ describe("BungeeProvider", () => {
                         amount: "1500000",
                     },
                     signTypedData: {
-                        domain: { name: "Permit2" },
-                        types: {},
-                        values: { witness: { betterField: "betterValue" } },
+                        domain: {
+                            name: "Permit2",
+                            chainId: ORIGIN_CHAIN_ID,
+                            verifyingContract: CANONICAL_PERMIT2_ADDRESS,
+                        },
+                        types: {
+                            PermitWitnessTransferFrom: [
+                                { name: "permitted", type: "TokenPermissions" },
+                                { name: "spender", type: "address" },
+                                { name: "nonce", type: "uint256" },
+                                { name: "deadline", type: "uint256" },
+                            ],
+                        },
+                        values: {
+                            permitted: { token: VALID_ADDRESS, amount: INPUT_AMOUNT },
+                            spender: BUNGEE_GATEWAY,
+                            nonce: "2",
+                            deadline: "1779129331",
+                            witness: {
+                                basicReq: { bungeeGateway: BUNGEE_GATEWAY },
+                                betterField: "betterValue",
+                            },
+                        },
                     },
                 }),
             ];
@@ -438,7 +582,10 @@ describe("BungeeProvider", () => {
             expect(mockPost).toHaveBeenCalledWith(
                 "/api/v1/bungee/submit",
                 expect.objectContaining({
-                    request: { betterField: "betterValue" },
+                    request: {
+                        basicReq: { bungeeGateway: BUNGEE_GATEWAY },
+                        betterField: "betterValue",
+                    },
                     quoteId: "route-better",
                 }),
             );

--- a/packages/cross-chain/test/protocols/bungee/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/provider.spec.ts
@@ -528,6 +528,21 @@ describe("BungeeProvider", () => {
             expect(quotes).toHaveLength(1);
             expect(quotes[0]!.order.steps).toHaveLength(1);
         });
+
+        it("rejects an autoRoute whose response originChainId differs from request.input.chainId, even if the response chain is supported", async () => {
+            const tamperedOriginChain = 10; // Optimism — supported by BUNGEE_GATEWAY_BY_CHAIN
+            respondWithAutoRoute({}, tamperedOriginChain);
+            const quotes = await provider.getQuotes(
+                makeQuoteRequest({
+                    input: {
+                        chainId: ORIGIN_CHAIN_ID,
+                        assetAddress: VALID_ADDRESS,
+                        amount: INPUT_AMOUNT,
+                    },
+                }),
+            );
+            expect(quotes).toEqual([]);
+        });
     });
 
     describe("submitOrder()", () => {

--- a/packages/cross-chain/test/protocols/relay/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/provider.spec.ts
@@ -4,6 +4,7 @@ import type { HttpClient } from "../../../src/core/interfaces/httpClient.interfa
 import type { Quote } from "../../../src/core/schemas/quote.js";
 import type { QuoteRequest } from "../../../src/core/schemas/quoteRequest.js";
 import type { RelayQuoteResponse } from "../../../src/protocols/relay/schemas.js";
+import { CANONICAL_PERMIT2_ADDRESS } from "../../../src/core/constants/permit2.js";
 import { HttpError } from "../../../src/core/errors/HttpError.exception.js";
 import { ProviderExecuteFailure } from "../../../src/core/errors/ProviderExecuteFailure.exception.js";
 import { ProviderGetQuoteFailure } from "../../../src/core/errors/ProviderGetQuoteFailure.exception.js";
@@ -129,6 +130,49 @@ function makeRelayQuoteResponse(overrides?: Partial<RelayQuoteResponse>): RelayQ
 
 function makeHttpError(data: unknown, status: number, message: string): HttpError {
     return new HttpError(message, "https://test/url", status, data);
+}
+
+function makeSignatureStepResponse(args: {
+    primaryType: string;
+    verifyingContract: string;
+    permitted?: Array<{ token: string; amount: string }>;
+}): Record<string, unknown> {
+    const message: Record<string, unknown> = {
+        spender: VALID_ADDRESS,
+        nonce: "1",
+        deadline: "1779129331",
+    };
+    if (args.permitted) message["permitted"] = args.permitted;
+    return {
+        id: "authorize",
+        action: "Sign permit",
+        description: STEP_DESCRIPTION,
+        kind: "signature",
+        requestId: REQUEST_ID,
+        items: [
+            {
+                status: "incomplete",
+                data: {
+                    sign: {
+                        signatureKind: "eip712",
+                        primaryType: args.primaryType,
+                        domain: {
+                            name: "Permit2",
+                            chainId: ORIGIN_CHAIN_ID,
+                            verifyingContract: args.verifyingContract,
+                        },
+                        types: { [args.primaryType]: [{ name: "spender", type: "address" }] },
+                        value: message,
+                    },
+                    post: {
+                        endpoint: "/execute/permits",
+                        method: "POST",
+                        body: { kind: "permit", requestId: REQUEST_ID },
+                    },
+                },
+            },
+        ],
+    };
 }
 
 // ── Tests ────────────────────────────────────────────────
@@ -268,6 +312,81 @@ describe("RelayProvider", () => {
             const quotes = await singleModeProvider.getQuotes(makeQuoteRequest());
             expect(quotes).toHaveLength(1);
             expect(mockPost).toHaveBeenCalledTimes(1);
+        });
+
+        it("returns a quote when the response signature step is a canonical Permit2 payload", async () => {
+            mockPost.mockResolvedValue({
+                status: 200,
+                data: makeRelayQuoteResponse({
+                    steps: [
+                        makeSignatureStepResponse({
+                            primaryType: "PermitBatchWitnessTransferFrom",
+                            verifyingContract: CANONICAL_PERMIT2_ADDRESS,
+                            permitted: [{ token: VALID_ADDRESS, amount: INPUT_AMOUNT }],
+                        }),
+                    ],
+                }),
+                headers: new Headers(),
+            });
+            const quotes = await provider.getQuotes(makeQuoteRequest());
+            expect(quotes).toHaveLength(1);
+            expect(quotes[0]!.order.steps[0]!.kind).toBe("signature");
+        });
+
+        it("rejects a Permit2 signature step whose verifyingContract is tampered", async () => {
+            mockPost.mockResolvedValue({
+                status: 200,
+                data: makeRelayQuoteResponse({
+                    steps: [
+                        makeSignatureStepResponse({
+                            primaryType: "PermitBatchWitnessTransferFrom",
+                            verifyingContract: "0x000000000000000000000000000000000000bEEF",
+                            permitted: [{ token: VALID_ADDRESS, amount: INPUT_AMOUNT }],
+                        }),
+                    ],
+                }),
+                headers: new Headers(),
+            });
+            await expect(provider.getQuotes(makeQuoteRequest())).rejects.toThrow(
+                ProviderGetQuoteFailure,
+            );
+        });
+
+        it("rejects an EIP-712 step that targets the canonical Permit2 with a non-Permit2 primaryType", async () => {
+            mockPost.mockResolvedValue({
+                status: 200,
+                data: makeRelayQuoteResponse({
+                    steps: [
+                        makeSignatureStepResponse({
+                            primaryType: "ReceiveWithAuthorization",
+                            verifyingContract: CANONICAL_PERMIT2_ADDRESS,
+                            permitted: [{ token: VALID_ADDRESS, amount: INPUT_AMOUNT }],
+                        }),
+                    ],
+                }),
+                headers: new Headers(),
+            });
+            await expect(provider.getQuotes(makeQuoteRequest())).rejects.toThrow(
+                ProviderGetQuoteFailure,
+            );
+        });
+
+        it("accepts an EIP-3009 ReceiveWithAuthorization signed against the token contract", async () => {
+            mockPost.mockResolvedValue({
+                status: 200,
+                data: makeRelayQuoteResponse({
+                    steps: [
+                        makeSignatureStepResponse({
+                            primaryType: "ReceiveWithAuthorization",
+                            verifyingContract: VALID_ADDRESS,
+                            permitted: undefined,
+                        }),
+                    ],
+                }),
+                headers: new Headers(),
+            });
+            const quotes = await provider.getQuotes(makeQuoteRequest());
+            expect(quotes).toHaveLength(1);
         });
 
         it("returns successful quotes when one mode fails", async () => {

--- a/packages/cross-chain/test/providers/OifProvider.spec.ts
+++ b/packages/cross-chain/test/providers/OifProvider.spec.ts
@@ -1,4 +1,8 @@
-import { PostOrderResponse, PostOrderResponseStatus } from "@openintentsframework/oif-specs";
+import {
+    GetQuoteResponse,
+    PostOrderResponse,
+    PostOrderResponseStatus,
+} from "@openintentsframework/oif-specs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { QuoteRequest } from "../../src/core/schemas/quoteRequest.js";
@@ -173,6 +177,63 @@ describe("OifProvider", () => {
             await expect(provider.getQuotes(mockQuoteRequest)).rejects.toThrow(
                 ProviderGetQuoteFailure,
             );
+        });
+
+        describe("Permit2 validation (audit V12 #6)", () => {
+            function withMutatedEscrow(
+                mutate: (payload: Record<string, unknown>) => void,
+            ): GetQuoteResponse {
+                const response = getMockedOifQuoteResponse();
+                const payload = response.quotes[0]!.order.payload as Record<string, unknown>;
+                mutate(payload);
+                return response;
+            }
+
+            it("rejects an escrow quote whose verifyingContract is tampered", async () => {
+                vi.mocked(httpRequest).mockResolvedValue({
+                    status: 200,
+                    data: withMutatedEscrow((p) => {
+                        (p.domain as Record<string, unknown>).verifyingContract =
+                            "0x000000000000000000000000000000000000bEEF";
+                    }),
+                    headers: new Headers(),
+                });
+                const quotes = await provider.getQuotes(mockQuoteRequest);
+                expect(quotes).toEqual([]);
+            });
+
+            it("rejects an escrow quote that smuggles a token outside the requested input", async () => {
+                vi.mocked(httpRequest).mockResolvedValue({
+                    status: 200,
+                    data: getMockedOifQuoteResponse({
+                        token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    }),
+                    headers: new Headers(),
+                });
+                const quotes = await provider.getQuotes(mockQuoteRequest);
+                expect(quotes).toEqual([]);
+            });
+
+            it("rejects an escrow quote whose permitted amount exceeds the requested input", async () => {
+                vi.mocked(httpRequest).mockResolvedValue({
+                    status: 200,
+                    data: getMockedOifQuoteResponse({ amount: "99999999999999999999" }),
+                    headers: new Headers(),
+                });
+                const quotes = await provider.getQuotes(mockQuoteRequest);
+                expect(quotes).toEqual([]);
+            });
+
+            it("accepts a canonical OIF escrow Permit2 quote", async () => {
+                vi.mocked(httpRequest).mockResolvedValue({
+                    status: 200,
+                    data: getMockedOifQuoteResponse(),
+                    headers: new Headers(),
+                });
+                const quotes = await provider.getQuotes(mockQuoteRequest);
+                expect(quotes).toHaveLength(1);
+                expect(quotes[0]!.order.steps[0]!.kind).toBe("signature");
+            });
         });
     });
 


### PR DESCRIPTION
## Why

Audit V12 finding #6 (Critical). The SDK signed the `verifyingContract`, `spender` and `permitted` fields exactly as the solver returned them. A hostile solver can swap `message.spender` for an attacker address, and the user's signature drains any allowance previously granted to the canonical Permit2 contract.

## What

A single `Permit2SignatureValidator` runs after every provider builds its `SignatureStep`. Quotes that fail validation are dropped from the provider's result (and surfaced in `aggregator.getQuotes().errors[]` when nothing else passes), so a tampered Permit2 message never reaches the user's wallet.

## Class diagram

```mermaid
classDiagram
    class Permit2SignatureValidator {
        +validate(step, context) void
    }
    class Permit2ValidationContext {
        providerId: string
        request: QuoteRequest
        expectedSpenders?: Address[]
    }
    class Permit2ValidationFailure {
        reason: verifying-contract | non-permit2-canonical | permitted-token | permitted-amount | spender
        providerId: string
    }

    class OifProvider
    class BungeeProvider
    class RelayProvider

    OifProvider --> Permit2SignatureValidator : validates SignatureStep
    BungeeProvider --> Permit2SignatureValidator : validates SignatureStep
    RelayProvider --> Permit2SignatureValidator : validates SignatureStep

    Permit2SignatureValidator --> Permit2ValidationContext : reads
    Permit2SignatureValidator ..> Permit2ValidationFailure : throws
```

## Validator rules

| Check | Rule |
|---|---|
| `domain.verifyingContract` | Must equal canonical Permit2 when `primaryType` is a Permit2 type |
| `primaryType` (anti-confusion) | Reject if `verifyingContract` is canonical Permit2 but `primaryType` is not Permit2 |
| `permitted[].token` | Must equal `request.input.assetAddress` (case-insensitive) |
| `permitted[].amount` (sum) | Must be ≤ `request.input.amount` |
| `message.spender` | Must be in `expectedSpenders` when the provider supplies a list |

## Per-provider integration

| Provider | `expectedSpenders` source | Note |
|---|---|---|
| OIF | `OIF_INPUT_SETTLER_ESCROW_BY_CHAIN[chainId]` | settlers already shipped as SDK constants |
| Bungee | `witness.basicReq.bungeeGateway` | auto-consistency check with the signed witness |
| Relay | undefined | no canonical registry; the `verifyingContract` + `permitted` rules already constrain the attack |
| Across | n/a | does not use Permit2 |
| LI.FI Intents | n/a | does not use Permit2 |

## Tests

- 12 unit tests on `Permit2SignatureValidator`
- 5 `BungeeProvider` tests covering tampered `verifyingContract`, tampered `spender` vs. witness, smuggled `permitted` token, permitted-amount overflow, and the canonical happy path
- 4 `RelayProvider` tests (Permit2 happy / tampered `verifyingContract` / non-Permit2 type against canonical Permit2 / EIP-3009 against token contract still accepted)
- 4 `OifProvider` tests for the same audit attack vectors
- Full `@wonderland/interop-cross-chain` suite: **1067 pass / 0 fail / 14 skipped**, `check-types` clean, `lint` reports no new errors

## Files

**New**
- `packages/cross-chain/src/core/constants/permit2.ts`
- `packages/cross-chain/src/core/errors/Permit2ValidationFailure.exception.ts`
- `packages/cross-chain/src/core/validators/permit2Validator.ts`
- `packages/cross-chain/test/core/validators/permit2Validator.spec.ts`

**Edited**
- `packages/cross-chain/src/core/{constants,errors,validators}/index.ts` (re-exports)
- `packages/cross-chain/src/protocols/oif/adapters/permit2AllowanceExtractor.ts` (use the shared canonical constant)
- `packages/cross-chain/src/protocols/oif/provider.ts`
- `packages/cross-chain/src/protocols/bungee/provider.ts`
- `packages/cross-chain/src/protocols/relay/provider.ts`
- `packages/cross-chain/test/providers/OifProvider.spec.ts`
- `packages/cross-chain/test/protocols/bungee/provider.spec.ts`
- `packages/cross-chain/test/protocols/relay/provider.spec.ts`

## Test plan

- [ ] `pnpm --filter @wonderland/interop-cross-chain test`
- [ ] `pnpm --filter @wonderland/interop-cross-chain check-types`
- [ ] `pnpm --filter @wonderland/interop-cross-chain lint`
- [ ] Read `Permit2SignatureValidator` and confirm the five rules match the audit acceptance criteria