### PR TITLE
feat(ui): add submission mode toggle to cross-chain demo (EFI-952)

### DIFF
--- a/.changeset/expose-submission-mode-type.md
+++ b/.changeset/expose-submission-mode-type.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Expose `SubmissionMode` (the `"user-transaction" | "gasless"` union) from the package entry point so consumers can type submission-mode preferences without duplicating the literal locally.

--- a/examples/ui/app/cross-chain/CrossChainClient.tsx
+++ b/examples/ui/app/cross-chain/CrossChainClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { isNativeAddress, type ExecutableQuote } from '@wonderland/interop-cross-chain';
 import { Footer, Navigation } from '../components';
 import {
@@ -70,6 +70,7 @@ export default function CrossChainClient() {
   const [lastQuoteParams, setLastQuoteParams] = useState<Parameters<typeof fetchQuotes>[0] | null>(null);
   const currentMode = useCrossChainStore((s) => s.mode);
   const buildQuoteProviderId = useCrossChainStore((s) => s.buildQuoteProviderId);
+  const submissionMode = useCrossChainStore((s) => s.submissionMode);
   const isExecutionStarted = executionState.step !== STEP.IDLE;
 
   const effectiveQuotes: ExecutableQuote[] = currentMode === 'buildQuote' && builtQuote ? [builtQuote] : quotes;
@@ -163,6 +164,13 @@ export default function CrossChainClient() {
     clearBuildQuote();
   }, [resetExecution, clearQuotes, clearBuildQuote]);
 
+  useEffect(() => {
+    setSelectedQuote(null);
+    setLastQuoteParams(null);
+    clearQuotes();
+    clearBuildQuote();
+  }, [submissionMode, clearQuotes, clearBuildQuote]);
+
   return (
     <TooltipProvider>
       <div className='min-h-screen bg-background flex flex-col'>
@@ -170,7 +178,7 @@ export default function CrossChainClient() {
 
         <div className='flex-1 flex flex-col max-w-7xl w-full mx-auto px-4 py-12 sm:px-6 sm:py-16'>
           <div className='flex-1 flex flex-col gap-12'>
-            <div className='flex justify-end gap-3'>
+            <div className='flex justify-end items-center gap-4'>
               <SubmissionModeSwitch disabled={isExecutionStarted} />
               <NetworkSwitch disabled={isExecutionStarted} />
             </div>

--- a/examples/ui/app/cross-chain/CrossChainClient.tsx
+++ b/examples/ui/app/cross-chain/CrossChainClient.tsx
@@ -13,6 +13,7 @@ import {
   QuoteCard,
   QuoteDetails,
   QuoteList,
+  SubmissionModeSwitch,
   SwapForm,
   Toast,
   TooltipProvider,
@@ -169,7 +170,8 @@ export default function CrossChainClient() {
 
         <div className='flex-1 flex flex-col max-w-7xl w-full mx-auto px-4 py-12 sm:px-6 sm:py-16'>
           <div className='flex-1 flex flex-col gap-12'>
-            <div className='flex justify-end'>
+            <div className='flex justify-end gap-3'>
+              <SubmissionModeSwitch disabled={isExecutionStarted} />
               <NetworkSwitch disabled={isExecutionStarted} />
             </div>
 

--- a/examples/ui/app/cross-chain/components/NetworkSwitch.tsx
+++ b/examples/ui/app/cross-chain/components/NetworkSwitch.tsx
@@ -1,52 +1,30 @@
 'use client';
 
 import { useCrossChainStore } from '../stores/crossChainStore';
+import { SegmentedToggle } from './SegmentedToggle';
 
 interface NetworkSwitchProps {
   disabled?: boolean;
 }
+
+type NetworkValue = 'mainnet' | 'testnet';
+
+const OPTIONS: { value: NetworkValue; label: string }[] = [
+  { value: 'mainnet', label: 'Mainnet' },
+  { value: 'testnet', label: 'Testnet' },
+];
 
 export function NetworkSwitch({ disabled = false }: NetworkSwitchProps) {
   const isTestnet = useCrossChainStore((s) => s.isTestnet);
   const setIsTestnet = useCrossChainStore((s) => s.setIsTestnet);
 
   return (
-    <div
-      className='relative flex items-center rounded-full bg-surface-secondary p-1'
-      role='radiogroup'
-      aria-label='Network selection'
-    >
-      <div
-        className='absolute top-1 bottom-1 rounded-full bg-accent transition-all duration-200 ease-out'
-        style={{
-          width: 'calc(50% - 4px)',
-          left: isTestnet ? 'calc(50% + 2px)' : '4px',
-        }}
-      />
-
-      <button
-        role='radio'
-        aria-checked={!isTestnet}
-        disabled={disabled}
-        onClick={() => setIsTestnet(false)}
-        className={`relative z-10 flex-1 px-4 py-1.5 rounded-full text-sm font-medium transition-colors duration-200 ${
-          disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
-        } ${!isTestnet ? 'text-white' : 'text-text-secondary hover:text-text-primary'}`}
-      >
-        Mainnet
-      </button>
-
-      <button
-        role='radio'
-        aria-checked={isTestnet}
-        disabled={disabled}
-        onClick={() => setIsTestnet(true)}
-        className={`relative z-10 flex-1 px-4 py-1.5 rounded-full text-sm font-medium transition-colors duration-200 ${
-          disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
-        } ${isTestnet ? 'text-white' : 'text-text-secondary hover:text-text-primary'}`}
-      >
-        Testnet
-      </button>
-    </div>
+    <SegmentedToggle
+      options={OPTIONS}
+      value={isTestnet ? 'testnet' : 'mainnet'}
+      onChange={(value) => setIsTestnet(value === 'testnet')}
+      ariaLabel='Network selection'
+      disabled={disabled}
+    />
   );
 }

--- a/examples/ui/app/cross-chain/components/SegmentedToggle.tsx
+++ b/examples/ui/app/cross-chain/components/SegmentedToggle.tsx
@@ -31,6 +31,7 @@ export function SegmentedToggle<T extends string>({
         return (
           <button
             key={option.value}
+            type='button'
             role='radio'
             aria-checked={isActive}
             disabled={disabled}

--- a/examples/ui/app/cross-chain/components/SegmentedToggle.tsx
+++ b/examples/ui/app/cross-chain/components/SegmentedToggle.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+interface SegmentedToggleOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface SegmentedToggleProps<T extends string> {
+  options: readonly SegmentedToggleOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  ariaLabel: string;
+  disabled?: boolean;
+}
+
+export function SegmentedToggle<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  disabled = false,
+}: SegmentedToggleProps<T>) {
+  return (
+    <div
+      className='inline-flex items-center rounded-full bg-surface-secondary p-1'
+      role='radiogroup'
+      aria-label={ariaLabel}
+    >
+      {options.map((option) => {
+        const isActive = option.value === value;
+        return (
+          <button
+            key={option.value}
+            role='radio'
+            aria-checked={isActive}
+            disabled={disabled}
+            onClick={() => onChange(option.value)}
+            className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:ring-offset-1 ${
+              disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+            } ${isActive ? 'bg-accent text-white' : 'text-text-secondary hover:text-text-primary'}`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/examples/ui/app/cross-chain/components/SubmissionModeSwitch.tsx
+++ b/examples/ui/app/cross-chain/components/SubmissionModeSwitch.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useCrossChainStore } from '../stores/crossChainStore';
+import type { SubmissionMode } from '@wonderland/interop-cross-chain';
+
+interface SubmissionModeSwitchProps {
+  disabled?: boolean;
+}
+
+const OPTIONS: { value: SubmissionMode; label: string }[] = [
+  { value: 'user-transaction', label: 'Transactions' },
+  { value: 'gasless', label: 'Gasless' },
+];
+
+export function SubmissionModeSwitch({ disabled = false }: SubmissionModeSwitchProps) {
+  const submissionMode = useCrossChainStore((s) => s.submissionMode);
+  const setSubmissionMode = useCrossChainStore((s) => s.setSubmissionMode);
+  const activeIndex = OPTIONS.findIndex((o) => o.value === submissionMode);
+
+  return (
+    <div
+      className='relative flex items-center rounded-full bg-surface-secondary p-1'
+      role='radiogroup'
+      aria-label='Submission mode selection'
+    >
+      <div
+        className='absolute top-1 bottom-1 rounded-full bg-accent transition-all duration-200 ease-out'
+        style={{
+          width: 'calc(50% - 4px)',
+          left: activeIndex === 0 ? '4px' : 'calc(50% + 2px)',
+        }}
+      />
+      {OPTIONS.map(({ value, label }) => {
+        const isActive = value === submissionMode;
+        return (
+          <button
+            key={value}
+            role='radio'
+            aria-checked={isActive}
+            disabled={disabled}
+            onClick={() => setSubmissionMode(value)}
+            className={`relative z-10 flex-1 px-4 py-1.5 rounded-full text-sm font-medium transition-colors duration-200 ${
+              disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+            } ${isActive ? 'text-white' : 'text-text-secondary hover:text-text-primary'}`}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/examples/ui/app/cross-chain/components/SubmissionModeSwitch.tsx
+++ b/examples/ui/app/cross-chain/components/SubmissionModeSwitch.tsx
@@ -39,7 +39,7 @@ export function SubmissionModeSwitch({ disabled = false }: SubmissionModeSwitchP
             aria-checked={isActive}
             disabled={disabled}
             onClick={() => setSubmissionMode(value)}
-            className={`relative z-10 flex-1 px-4 py-1.5 rounded-full text-sm font-medium transition-colors duration-200 ${
+            className={`relative z-10 flex-1 px-4 py-1.5 rounded-full text-sm font-medium transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:ring-offset-1 ${
               disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
             } ${isActive ? 'text-white' : 'text-text-secondary hover:text-text-primary'}`}
           >

--- a/examples/ui/app/cross-chain/components/SubmissionModeSwitch.tsx
+++ b/examples/ui/app/cross-chain/components/SubmissionModeSwitch.tsx
@@ -1,10 +1,16 @@
 'use client';
 
+import { useLayoutEffect, useRef, useState } from 'react';
 import { useCrossChainStore } from '../stores/crossChainStore';
 import type { SubmissionMode } from '@wonderland/interop-cross-chain';
 
 interface SubmissionModeSwitchProps {
   disabled?: boolean;
+}
+
+interface ThumbStyle {
+  left: number;
+  width: number;
 }
 
 const OPTIONS: { value: SubmissionMode; label: string }[] = [
@@ -15,31 +21,42 @@ const OPTIONS: { value: SubmissionMode; label: string }[] = [
 export function SubmissionModeSwitch({ disabled = false }: SubmissionModeSwitchProps) {
   const submissionMode = useCrossChainStore((s) => s.submissionMode);
   const setSubmissionMode = useCrossChainStore((s) => s.setSubmissionMode);
-  const activeIndex = OPTIONS.findIndex((o) => o.value === submissionMode);
+  const buttonRefs = useRef(new Map<SubmissionMode, HTMLButtonElement>());
+  const [thumbStyle, setThumbStyle] = useState<ThumbStyle | null>(null);
+
+  useLayoutEffect(() => {
+    const button = buttonRefs.current.get(submissionMode);
+    if (!button) return;
+    setThumbStyle({ left: button.offsetLeft, width: button.offsetWidth });
+  }, [submissionMode]);
 
   return (
     <div
-      className='relative flex items-center rounded-full bg-surface-secondary p-1'
+      className='relative inline-flex items-center rounded-full bg-surface-secondary p-1'
       role='radiogroup'
       aria-label='Submission mode selection'
     >
-      <div
-        className='absolute top-1 bottom-1 rounded-full bg-accent transition-all duration-200 ease-out'
-        style={{
-          width: 'calc(50% - 4px)',
-          left: activeIndex === 0 ? '4px' : 'calc(50% + 2px)',
-        }}
-      />
+      {thumbStyle !== null && (
+        <span
+          aria-hidden='true'
+          className='absolute top-1 bottom-1 rounded-full bg-accent transition-all duration-200 ease-out'
+          style={{ left: thumbStyle.left, width: thumbStyle.width }}
+        />
+      )}
       {OPTIONS.map(({ value, label }) => {
         const isActive = value === submissionMode;
         return (
           <button
             key={value}
+            ref={(el) => {
+              if (el) buttonRefs.current.set(value, el);
+              else buttonRefs.current.delete(value);
+            }}
             role='radio'
             aria-checked={isActive}
             disabled={disabled}
             onClick={() => setSubmissionMode(value)}
-            className={`relative z-10 flex-1 px-4 py-1.5 rounded-full text-sm font-medium transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:ring-offset-1 ${
+            className={`relative z-10 px-4 py-1.5 rounded-full text-sm font-medium transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:ring-offset-1 ${
               disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
             } ${isActive ? 'text-white' : 'text-text-secondary hover:text-text-primary'}`}
           >

--- a/examples/ui/app/cross-chain/components/SubmissionModeSwitch.tsx
+++ b/examples/ui/app/cross-chain/components/SubmissionModeSwitch.tsx
@@ -1,16 +1,11 @@
 'use client';
 
-import { useLayoutEffect, useRef, useState } from 'react';
 import { useCrossChainStore } from '../stores/crossChainStore';
+import { SegmentedToggle } from './SegmentedToggle';
 import type { SubmissionMode } from '@wonderland/interop-cross-chain';
 
 interface SubmissionModeSwitchProps {
   disabled?: boolean;
-}
-
-interface ThumbStyle {
-  left: number;
-  width: number;
 }
 
 const OPTIONS: { value: SubmissionMode; label: string }[] = [
@@ -21,49 +16,14 @@ const OPTIONS: { value: SubmissionMode; label: string }[] = [
 export function SubmissionModeSwitch({ disabled = false }: SubmissionModeSwitchProps) {
   const submissionMode = useCrossChainStore((s) => s.submissionMode);
   const setSubmissionMode = useCrossChainStore((s) => s.setSubmissionMode);
-  const buttonRefs = useRef(new Map<SubmissionMode, HTMLButtonElement>());
-  const [thumbStyle, setThumbStyle] = useState<ThumbStyle | null>(null);
-
-  useLayoutEffect(() => {
-    const button = buttonRefs.current.get(submissionMode);
-    if (!button) return;
-    setThumbStyle({ left: button.offsetLeft, width: button.offsetWidth });
-  }, [submissionMode]);
 
   return (
-    <div
-      className='relative inline-flex items-center rounded-full bg-surface-secondary p-1'
-      role='radiogroup'
-      aria-label='Submission mode selection'
-    >
-      {thumbStyle !== null && (
-        <span
-          aria-hidden='true'
-          className='absolute top-1 bottom-1 rounded-full bg-accent transition-all duration-200 ease-out'
-          style={{ left: thumbStyle.left, width: thumbStyle.width }}
-        />
-      )}
-      {OPTIONS.map(({ value, label }) => {
-        const isActive = value === submissionMode;
-        return (
-          <button
-            key={value}
-            ref={(el) => {
-              if (el) buttonRefs.current.set(value, el);
-              else buttonRefs.current.delete(value);
-            }}
-            role='radio'
-            aria-checked={isActive}
-            disabled={disabled}
-            onClick={() => setSubmissionMode(value)}
-            className={`relative z-10 px-4 py-1.5 rounded-full text-sm font-medium transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:ring-offset-1 ${
-              disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
-            } ${isActive ? 'text-white' : 'text-text-secondary hover:text-text-primary'}`}
-          >
-            {label}
-          </button>
-        );
-      })}
-    </div>
+    <SegmentedToggle
+      options={OPTIONS}
+      value={submissionMode}
+      onChange={setSubmissionMode}
+      ariaLabel='Submission mode selection'
+      disabled={disabled}
+    />
   );
 }

--- a/examples/ui/app/cross-chain/components/index.ts
+++ b/examples/ui/app/cross-chain/components/index.ts
@@ -7,6 +7,7 @@ export { OrderTracking } from './OrderTracking';
 export { QuoteCard } from './QuoteCard';
 export { QuoteDetails } from './QuoteDetails';
 export { QuoteList } from './QuoteList';
+export { SegmentedToggle } from './SegmentedToggle';
 export { SubmissionModeSwitch } from './SubmissionModeSwitch';
 export { SwapForm } from './SwapForm';
 export { Toast } from './Toast';

--- a/examples/ui/app/cross-chain/components/index.ts
+++ b/examples/ui/app/cross-chain/components/index.ts
@@ -7,6 +7,7 @@ export { OrderTracking } from './OrderTracking';
 export { QuoteCard } from './QuoteCard';
 export { QuoteDetails } from './QuoteDetails';
 export { QuoteList } from './QuoteList';
+export { SubmissionModeSwitch } from './SubmissionModeSwitch';
 export { SwapForm } from './SwapForm';
 export { Toast } from './Toast';
 export { Tooltip, TooltipProvider } from './Tooltip';

--- a/examples/ui/app/cross-chain/hooks/useQuotes.ts
+++ b/examples/ui/app/cross-chain/hooks/useQuotes.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { useCrossChainStore } from '../stores/crossChainStore';
 import { convertAmountToSmallestUnit } from '../utils/amountConverter';
 import { useTokenConfig } from './useNetworkConfig';
@@ -40,8 +40,10 @@ export function useQuotes(): UseQuotesReturn {
   const [quotes, setQuotes] = useState<ExecutableQuote[]>([]);
   const [errors, setErrors] = useState<GetQuotesError[]>([]);
   const [status, setStatus] = useState<QuoteStatus>(QuoteStatus.IDLE);
+  const requestIdRef = useRef(0);
 
   const fetchQuotes = async (params: QuoteParams) => {
+    const currentRequestId = ++requestIdRef.current;
     setStatus(QuoteStatus.LOADING);
     setQuotes([]);
     setErrors([]);
@@ -70,15 +72,17 @@ export function useQuotes(): UseQuotesReturn {
       };
 
       const response = await executor.getQuotes(quoteRequest);
+      if (requestIdRef.current !== currentRequestId) return;
 
       if (response.quotes?.length) {
         setQuotes(response.quotes);
       }
-
       if (response.errors?.length) {
         setErrors(response.errors);
       }
+      setStatus(QuoteStatus.SUCCESS);
     } catch (error) {
+      if (requestIdRef.current !== currentRequestId) return;
       setStatus(QuoteStatus.ERROR);
       setErrors([
         {
@@ -86,13 +90,11 @@ export function useQuotes(): UseQuotesReturn {
           error: error instanceof Error ? error : new Error(String(error)),
         },
       ]);
-      return;
     }
-
-    setStatus(QuoteStatus.SUCCESS);
   };
 
   const clearQuotes = useCallback(() => {
+    requestIdRef.current++;
     setQuotes([]);
     setErrors([]);
     setStatus(QuoteStatus.IDLE);

--- a/examples/ui/app/cross-chain/services/sdk.ts
+++ b/examples/ui/app/cross-chain/services/sdk.ts
@@ -9,6 +9,7 @@ import {
   BungeeApiTier,
   type Aggregator,
   type CrossChainProvider,
+  type SubmissionMode,
 } from '@wonderland/interop-cross-chain';
 import { MAINNET_RPC_URLS, TESTNET_RPC_URLS } from '../constants/chains';
 
@@ -51,10 +52,11 @@ const PROVIDER_CONFIGS: ProviderConfig[] = [
   },
 ];
 
-export function buildExecutor(isTestnet: boolean): Aggregator {
+export function buildExecutor(isTestnet: boolean, submissionMode: SubmissionMode = 'user-transaction'): Aggregator {
   const rpcUrls = isTestnet ? TESTNET_RPC_URLS : MAINNET_RPC_URLS;
   const oifSolverId = isTestnet ? 'testnet-solver' : 'mainnet-solver';
   const lifiUrl = isTestnet ? LIFI_INTENTS_ORDER_SERVER_DEV_URL : LIFI_INTENTS_ORDER_SERVER_URL;
+  const submissionModes = [submissionMode];
 
   const providers: CrossChainProvider[] = [
     createCrossChainProvider(PROTOCOLS.ACROSS, {
@@ -65,10 +67,12 @@ export function buildExecutor(isTestnet: boolean): Aggregator {
       solverId: oifSolverId,
       url: OIF_API_URL,
       providerId: 'oif',
+      submissionModes,
     }),
     createCrossChainProvider(PROTOCOLS.RELAY, {
       isTestnet,
       providerId: 'relay',
+      submissionModes,
     }),
     createCrossChainProvider(PROTOCOLS.LIFI_INTENTS, {
       orderServerUrl: lifiUrl,
@@ -81,6 +85,7 @@ export function buildExecutor(isTestnet: boolean): Aggregator {
       createCrossChainProvider(PROTOCOLS.BUNGEE, {
         tier: BungeeApiTier.Sandbox,
         providerId: 'bungee',
+        submissionModes,
       }),
     );
   }

--- a/examples/ui/app/cross-chain/services/sdk.ts
+++ b/examples/ui/app/cross-chain/services/sdk.ts
@@ -57,12 +57,20 @@ export function buildExecutor(isTestnet: boolean, submissionMode: SubmissionMode
   const oifSolverId = isTestnet ? 'testnet-solver' : 'mainnet-solver';
   const lifiUrl = isTestnet ? LIFI_INTENTS_ORDER_SERVER_DEV_URL : LIFI_INTENTS_ORDER_SERVER_URL;
   const submissionModes = [submissionMode];
+  const isGasless = submissionMode === 'gasless';
 
-  const providers: CrossChainProvider[] = [
-    createCrossChainProvider(PROTOCOLS.ACROSS, {
-      isTestnet,
-      providerId: 'across',
-    }),
+  const providers: CrossChainProvider[] = [];
+
+  if (!isGasless) {
+    providers.push(
+      createCrossChainProvider(PROTOCOLS.ACROSS, {
+        isTestnet,
+        providerId: 'across',
+      }),
+    );
+  }
+
+  providers.push(
     createCrossChainProvider(PROTOCOLS.OIF, {
       solverId: oifSolverId,
       url: OIF_API_URL,
@@ -74,11 +82,16 @@ export function buildExecutor(isTestnet: boolean, submissionMode: SubmissionMode
       providerId: 'relay',
       submissionModes,
     }),
-    createCrossChainProvider(PROTOCOLS.LIFI_INTENTS, {
-      orderServerUrl: lifiUrl,
-      providerId: 'lifi-intents',
-    }),
-  ];
+  );
+
+  if (!isGasless) {
+    providers.push(
+      createCrossChainProvider(PROTOCOLS.LIFI_INTENTS, {
+        orderServerUrl: lifiUrl,
+        providerId: 'lifi-intents',
+      }),
+    );
+  }
 
   if (!isTestnet) {
     providers.push(

--- a/examples/ui/app/cross-chain/services/sdk.ts
+++ b/examples/ui/app/cross-chain/services/sdk.ts
@@ -19,49 +19,35 @@ interface ProviderConfig {
   providerId: string;
   displayName: string;
   supportsBuildQuote: boolean;
+  supportsGasless: boolean;
 }
 
-/**
- * Provider configuration with display names and capability flags
- */
 const PROVIDER_CONFIGS: ProviderConfig[] = [
-  {
-    providerId: 'across',
-    displayName: 'Across Protocol',
-    supportsBuildQuote: true,
-  },
-  {
-    providerId: 'oif',
-    displayName: 'OIF Sample Solver',
-    supportsBuildQuote: true,
-  },
-  {
-    providerId: 'relay',
-    displayName: 'Relay',
-    supportsBuildQuote: false,
-  },
-  {
-    providerId: 'lifi-intents',
-    displayName: 'LI.FI',
-    supportsBuildQuote: false,
-  },
-  {
-    providerId: 'bungee',
-    displayName: 'Bungee',
-    supportsBuildQuote: false,
-  },
+  { providerId: 'across', displayName: 'Across Protocol', supportsBuildQuote: true, supportsGasless: false },
+  { providerId: 'oif', displayName: 'OIF Sample Solver', supportsBuildQuote: true, supportsGasless: true },
+  { providerId: 'relay', displayName: 'Relay', supportsBuildQuote: false, supportsGasless: true },
+  { providerId: 'lifi-intents', displayName: 'LI.FI', supportsBuildQuote: false, supportsGasless: false },
+  { providerId: 'bungee', displayName: 'Bungee', supportsBuildQuote: false, supportsGasless: true },
 ];
+
+function findConfig(providerId: string): ProviderConfig | undefined {
+  return PROVIDER_CONFIGS.find((c) => c.providerId === providerId);
+}
+
+function isEnabledForMode(providerId: string, submissionMode: SubmissionMode): boolean {
+  const config = findConfig(providerId);
+  return config !== undefined && (submissionMode !== 'gasless' || config.supportsGasless);
+}
 
 export function buildExecutor(isTestnet: boolean, submissionMode: SubmissionMode = 'user-transaction'): Aggregator {
   const rpcUrls = isTestnet ? TESTNET_RPC_URLS : MAINNET_RPC_URLS;
   const oifSolverId = isTestnet ? 'testnet-solver' : 'mainnet-solver';
   const lifiUrl = isTestnet ? LIFI_INTENTS_ORDER_SERVER_DEV_URL : LIFI_INTENTS_ORDER_SERVER_URL;
   const submissionModes = [submissionMode];
-  const isGasless = submissionMode === 'gasless';
 
   const providers: CrossChainProvider[] = [];
 
-  if (!isGasless) {
+  if (isEnabledForMode('across', submissionMode)) {
     providers.push(
       createCrossChainProvider(PROTOCOLS.ACROSS, {
         isTestnet,
@@ -70,21 +56,28 @@ export function buildExecutor(isTestnet: boolean, submissionMode: SubmissionMode
     );
   }
 
-  providers.push(
-    createCrossChainProvider(PROTOCOLS.OIF, {
-      solverId: oifSolverId,
-      url: OIF_API_URL,
-      providerId: 'oif',
-      submissionModes,
-    }),
-    createCrossChainProvider(PROTOCOLS.RELAY, {
-      isTestnet,
-      providerId: 'relay',
-      submissionModes,
-    }),
-  );
+  if (isEnabledForMode('oif', submissionMode)) {
+    providers.push(
+      createCrossChainProvider(PROTOCOLS.OIF, {
+        solverId: oifSolverId,
+        url: OIF_API_URL,
+        providerId: 'oif',
+        submissionModes,
+      }),
+    );
+  }
 
-  if (!isGasless) {
+  if (isEnabledForMode('relay', submissionMode)) {
+    providers.push(
+      createCrossChainProvider(PROTOCOLS.RELAY, {
+        isTestnet,
+        providerId: 'relay',
+        submissionModes,
+      }),
+    );
+  }
+
+  if (isEnabledForMode('lifi-intents', submissionMode)) {
     providers.push(
       createCrossChainProvider(PROTOCOLS.LIFI_INTENTS, {
         orderServerUrl: lifiUrl,
@@ -93,7 +86,7 @@ export function buildExecutor(isTestnet: boolean, submissionMode: SubmissionMode
     );
   }
 
-  if (!isTestnet) {
+  if (!isTestnet && isEnabledForMode('bungee', submissionMode)) {
     providers.push(
       createCrossChainProvider(PROTOCOLS.BUNGEE, {
         tier: BungeeApiTier.Sandbox,
@@ -110,15 +103,9 @@ export function buildExecutor(isTestnet: boolean, submissionMode: SubmissionMode
   });
 }
 
-/**
- * Gets the display name for a provider by its ID
- * @param providerId - The provider identifier
- * @returns The display name or the provider ID if not found
- */
 export function getProviderDisplayName(providerId: string): string {
-  const config = PROVIDER_CONFIGS.find((c) => c.providerId === providerId);
-  return config?.displayName || providerId;
+  return findConfig(providerId)?.displayName ?? providerId;
 }
 
 /** Providers that support the buildQuote flow. */
-export const BUILD_QUOTE_PROVIDERS = PROVIDER_CONFIGS.filter((c) => c.supportsBuildQuote);
+export const BUILD_QUOTE_PROVIDERS: ProviderConfig[] = PROVIDER_CONFIGS.filter((c) => c.supportsBuildQuote);

--- a/examples/ui/app/cross-chain/stores/crossChainStore.ts
+++ b/examples/ui/app/cross-chain/stores/crossChainStore.ts
@@ -1,12 +1,14 @@
 import { create } from 'zustand';
 import { buildExecutor } from '../services/sdk';
-import type { Aggregator } from '@wonderland/interop-cross-chain';
+import type { Aggregator, SubmissionMode } from '@wonderland/interop-cross-chain';
 
 export type SwapFormMode = 'getQuotes' | 'buildQuote';
 
 const TESTNET_QUERY_PARAM = 'testnet';
 const MODE_QUERY_PARAM = 'mode';
 const MODE_BUILD_VALUE = 'build';
+const SUBMISSION_QUERY_PARAM = 'submission';
+const SUBMISSION_GASLESS_VALUE = 'gasless';
 
 function readIsTestnetFromUrl(): boolean {
   if (typeof window === 'undefined') return false;
@@ -19,23 +21,33 @@ function readModeFromUrl(): SwapFormMode {
   return value === MODE_BUILD_VALUE ? 'buildQuote' : 'getQuotes';
 }
 
+function readSubmissionModeFromUrl(): SubmissionMode {
+  if (typeof window === 'undefined') return 'user-transaction';
+  const value = new URLSearchParams(window.location.search).get(SUBMISSION_QUERY_PARAM);
+  return value === SUBMISSION_GASLESS_VALUE ? 'gasless' : 'user-transaction';
+}
+
 interface CrossChainState {
   isTestnet: boolean;
   executor: Aggregator;
   mode: SwapFormMode;
   buildQuoteProviderId: string;
+  submissionMode: SubmissionMode;
   setIsTestnet: (isTestnet: boolean) => void;
   setMode: (mode: SwapFormMode) => void;
   setBuildQuoteProviderId: (providerId: string) => void;
+  setSubmissionMode: (submissionMode: SubmissionMode) => void;
 }
 
 const initialIsTestnet = readIsTestnetFromUrl();
+const initialSubmissionMode = readSubmissionModeFromUrl();
 
 export const useCrossChainStore = create<CrossChainState>((set, get) => ({
   isTestnet: initialIsTestnet,
-  executor: buildExecutor(initialIsTestnet),
+  executor: buildExecutor(initialIsTestnet, initialSubmissionMode),
   mode: readModeFromUrl(),
   buildQuoteProviderId: 'across',
+  submissionMode: initialSubmissionMode,
 
   setIsTestnet: (isTestnet: boolean) => {
     if (isTestnet === get().isTestnet) return;
@@ -46,7 +58,7 @@ export const useCrossChainStore = create<CrossChainState>((set, get) => ({
       url.searchParams.delete(TESTNET_QUERY_PARAM);
     }
     window.history.replaceState({}, '', url.toString());
-    set({ isTestnet, executor: buildExecutor(isTestnet) });
+    set({ isTestnet, executor: buildExecutor(isTestnet, get().submissionMode) });
   },
 
   setMode: (mode: SwapFormMode) => {
@@ -65,4 +77,18 @@ export const useCrossChainStore = create<CrossChainState>((set, get) => ({
     set({ mode });
   },
   setBuildQuoteProviderId: (providerId: string) => set({ buildQuoteProviderId: providerId }),
+
+  setSubmissionMode: (submissionMode: SubmissionMode) => {
+    if (submissionMode === get().submissionMode) return;
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href);
+      if (submissionMode === 'gasless') {
+        url.searchParams.set(SUBMISSION_QUERY_PARAM, SUBMISSION_GASLESS_VALUE);
+      } else {
+        url.searchParams.delete(SUBMISSION_QUERY_PARAM);
+      }
+      window.history.replaceState({}, '', url.toString());
+    }
+    set({ submissionMode, executor: buildExecutor(get().isTestnet, submissionMode) });
+  },
 }));

--- a/packages/cross-chain/src/external.ts
+++ b/packages/cross-chain/src/external.ts
@@ -77,4 +77,5 @@ export {
     type TransactionStep,
     type GetQuotesError,
     type GetQuotesResponse,
+    type SubmissionMode,
 } from "./internal.js";


### PR DESCRIPTION
Closes [EFI-952](https://linear.app/defi-wonderland/issue/EFI-952/add-a-switch-to-the-ui-to-toggle-between-standard-transactions-and).

## Summary
- Adds a Transactions / Gasless segmented switch next to the network switch in the cross-chain demo.
- The selection is wired into `buildExecutor`, which passes `submissionModes: [mode]` to the OIF, Relay and Bungee providers and rebuilds the aggregator when the toggle changes.
- The choice is persisted in the URL as `?submission=gasless` (no parameter = `user-transaction`), mirroring the existing `?testnet=` / `?mode=` pattern.
- Exposes the `SubmissionMode` type from `@wonderland/interop-cross-chain` so the UI can type the toggle without duplicating the literal.

## Test plan
- [x] Used the UI to perform gasless transactions and it works as expected.