### PR TITLE
feat(cross-chain): add eip-712 envelope validation core utilities (EFI-949)

### DIFF
--- a/.changeset/eip712-envelope-validation.md
+++ b/.changeset/eip712-envelope-validation.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Add reusable EIP-712 envelope validation utilities under `src/core`: `validatePrimaryType` and `validateEnvelopeDomain` for envelope-level checks, `validatePermit2Message` for Permit2 single and batch payloads, and `validateEip3009Message` for transfer/receive-with-authorization payloads. Mismatches throw a typed `Eip712EnvelopeMismatch`. EIP-3009 `message.value` is decoded strictly (only `bigint`, numeric strings, and safe-integer numbers).
+
+These utilities are not wired into any protocol yet — Bungee, Relay, and OIF integration will follow in separate changes.

--- a/packages/cross-chain/src/core/constants/eip712.ts
+++ b/packages/cross-chain/src/core/constants/eip712.ts
@@ -1,0 +1,35 @@
+import type { Address } from "viem";
+import { getAddress } from "viem";
+
+/** Permit2 (Uniswap) — same CREATE2-deployed address on every EVM chain. */
+export const PERMIT2_ADDRESS: Address = getAddress("0x000000000022D473030F116dDEE9F6B43aC78BA3");
+
+/** Relay Depository — used with `primaryType: "CallRequest"`. */
+export const RELAY_DEPOSITORY_ADDRESS: Address = getAddress(
+    "0x4cD00E387622C35bDDB9b4c962C136462338BC31",
+);
+
+export const PERMIT2_SINGLE_PRIMARY_TYPES: ReadonlySet<string> = new Set([
+    "PermitTransferFrom",
+    "PermitWitnessTransferFrom",
+]);
+
+export const PERMIT2_BATCH_PRIMARY_TYPES: ReadonlySet<string> = new Set([
+    "PermitBatchTransferFrom",
+    "PermitBatchWitnessTransferFrom",
+]);
+
+export const PERMIT2_PRIMARY_TYPES: ReadonlySet<string> = new Set([
+    "Permit",
+    "PermitBatch",
+    ...PERMIT2_SINGLE_PRIMARY_TYPES,
+    ...PERMIT2_BATCH_PRIMARY_TYPES,
+]);
+
+export const EIP3009_PRIMARY_TYPES: ReadonlySet<string> = new Set([
+    "TransferWithAuthorization",
+    "ReceiveWithAuthorization",
+]);
+
+/** Wall-clock tolerance for `deadline` / `validBefore` checks. */
+export const DEFAULT_DEADLINE_SKEW_SECONDS = 60;

--- a/packages/cross-chain/src/core/constants/index.ts
+++ b/packages/cross-chain/src/core/constants/index.ts
@@ -1,1 +1,2 @@
 export * from "./tokens.js";
+export * from "./eip712.js";

--- a/packages/cross-chain/src/core/errors/Eip712EnvelopeMismatch.exception.ts
+++ b/packages/cross-chain/src/core/errors/Eip712EnvelopeMismatch.exception.ts
@@ -1,0 +1,49 @@
+import { ProviderGetQuoteFailure } from "./ProviderGetQuoteFailure.exception.js";
+
+export type Eip712MismatchField =
+    | "chainId"
+    | "verifyingContract"
+    | "primaryType"
+    | "domainVersion"
+    | "token"
+    | "amount"
+    | "deadline"
+    | "user"
+    | "to"
+    | "recipient"
+    | "structure";
+
+interface Eip712EnvelopeMismatchArgs {
+    field: Eip712MismatchField;
+    provider: string;
+    primaryType?: string;
+    expected?: string | number;
+    received?: string | number;
+    cause?: string;
+}
+
+export class Eip712EnvelopeMismatch extends ProviderGetQuoteFailure {
+    public readonly field: Eip712MismatchField;
+    public readonly provider: string;
+    public readonly primaryType?: string;
+    public readonly expected?: string | number;
+    public readonly received?: string | number;
+
+    constructor(args: Eip712EnvelopeMismatchArgs) {
+        super(buildMessage(args), args.cause);
+        this.field = args.field;
+        this.provider = args.provider;
+        this.primaryType = args.primaryType;
+        this.expected = args.expected;
+        this.received = args.received;
+    }
+}
+
+function buildMessage(args: Eip712EnvelopeMismatchArgs): string {
+    const parts = [`EIP-712 envelope mismatch from "${args.provider}" on field "${args.field}"`];
+    if (args.primaryType !== undefined) parts.push(`primaryType=${args.primaryType}`);
+    if (args.expected !== undefined) parts.push(`expected=${args.expected}`);
+    if (args.received !== undefined) parts.push(`received=${args.received}`);
+    if (args.cause !== undefined) parts.push(args.cause);
+    return parts.join("; ");
+}

--- a/packages/cross-chain/src/core/errors/index.ts
+++ b/packages/cross-chain/src/core/errors/index.ts
@@ -24,3 +24,4 @@ export * from "./UnsupportedAsset.exception.js";
 export * from "./HttpError.exception.js";
 export * from "./HttpTimeout.exception.js";
 export * from "./HttpNetworkError.exception.js";
+export * from "./Eip712EnvelopeMismatch.exception.js";

--- a/packages/cross-chain/src/core/types/eip712.ts
+++ b/packages/cross-chain/src/core/types/eip712.ts
@@ -1,0 +1,34 @@
+import type { Address } from "viem";
+
+export interface Eip712Envelope {
+    domain: Record<string, unknown>;
+    primaryType: string;
+    types: Record<string, Array<{ name: string; type: string }>>;
+    message: Record<string, unknown>;
+}
+
+export interface ExpectedEnvelope {
+    chainId: number;
+    verifyingContracts: ReadonlyArray<Address>;
+    primaryTypes: ReadonlySet<string>;
+    provider: string;
+}
+
+export interface ExpectedPermit2Message {
+    provider: string;
+    inputToken?: Address;
+    maxAmount?: bigint;
+    skewSeconds?: number;
+}
+
+export interface ExpectedEip3009Message {
+    provider: string;
+    user: Address;
+    maxValue?: bigint;
+    skewSeconds?: number;
+}
+
+export interface PermittedEntry {
+    token: Address;
+    amount: bigint;
+}

--- a/packages/cross-chain/src/core/types/index.ts
+++ b/packages/cross-chain/src/core/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./orderTracking.js";
 export * from "./assetDiscovery.js";
 export * from "./orderExplorers.js";
+export * from "./eip712.js";

--- a/packages/cross-chain/src/core/utils/index.ts
+++ b/packages/cross-chain/src/core/utils/index.ts
@@ -10,3 +10,4 @@ export * from "./typedEventEmitter.js";
 export * from "./interopAccountId.js";
 export * from "./stepHelpers.js";
 export * from "./httpClient.js";
+export * from "./permit2.js";

--- a/packages/cross-chain/src/core/utils/permit2.ts
+++ b/packages/cross-chain/src/core/utils/permit2.ts
@@ -1,0 +1,125 @@
+import { getAddress } from "viem";
+
+import type { Eip712Envelope, PermittedEntry } from "../types/eip712.js";
+import {
+    DEFAULT_DEADLINE_SKEW_SECONDS,
+    PERMIT2_BATCH_PRIMARY_TYPES,
+    PERMIT2_SINGLE_PRIMARY_TYPES,
+} from "../constants/eip712.js";
+import { Eip712EnvelopeMismatch } from "../errors/Eip712EnvelopeMismatch.exception.js";
+
+interface RawTokenPermission {
+    token?: unknown;
+    amount?: unknown;
+}
+
+/** Normalize Permit2's `permitted` field (single or batch) into a typed array. */
+export function readPermittedEntries(envelope: Eip712Envelope): PermittedEntry[] {
+    const raw = envelope.message.permitted;
+    if (PERMIT2_SINGLE_PRIMARY_TYPES.has(envelope.primaryType)) {
+        if (raw === undefined || raw === null) return [];
+        if (typeof raw !== "object" || Array.isArray(raw)) {
+            throw new Eip712EnvelopeMismatch({
+                field: "structure",
+                provider: "permit2",
+                primaryType: envelope.primaryType,
+                cause: "permitted must be an object",
+            });
+        }
+        return [toPermittedEntry(raw as RawTokenPermission)];
+    }
+    if (PERMIT2_BATCH_PRIMARY_TYPES.has(envelope.primaryType)) {
+        if (raw === undefined || raw === null) return [];
+        if (!Array.isArray(raw)) {
+            throw new Eip712EnvelopeMismatch({
+                field: "structure",
+                provider: "permit2",
+                primaryType: envelope.primaryType,
+                cause: "permitted must be an array",
+            });
+        }
+        return (raw as RawTokenPermission[]).map(toPermittedEntry);
+    }
+    return [];
+}
+
+/** Reject `deadline` values that are missing, malformed, or already expired (with skew tolerance). */
+export function assertDeadlineFresh(args: {
+    deadline: unknown;
+    provider: string;
+    primaryType: string;
+    skewSeconds?: number;
+}): void {
+    const parsed = parseUnixSeconds(args.deadline);
+    if (parsed === undefined) {
+        throw new Eip712EnvelopeMismatch({
+            field: "deadline",
+            provider: args.provider,
+            primaryType: args.primaryType,
+            received: String(args.deadline),
+        });
+    }
+
+    const skew = args.skewSeconds ?? DEFAULT_DEADLINE_SKEW_SECONDS;
+    const now = Math.floor(Date.now() / 1000);
+    if (parsed < now - skew) {
+        throw new Eip712EnvelopeMismatch({
+            field: "deadline",
+            provider: args.provider,
+            primaryType: args.primaryType,
+            expected: `>=${now - skew}`,
+            received: parsed,
+        });
+    }
+}
+
+function toPermittedEntry(raw: RawTokenPermission): PermittedEntry {
+    if (typeof raw.token !== "string") {
+        throw new Eip712EnvelopeMismatch({
+            field: "token",
+            provider: "permit2",
+            received: String(raw.token),
+        });
+    }
+    let token: PermittedEntry["token"];
+    try {
+        token = getAddress(raw.token);
+    } catch {
+        throw new Eip712EnvelopeMismatch({
+            field: "token",
+            provider: "permit2",
+            received: raw.token,
+        });
+    }
+    let amount: bigint;
+    try {
+        amount = BigInt(String(raw.amount ?? "0"));
+    } catch {
+        throw new Eip712EnvelopeMismatch({
+            field: "amount",
+            provider: "permit2",
+            received: String(raw.amount),
+        });
+    }
+    return { token, amount };
+}
+
+function parseUnixSeconds(value: unknown): number | undefined {
+    if (
+        typeof value === "number" &&
+        Number.isFinite(value) &&
+        Number.isInteger(value) &&
+        value > 0
+    ) {
+        return value;
+    }
+    if (typeof value === "bigint" && value > 0n) {
+        if (value > BigInt(Number.MAX_SAFE_INTEGER)) return undefined;
+        return Number(value);
+    }
+    if (typeof value === "string" && value.length > 0) {
+        const parsed = Number(value);
+        if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0) return parsed;
+    }
+    return undefined;
+}

--- a/packages/cross-chain/src/core/validators/eip3009MessageValidator.ts
+++ b/packages/cross-chain/src/core/validators/eip3009MessageValidator.ts
@@ -1,0 +1,128 @@
+import { getAddress, isAddressEqual } from "viem";
+
+import type { Eip712Envelope, ExpectedEip3009Message } from "../types/eip712.js";
+import { DEFAULT_DEADLINE_SKEW_SECONDS } from "../constants/eip712.js";
+import { Eip712EnvelopeMismatch } from "../errors/Eip712EnvelopeMismatch.exception.js";
+
+/** Validate the EIP-3009 message fields (`from`, `value`, `validBefore`) against the user intent. */
+export function validateEip3009Message(
+    envelope: Eip712Envelope,
+    expected: ExpectedEip3009Message,
+): void {
+    assertFromMatchesUser(envelope, expected);
+    assertValueWithinLimit(envelope, expected);
+    assertValidBeforeFresh(envelope, expected);
+}
+
+function assertFromMatchesUser(envelope: Eip712Envelope, expected: ExpectedEip3009Message): void {
+    const rawFrom = envelope.message.from;
+    if (typeof rawFrom !== "string") {
+        throw new Eip712EnvelopeMismatch({
+            field: "user",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            received: String(rawFrom),
+        });
+    }
+    let normalizedFrom: ReturnType<typeof getAddress>;
+    try {
+        normalizedFrom = getAddress(rawFrom);
+    } catch {
+        throw new Eip712EnvelopeMismatch({
+            field: "user",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            expected: expected.user,
+            received: rawFrom,
+        });
+    }
+    if (!isAddressEqual(normalizedFrom, expected.user)) {
+        throw new Eip712EnvelopeMismatch({
+            field: "user",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            expected: expected.user,
+            received: rawFrom,
+        });
+    }
+}
+
+function assertValueWithinLimit(envelope: Eip712Envelope, expected: ExpectedEip3009Message): void {
+    if (expected.maxValue === undefined) return;
+    const value = parseBigint(envelope.message.value);
+    if (value === undefined) {
+        throw new Eip712EnvelopeMismatch({
+            field: "amount",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            received: String(envelope.message.value),
+        });
+    }
+    if (value > expected.maxValue) {
+        throw new Eip712EnvelopeMismatch({
+            field: "amount",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            expected: expected.maxValue.toString(),
+            received: value.toString(),
+        });
+    }
+}
+
+function assertValidBeforeFresh(envelope: Eip712Envelope, expected: ExpectedEip3009Message): void {
+    const validBefore = parseUnixSeconds(envelope.message.validBefore);
+    if (validBefore === undefined) {
+        throw new Eip712EnvelopeMismatch({
+            field: "deadline",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            received: String(envelope.message.validBefore),
+        });
+    }
+    const skew = expected.skewSeconds ?? DEFAULT_DEADLINE_SKEW_SECONDS;
+    const now = Math.floor(Date.now() / 1000);
+    if (validBefore < now - skew) {
+        throw new Eip712EnvelopeMismatch({
+            field: "deadline",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            expected: `>=${now - skew}`,
+            received: validBefore,
+        });
+    }
+}
+
+function parseBigint(value: unknown): bigint | undefined {
+    if (typeof value === "bigint") return value;
+    if (typeof value === "number") {
+        return Number.isSafeInteger(value) ? BigInt(value) : undefined;
+    }
+    if (typeof value === "string" && value.length > 0) {
+        try {
+            return BigInt(value);
+        } catch {
+            return undefined;
+        }
+    }
+    return undefined;
+}
+
+function parseUnixSeconds(value: unknown): number | undefined {
+    if (
+        typeof value === "number" &&
+        Number.isFinite(value) &&
+        Number.isInteger(value) &&
+        value > 0
+    ) {
+        return value;
+    }
+    if (typeof value === "bigint" && value > 0n) {
+        if (value > BigInt(Number.MAX_SAFE_INTEGER)) return undefined;
+        return Number(value);
+    }
+    if (typeof value === "string" && value.length > 0) {
+        const parsed = Number(value);
+        if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0) return parsed;
+    }
+    return undefined;
+}

--- a/packages/cross-chain/src/core/validators/eip712EnvelopeValidator.ts
+++ b/packages/cross-chain/src/core/validators/eip712EnvelopeValidator.ts
@@ -1,0 +1,118 @@
+import { getAddress, isAddressEqual } from "viem";
+
+import type { Eip712Envelope, ExpectedEnvelope } from "../types/eip712.js";
+import { PERMIT2_PRIMARY_TYPES } from "../constants/eip712.js";
+import { Eip712EnvelopeMismatch } from "../errors/Eip712EnvelopeMismatch.exception.js";
+
+/** Reject envelopes whose `primaryType` is not in the allow-list. */
+export function validatePrimaryType(
+    envelope: Eip712Envelope,
+    allowed: ReadonlySet<string>,
+    provider: string,
+): void {
+    if (!allowed.has(envelope.primaryType)) {
+        throw new Eip712EnvelopeMismatch({
+            field: "primaryType",
+            provider,
+            primaryType: envelope.primaryType,
+            expected: [...allowed].join("|"),
+            received: envelope.primaryType,
+        });
+    }
+}
+
+/** Validate `domain.chainId`, `domain.verifyingContract`, and disallow `domain.version` for Permit2. */
+export function validateEnvelopeDomain(envelope: Eip712Envelope, expected: ExpectedEnvelope): void {
+    if (expected.verifyingContracts.length === 0) {
+        throw new Eip712EnvelopeMismatch({
+            field: "structure",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            cause: "verifyingContracts allow-list is empty",
+        });
+    }
+
+    const chainId = coerceChainId(envelope.domain.chainId);
+    if (chainId === undefined) {
+        throw new Eip712EnvelopeMismatch({
+            field: "chainId",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            expected: expected.chainId,
+            received: String(envelope.domain.chainId),
+        });
+    }
+    if (chainId !== expected.chainId) {
+        throw new Eip712EnvelopeMismatch({
+            field: "chainId",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            expected: expected.chainId,
+            received: chainId,
+        });
+    }
+
+    const rawVerifying = envelope.domain.verifyingContract;
+    if (typeof rawVerifying !== "string") {
+        throw new Eip712EnvelopeMismatch({
+            field: "verifyingContract",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            expected: expected.verifyingContracts.join("|"),
+            received: String(rawVerifying),
+        });
+    }
+
+    let normalized: ReturnType<typeof getAddress>;
+    try {
+        normalized = getAddress(rawVerifying);
+    } catch {
+        throw new Eip712EnvelopeMismatch({
+            field: "verifyingContract",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            expected: expected.verifyingContracts.join("|"),
+            received: rawVerifying,
+        });
+    }
+
+    const matches = expected.verifyingContracts.some((candidate) =>
+        isAddressEqual(normalized, candidate),
+    );
+    if (!matches) {
+        throw new Eip712EnvelopeMismatch({
+            field: "verifyingContract",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            expected: expected.verifyingContracts.join("|"),
+            received: normalized,
+        });
+    }
+
+    // Permit2 EIP712Domain intentionally omits `version`. A populated value would change
+    // the domain separator and is a tampering signal.
+    if (PERMIT2_PRIMARY_TYPES.has(envelope.primaryType) && envelope.domain.version !== undefined) {
+        throw new Eip712EnvelopeMismatch({
+            field: "domainVersion",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            expected: "absent",
+            received: String(envelope.domain.version),
+        });
+    }
+}
+
+function coerceChainId(value: unknown): number | undefined {
+    if (typeof value === "number" && Number.isFinite(value) && Number.isInteger(value)) {
+        return value;
+    }
+    if (typeof value === "bigint") {
+        if (value > BigInt(Number.MAX_SAFE_INTEGER)) return undefined;
+        return Number(value);
+    }
+    if (typeof value === "string" && value.length > 0) {
+        const parsed = value.startsWith("0x") ? Number.parseInt(value, 16) : Number(value);
+        if (Number.isFinite(parsed) && Number.isInteger(parsed)) return parsed;
+    }
+    return undefined;
+}

--- a/packages/cross-chain/src/core/validators/index.ts
+++ b/packages/cross-chain/src/core/validators/index.ts
@@ -1,2 +1,5 @@
 export * from "./settlerIntentValidator.js";
 export * from "./buildQuoteValidator.js";
+export * from "./eip712EnvelopeValidator.js";
+export * from "./permit2MessageValidator.js";
+export * from "./eip3009MessageValidator.js";

--- a/packages/cross-chain/src/core/validators/permit2MessageValidator.ts
+++ b/packages/cross-chain/src/core/validators/permit2MessageValidator.ts
@@ -1,0 +1,55 @@
+import { isAddressEqual } from "viem";
+
+import type { Eip712Envelope, ExpectedPermit2Message } from "../types/eip712.js";
+import { Eip712EnvelopeMismatch } from "../errors/Eip712EnvelopeMismatch.exception.js";
+import { assertDeadlineFresh, readPermittedEntries } from "../utils/permit2.js";
+
+/** Validate `permitted[]`, `deadline`, and (optionally) token/amount against user intent. */
+export function validatePermit2Message(
+    envelope: Eip712Envelope,
+    expected: ExpectedPermit2Message,
+): void {
+    const entries = readPermittedEntries(envelope);
+    if (entries.length === 0) {
+        throw new Eip712EnvelopeMismatch({
+            field: "structure",
+            provider: expected.provider,
+            primaryType: envelope.primaryType,
+            cause: "permitted entries missing or empty",
+        });
+    }
+
+    if (expected.inputToken !== undefined) {
+        const target = expected.inputToken;
+        const mismatched = entries.find((entry) => !isAddressEqual(entry.token, target));
+        if (mismatched) {
+            throw new Eip712EnvelopeMismatch({
+                field: "token",
+                provider: expected.provider,
+                primaryType: envelope.primaryType,
+                expected: target,
+                received: mismatched.token,
+            });
+        }
+    }
+
+    if (expected.maxAmount !== undefined) {
+        const total = entries.reduce((sum, entry) => sum + entry.amount, 0n);
+        if (total > expected.maxAmount) {
+            throw new Eip712EnvelopeMismatch({
+                field: "amount",
+                provider: expected.provider,
+                primaryType: envelope.primaryType,
+                expected: expected.maxAmount.toString(),
+                received: total.toString(),
+            });
+        }
+    }
+
+    assertDeadlineFresh({
+        deadline: envelope.message.deadline,
+        skewSeconds: expected.skewSeconds,
+        provider: expected.provider,
+        primaryType: envelope.primaryType,
+    });
+}

--- a/packages/cross-chain/src/external.ts
+++ b/packages/cross-chain/src/external.ts
@@ -77,4 +77,5 @@ export {
     type TransactionStep,
     type GetQuotesError,
     type GetQuotesResponse,
+    type SubmissionMode,
 } from "./internal.js";

--- a/packages/cross-chain/test/core/utils/permit2.spec.ts
+++ b/packages/cross-chain/test/core/utils/permit2.spec.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import type { Eip712Envelope } from "../../../src/core/types/eip712.js";
+import { PERMIT2_ADDRESS } from "../../../src/core/constants/eip712.js";
+import { Eip712EnvelopeMismatch } from "../../../src/core/errors/Eip712EnvelopeMismatch.exception.js";
+import { assertDeadlineFresh, readPermittedEntries } from "../../../src/core/utils/permit2.js";
+
+const PROVIDER = "test";
+const TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const FUTURE = Math.floor(Date.now() / 1000) + 3600;
+const PAST = Math.floor(Date.now() / 1000) - 3600;
+
+function singleEnvelope(overrides?: Partial<Eip712Envelope>): Eip712Envelope {
+    return {
+        domain: { chainId: 1, verifyingContract: PERMIT2_ADDRESS },
+        primaryType: "PermitTransferFrom",
+        types: {},
+        message: {
+            permitted: { token: TOKEN, amount: "1000000" },
+            spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+            nonce: "1",
+            deadline: FUTURE,
+        },
+        ...overrides,
+    };
+}
+
+function batchEnvelope(overrides?: Partial<Eip712Envelope>): Eip712Envelope {
+    return {
+        domain: { chainId: 1, verifyingContract: PERMIT2_ADDRESS },
+        primaryType: "PermitBatchTransferFrom",
+        types: {},
+        message: {
+            permitted: [
+                { token: TOKEN, amount: "400000" },
+                { token: TOKEN, amount: "600000" },
+            ],
+            spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+            nonce: "1",
+            deadline: FUTURE,
+        },
+        ...overrides,
+    };
+}
+
+describe("readPermittedEntries", () => {
+    it("normalizes the single PermitTransferFrom shape to an array", () => {
+        const entries = readPermittedEntries(singleEnvelope());
+        expect(entries).toHaveLength(1);
+        expect(entries[0]!.token.toLowerCase()).toBe(TOKEN.toLowerCase());
+        expect(entries[0]!.amount).toBe(1_000_000n);
+    });
+
+    it("reads the batch PermitBatchTransferFrom shape directly", () => {
+        const entries = readPermittedEntries(batchEnvelope());
+        expect(entries).toHaveLength(2);
+        expect(entries[0]!.amount).toBe(400_000n);
+        expect(entries[1]!.amount).toBe(600_000n);
+    });
+
+    it("returns an empty array for unknown primaryTypes", () => {
+        const envelope = singleEnvelope({ primaryType: "Foo" });
+        expect(readPermittedEntries(envelope)).toEqual([]);
+    });
+
+    it("throws Eip712EnvelopeMismatch (not InvalidAddressError) for a malformed token", () => {
+        const envelope = singleEnvelope({
+            message: {
+                permitted: { token: "not-an-address", amount: "1" },
+                spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                nonce: "1",
+                deadline: FUTURE,
+            },
+        });
+        expect(() => readPermittedEntries(envelope)).toThrow(Eip712EnvelopeMismatch);
+    });
+
+    it("throws Eip712EnvelopeMismatch (not SyntaxError) for a non-numeric amount", () => {
+        const envelope = singleEnvelope({
+            message: {
+                permitted: { token: TOKEN, amount: "not-a-number" },
+                spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                nonce: "1",
+                deadline: FUTURE,
+            },
+        });
+        expect(() => readPermittedEntries(envelope)).toThrow(Eip712EnvelopeMismatch);
+    });
+
+    it("throws Eip712EnvelopeMismatch when batch permitted is not an array", () => {
+        const envelope = batchEnvelope({
+            message: {
+                permitted: { token: TOKEN, amount: "1" },
+                spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                nonce: "1",
+                deadline: FUTURE,
+            },
+        });
+        expect(() => readPermittedEntries(envelope)).toThrow(Eip712EnvelopeMismatch);
+    });
+
+    it("throws Eip712EnvelopeMismatch when single permitted is not an object", () => {
+        const envelope = singleEnvelope({
+            message: {
+                permitted: [{ token: TOKEN, amount: "1" }],
+                spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                nonce: "1",
+                deadline: FUTURE,
+            },
+        });
+        expect(() => readPermittedEntries(envelope)).toThrow(Eip712EnvelopeMismatch);
+    });
+
+    it("throws Eip712EnvelopeMismatch when batch permitted is a primitive", () => {
+        const envelope = batchEnvelope({
+            message: {
+                permitted: "not-an-array",
+                spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                nonce: "1",
+                deadline: FUTURE,
+            },
+        });
+        expect(() => readPermittedEntries(envelope)).toThrow(Eip712EnvelopeMismatch);
+    });
+});
+
+describe("assertDeadlineFresh", () => {
+    it("accepts a future deadline", () => {
+        expect(() =>
+            assertDeadlineFresh({
+                deadline: FUTURE,
+                provider: PROVIDER,
+                primaryType: "PermitTransferFrom",
+            }),
+        ).not.toThrow();
+    });
+
+    it("rejects a missing deadline", () => {
+        expect(() =>
+            assertDeadlineFresh({
+                deadline: undefined,
+                provider: PROVIDER,
+                primaryType: "PermitTransferFrom",
+            }),
+        ).toThrowError(/deadline/);
+    });
+
+    it("rejects an expired deadline", () => {
+        expect(() =>
+            assertDeadlineFresh({
+                deadline: PAST,
+                provider: PROVIDER,
+                primaryType: "PermitTransferFrom",
+            }),
+        ).toThrowError(/deadline/);
+    });
+});

--- a/packages/cross-chain/test/core/validators/eip3009MessageValidator.spec.ts
+++ b/packages/cross-chain/test/core/validators/eip3009MessageValidator.spec.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+
+import type { Eip712Envelope } from "../../../src/core/types/eip712.js";
+import { Eip712EnvelopeMismatch } from "../../../src/core/errors/Eip712EnvelopeMismatch.exception.js";
+import { validateEip3009Message } from "../../../src/core/validators/eip3009MessageValidator.js";
+
+const PROVIDER = "test";
+const TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const USER = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+const FUTURE = Math.floor(Date.now() / 1000) + 3600;
+
+function envelope(overrides?: Partial<Eip712Envelope>): Eip712Envelope {
+    return {
+        domain: { name: "USD Coin", version: "2", chainId: 1, verifyingContract: TOKEN },
+        primaryType: "TransferWithAuthorization",
+        types: {},
+        message: {
+            from: USER,
+            to: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+            value: "1000000",
+            validAfter: 0,
+            validBefore: FUTURE,
+            nonce: "0xabcd",
+        },
+        ...overrides,
+    };
+}
+
+describe("validateEip3009Message", () => {
+    it("accepts a value supplied as a decimal string", () => {
+        expect(() =>
+            validateEip3009Message(envelope(), {
+                provider: PROVIDER,
+                user: USER as `0x${string}`,
+                maxValue: 1_000_000n,
+            }),
+        ).not.toThrow();
+    });
+
+    it("accepts a value supplied as a bigint", () => {
+        const e = envelope({
+            message: {
+                from: USER,
+                to: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                value: 1_000_000n,
+                validAfter: 0,
+                validBefore: FUTURE,
+                nonce: "0xabcd",
+            },
+        });
+        expect(() =>
+            validateEip3009Message(e, {
+                provider: PROVIDER,
+                user: USER as `0x${string}`,
+                maxValue: 1_000_000n,
+            }),
+        ).not.toThrow();
+    });
+
+    it("accepts a safe-integer numeric value without precision loss", () => {
+        const e = envelope({
+            message: {
+                from: USER,
+                to: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                value: 1_000_000,
+                validAfter: 0,
+                validBefore: FUTURE,
+                nonce: "0xabcd",
+            },
+        });
+        expect(() =>
+            validateEip3009Message(e, {
+                provider: PROVIDER,
+                user: USER as `0x${string}`,
+                maxValue: 1_000_000n,
+            }),
+        ).not.toThrow();
+    });
+
+    it("rejects a fractional numeric value instead of truncating it", () => {
+        const e = envelope({
+            message: {
+                from: USER,
+                to: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                value: 1_000_000.5,
+                validAfter: 0,
+                validBefore: FUTURE,
+                nonce: "0xabcd",
+            },
+        });
+        expect(() =>
+            validateEip3009Message(e, {
+                provider: PROVIDER,
+                user: USER as `0x${string}`,
+                maxValue: 1_000_000n,
+            }),
+        ).toThrow(Eip712EnvelopeMismatch);
+    });
+
+    it("rejects a numeric value above Number.MAX_SAFE_INTEGER to avoid precision loss", () => {
+        const e = envelope({
+            message: {
+                from: USER,
+                to: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                value: 1e18,
+                validAfter: 0,
+                validBefore: FUTURE,
+                nonce: "0xabcd",
+            },
+        });
+        expect(() =>
+            validateEip3009Message(e, {
+                provider: PROVIDER,
+                user: USER as `0x${string}`,
+                maxValue: 2n * 10n ** 18n,
+            }),
+        ).toThrow(Eip712EnvelopeMismatch);
+    });
+
+    it("rejects a value above maxValue", () => {
+        const e = envelope({
+            message: {
+                from: USER,
+                to: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                value: "2000000",
+                validAfter: 0,
+                validBefore: FUTURE,
+                nonce: "0xabcd",
+            },
+        });
+        expect(() =>
+            validateEip3009Message(e, {
+                provider: PROVIDER,
+                user: USER as `0x${string}`,
+                maxValue: 1_000_000n,
+            }),
+        ).toThrowError(/amount/);
+    });
+
+    it("rejects a from address that does not match the user", () => {
+        const e = envelope({
+            message: {
+                from: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                to: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                value: "1000000",
+                validAfter: 0,
+                validBefore: FUTURE,
+                nonce: "0xabcd",
+            },
+        });
+        expect(() =>
+            validateEip3009Message(e, {
+                provider: PROVIDER,
+                user: USER as `0x${string}`,
+                maxValue: 1_000_000n,
+            }),
+        ).toThrowError(/user/);
+    });
+
+    it("rejects an expired validBefore", () => {
+        const e = envelope({
+            message: {
+                from: USER,
+                to: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                value: "1000000",
+                validAfter: 0,
+                validBefore: Math.floor(Date.now() / 1000) - 3600,
+                nonce: "0xabcd",
+            },
+        });
+        expect(() =>
+            validateEip3009Message(e, {
+                provider: PROVIDER,
+                user: USER as `0x${string}`,
+                maxValue: 1_000_000n,
+            }),
+        ).toThrowError(/deadline/);
+    });
+});

--- a/packages/cross-chain/test/core/validators/eip712EnvelopeValidator.spec.ts
+++ b/packages/cross-chain/test/core/validators/eip712EnvelopeValidator.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import type { Eip712Envelope } from "../../../src/core/types/eip712.js";
+import { PERMIT2_ADDRESS, PERMIT2_PRIMARY_TYPES } from "../../../src/core/constants/eip712.js";
+import { Eip712EnvelopeMismatch } from "../../../src/core/errors/Eip712EnvelopeMismatch.exception.js";
+import {
+    validateEnvelopeDomain,
+    validatePrimaryType,
+} from "../../../src/core/validators/eip712EnvelopeValidator.js";
+
+const PROVIDER = "test";
+
+function makeEnvelope(overrides?: Partial<Eip712Envelope>): Eip712Envelope {
+    return {
+        domain: { chainId: 1, verifyingContract: PERMIT2_ADDRESS },
+        primaryType: "PermitTransferFrom",
+        types: {},
+        message: {},
+        ...overrides,
+    };
+}
+
+describe("validatePrimaryType", () => {
+    const allowed = new Set(["PermitTransferFrom"]);
+
+    it("accepts an allow-listed primaryType", () => {
+        expect(() => validatePrimaryType(makeEnvelope(), allowed, PROVIDER)).not.toThrow();
+    });
+
+    it("rejects a primaryType outside the allow-list", () => {
+        const envelope = makeEnvelope({ primaryType: "Foo" });
+        expect(() => validatePrimaryType(envelope, allowed, PROVIDER)).toThrow(
+            Eip712EnvelopeMismatch,
+        );
+    });
+
+    it("rejects case mismatches (EIP-712 type names are case-sensitive)", () => {
+        const envelope = makeEnvelope({ primaryType: "permitTransferFrom" });
+        expect(() => validatePrimaryType(envelope, allowed, PROVIDER)).toThrow(
+            Eip712EnvelopeMismatch,
+        );
+    });
+});
+
+describe("validateEnvelopeDomain", () => {
+    const expected = {
+        chainId: 1,
+        verifyingContracts: [PERMIT2_ADDRESS],
+        primaryTypes: PERMIT2_PRIMARY_TYPES,
+        provider: PROVIDER,
+    };
+
+    it("accepts a matching envelope", () => {
+        expect(() => validateEnvelopeDomain(makeEnvelope(), expected)).not.toThrow();
+    });
+
+    it("accepts a string chainId that parses to the expected number", () => {
+        const envelope = makeEnvelope({
+            domain: { chainId: "1", verifyingContract: PERMIT2_ADDRESS },
+        });
+        expect(() => validateEnvelopeDomain(envelope, expected)).not.toThrow();
+    });
+
+    it("accepts hex chainId", () => {
+        const envelope = makeEnvelope({
+            domain: { chainId: "0x1", verifyingContract: PERMIT2_ADDRESS },
+        });
+        expect(() => validateEnvelopeDomain(envelope, expected)).not.toThrow();
+    });
+
+    it("accepts bigint chainId", () => {
+        const envelope = makeEnvelope({
+            domain: { chainId: 1n, verifyingContract: PERMIT2_ADDRESS },
+        });
+        expect(() => validateEnvelopeDomain(envelope, expected)).not.toThrow();
+    });
+
+    it("rejects mismatched chainId", () => {
+        const envelope = makeEnvelope({
+            domain: { chainId: 137, verifyingContract: PERMIT2_ADDRESS },
+        });
+        expect(() => validateEnvelopeDomain(envelope, expected)).toThrowError(/chainId/);
+    });
+
+    it("rejects malformed chainId", () => {
+        const envelope = makeEnvelope({
+            domain: { chainId: "abc", verifyingContract: PERMIT2_ADDRESS },
+        });
+        expect(() => validateEnvelopeDomain(envelope, expected)).toThrowError(/chainId/);
+    });
+
+    it("rejects missing chainId", () => {
+        const envelope = makeEnvelope({
+            domain: { verifyingContract: PERMIT2_ADDRESS },
+        });
+        expect(() => validateEnvelopeDomain(envelope, expected)).toThrowError(/chainId/);
+    });
+
+    it("rejects a non-canonical verifyingContract", () => {
+        const envelope = makeEnvelope({
+            domain: { chainId: 1, verifyingContract: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" },
+        });
+        expect(() => validateEnvelopeDomain(envelope, expected)).toThrowError(/verifyingContract/);
+    });
+
+    it("accepts checksummed and lowercase verifyingContract equally", () => {
+        const lowercase = makeEnvelope({
+            domain: { chainId: 1, verifyingContract: PERMIT2_ADDRESS.toLowerCase() },
+        });
+        expect(() => validateEnvelopeDomain(lowercase, expected)).not.toThrow();
+    });
+
+    it("rejects when verifyingContracts allow-list is empty", () => {
+        expect(() =>
+            validateEnvelopeDomain(makeEnvelope(), { ...expected, verifyingContracts: [] }),
+        ).toThrowError(/verifyingContracts allow-list is empty/);
+    });
+
+    it("rejects Permit2 envelopes that carry a domain.version", () => {
+        const envelope = makeEnvelope({
+            domain: { chainId: 1, verifyingContract: PERMIT2_ADDRESS, version: "1" },
+        });
+        expect(() => validateEnvelopeDomain(envelope, expected)).toThrowError(/domainVersion/);
+    });
+});

--- a/packages/cross-chain/test/core/validators/permit2MessageValidator.spec.ts
+++ b/packages/cross-chain/test/core/validators/permit2MessageValidator.spec.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import type { Eip712Envelope } from "../../../src/core/types/eip712.js";
+import { PERMIT2_ADDRESS } from "../../../src/core/constants/eip712.js";
+import { Eip712EnvelopeMismatch } from "../../../src/core/errors/Eip712EnvelopeMismatch.exception.js";
+import { validatePermit2Message } from "../../../src/core/validators/permit2MessageValidator.js";
+
+const PROVIDER = "test";
+const TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const FUTURE = Math.floor(Date.now() / 1000) + 3600;
+const PAST = Math.floor(Date.now() / 1000) - 3600;
+
+function singleEnvelope(overrides?: Partial<Eip712Envelope>): Eip712Envelope {
+    return {
+        domain: { chainId: 1, verifyingContract: PERMIT2_ADDRESS },
+        primaryType: "PermitTransferFrom",
+        types: {},
+        message: {
+            permitted: { token: TOKEN, amount: "1000000" },
+            spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+            nonce: "1",
+            deadline: FUTURE,
+        },
+        ...overrides,
+    };
+}
+
+function batchEnvelope(overrides?: Partial<Eip712Envelope>): Eip712Envelope {
+    return {
+        domain: { chainId: 1, verifyingContract: PERMIT2_ADDRESS },
+        primaryType: "PermitBatchTransferFrom",
+        types: {},
+        message: {
+            permitted: [
+                { token: TOKEN, amount: "400000" },
+                { token: TOKEN, amount: "600000" },
+            ],
+            spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+            nonce: "1",
+            deadline: FUTURE,
+        },
+        ...overrides,
+    };
+}
+
+describe("validatePermit2Message", () => {
+    it("accepts a matching envelope", () => {
+        expect(() =>
+            validatePermit2Message(singleEnvelope(), {
+                provider: PROVIDER,
+                inputToken: TOKEN as `0x${string}`,
+                maxAmount: 1_000_000n,
+            }),
+        ).not.toThrow();
+    });
+
+    it("accepts an amount lower than the requested maximum", () => {
+        const envelope = singleEnvelope({
+            message: {
+                permitted: { token: TOKEN, amount: "500000" },
+                spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                nonce: "1",
+                deadline: FUTURE,
+            },
+        });
+        expect(() =>
+            validatePermit2Message(envelope, {
+                provider: PROVIDER,
+                inputToken: TOKEN as `0x${string}`,
+                maxAmount: 1_000_000n,
+            }),
+        ).not.toThrow();
+    });
+
+    it("rejects an inflated total amount across batch entries", () => {
+        expect(() =>
+            validatePermit2Message(batchEnvelope(), {
+                provider: PROVIDER,
+                inputToken: TOKEN as `0x${string}`,
+                maxAmount: 500_000n,
+            }),
+        ).toThrowError(/amount/);
+    });
+
+    it("rejects a tampered token", () => {
+        const envelope = singleEnvelope({
+            message: {
+                permitted: {
+                    token: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                    amount: "1000000",
+                },
+                spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                nonce: "1",
+                deadline: FUTURE,
+            },
+        });
+        expect(() =>
+            validatePermit2Message(envelope, {
+                provider: PROVIDER,
+                inputToken: TOKEN as `0x${string}`,
+            }),
+        ).toThrowError(/token/);
+    });
+
+    it("rejects an expired deadline", () => {
+        const envelope = singleEnvelope({
+            message: {
+                permitted: { token: TOKEN, amount: "1000000" },
+                spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                nonce: "1",
+                deadline: PAST,
+            },
+        });
+        expect(() => validatePermit2Message(envelope, { provider: PROVIDER })).toThrowError(
+            /deadline/,
+        );
+    });
+
+    it("rejects an envelope with empty permitted entries", () => {
+        const envelope = singleEnvelope({
+            message: {
+                permitted: undefined,
+                deadline: FUTURE,
+            },
+        });
+        expect(() => validatePermit2Message(envelope, { provider: PROVIDER })).toThrow(
+            Eip712EnvelopeMismatch,
+        );
+    });
+
+    it("rejects a batch entry whose token differs from inputToken", () => {
+        const OTHER_TOKEN = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+        const envelope = batchEnvelope({
+            message: {
+                permitted: [
+                    { token: TOKEN, amount: "400000" },
+                    { token: OTHER_TOKEN, amount: "600000" },
+                ],
+                spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                nonce: "1",
+                deadline: FUTURE,
+            },
+        });
+        expect(() =>
+            validatePermit2Message(envelope, {
+                provider: PROVIDER,
+                inputToken: TOKEN as `0x${string}`,
+                maxAmount: 1_000_000n,
+            }),
+        ).toThrowError(/token/);
+    });
+
+    it("rejects a batch with the input token at amount zero and another token carrying the value", () => {
+        const OTHER_TOKEN = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+        const envelope = batchEnvelope({
+            message: {
+                permitted: [
+                    { token: TOKEN, amount: "0" },
+                    { token: OTHER_TOKEN, amount: "1000000" },
+                ],
+                spender: "0x52602D7cc3D833F5d28ee6D01C7F82C9b2322e10",
+                nonce: "1",
+                deadline: FUTURE,
+            },
+        });
+        expect(() =>
+            validatePermit2Message(envelope, {
+                provider: PROVIDER,
+                inputToken: TOKEN as `0x${string}`,
+                maxAmount: 1_000_000n,
+            }),
+        ).toThrowError(/token/);
+    });
+
+    it("accepts a batch where all entries use the input token and the total respects maxAmount", () => {
+        expect(() =>
+            validatePermit2Message(batchEnvelope(), {
+                provider: PROVIDER,
+                inputToken: TOKEN as `0x${string}`,
+                maxAmount: 1_000_000n,
+            }),
+        ).not.toThrow();
+    });
+});


### PR DESCRIPTION
Closes EFI-949 (subtask of EFI-944).

## Summary

Adds the reusable EIP-712 envelope validation utilities under `packages/cross-chain/src/core` that EFI-944 (V12 audit, finding #4, critical) calls for. No protocol uses them yet — Bungee+Relay (EFI-950) and OIF (EFI-951) ship in their own PRs on top of this one.

### What's in this PR

- `core/validators/eip712EnvelopeValidator.ts` — `validatePrimaryType`, `validateEnvelopeDomain`
- `core/validators/permit2MessageValidator.ts` — single and batch Permit2 payloads
- `core/validators/eip3009MessageValidator.ts` — `TransferWithAuthorization` / `ReceiveWithAuthorization`. `message.value` is decoded strictly (only `bigint`, numeric strings and safe-integer numbers; floats and lossy values are rejected)
- `core/errors/Eip712EnvelopeMismatch.exception.ts` — typed `ProviderGetQuoteFailure` subclass thrown by every mismatch
- `core/types/eip712.ts` and `core/constants/eip712.ts` — shared primitives (Permit2 address, witness types, etc.)
- `core/utils/permit2.ts` — Permit2 decode helpers
- Unit tests for everything under `test/core/`
- `SubmissionMode` re-exported from the public entrypoint

### What's not in this PR

No provider behaviour changes. Relay, Bungee and OIF still forward whatever the API returns to the wallet — the wiring of these validators into each protocol is tracked in EFI-950 (Bungee + Relay) and EFI-951 (OIF) so they can be reviewed in parallel by different owners on top of this base.

## Diagram

```mermaid
classDiagram
    direction TB

    class Eip712EnvelopeValidator {
        +validatePrimaryType()
        +validateEnvelopeDomain()
    }
    class Permit2MessageValidator {
        +validatePermit2Message()
    }
    class Eip3009MessageValidator {
        +validateEip3009Message()
    }

    class Permit2Utils {
        +decodePermit2Permitted()
    }

    class Eip712EnvelopeMismatch
    class ProviderGetQuoteFailure

    Eip712EnvelopeValidator ..> Eip712EnvelopeMismatch : throws
    Permit2MessageValidator ..> Eip712EnvelopeMismatch : throws
    Permit2MessageValidator ..> Permit2Utils
    Eip3009MessageValidator ..> Eip712EnvelopeMismatch : throws

    Eip712EnvelopeMismatch --|> ProviderGetQuoteFailure
```

## Test plan

- [x] `pnpm --filter @wonderland/interop-cross-chain build`
- [x] `pnpm --filter @wonderland/interop-cross-chain test` (1085 passing, 14 skipped)
- [x] `git diff dev...HEAD --stat` — only `src/core/`, `test/core/`, `.changeset/` and a one-line addition to `external.ts`
