### PR TITLE
feat(cross-chain): wire eip-712 envelope validation into relay (EFI-955)

### DIFF
--- a/.changeset/eip712-envelope-validation-relay.md
+++ b/.changeset/eip712-envelope-validation-relay.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Wire the EIP-712 envelope validators into the Relay signature flow. The Relay quote adapter now runs `validateRelaySignatureEnvelope` before surfacing any EIP-712 signature step, so tampered envelopes are rejected with a typed `Eip712EnvelopeMismatch` before the wallet is prompted.
+
+The validator dispatches by `primaryType` to the Permit2 or EIP-3009 path, enforces Relay-specific invariants (no native input asset, Permit2 domain without `version`, EIP-3009 domain with a non-empty `version`), and reads the recipient field from the envelope (`spender` for Permit2, `to` for EIP-3009) to assert it is a well-formed address and is not the user.

--- a/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
@@ -76,9 +76,15 @@ export function adaptQuote(
     const fees = adaptFees(response);
     const fallbackToken = extractFallbackToken(params, response);
 
+    // Use quoted input so the envelope cap also binds on `exact-output`.
+    const paramsForValidation: QuoteRequest = {
+        ...params,
+        input: { ...params.input, amount: currencyIn?.amount ?? params.input.amount },
+    };
+
     return {
         order: {
-            steps: nonApproveSteps.flatMap((step) => adaptRelaySteps(step, params)),
+            steps: nonApproveSteps.flatMap((step) => adaptRelaySteps(step, paramsForValidation)),
             ...(allowances.length > 0 && { checks: { allowances } }),
         },
         preview: {

--- a/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
@@ -6,6 +6,7 @@ import type { QuoteRequest, Step } from "../../../internal.js";
 import type { RelayQuoteResponse, RelayQuoteStep, RelaySignatureStep } from "../schemas.js";
 import { toCanonicalNativeAddress } from "../../../core/utils/token.js";
 import { ProviderGetQuoteFailure } from "../../../internal.js";
+import { validateRelaySignatureEnvelope } from "../validators/signatureEnvelopeValidator.js";
 import { adaptFees } from "./quoteFeeAdapter.js";
 
 /**
@@ -77,7 +78,7 @@ export function adaptQuote(
 
     return {
         order: {
-            steps: nonApproveSteps.flatMap((step) => adaptRelaySteps(step)),
+            steps: nonApproveSteps.flatMap((step) => adaptRelaySteps(step, params)),
             ...(allowances.length > 0 && { checks: { allowances } }),
         },
         preview: {
@@ -139,9 +140,9 @@ function extractFallbackToken(
 }
 
 /** Map a single Relay step to SDK Step entries (one per incomplete item). */
-export function adaptRelaySteps(step: RelayQuoteStep): Step[] {
+export function adaptRelaySteps(step: RelayQuoteStep, params: QuoteRequest): Step[] {
     if (step.kind === "signature") {
-        return adaptSignatureStep(step);
+        return adaptSignatureStep(step, params);
     }
 
     return step.items
@@ -169,7 +170,7 @@ export function adaptRelaySteps(step: RelayQuoteStep): Step[] {
 }
 
 /** Map a Relay signature step to SDK SignatureStep entries (EIP-712 only). */
-function adaptSignatureStep(step: RelaySignatureStep): Step[] {
+function adaptSignatureStep(step: RelaySignatureStep, params: QuoteRequest): Step[] {
     return step.items.flatMap((item) => {
         if (item.status !== "incomplete") return [];
 
@@ -180,6 +181,16 @@ function adaptSignatureStep(step: RelaySignatureStep): Step[] {
                 `Unsupported signature kind "${sign.signatureKind}". Only EIP-712 signatures are currently supported.`,
             );
         }
+
+        validateRelaySignatureEnvelope(
+            {
+                domain: sign.domain,
+                primaryType: sign.primaryType,
+                types: sign.types,
+                message: sign.value,
+            },
+            params,
+        );
 
         return {
             kind: "signature" as const,

--- a/packages/cross-chain/src/protocols/relay/validators/signatureEnvelopeValidator.ts
+++ b/packages/cross-chain/src/protocols/relay/validators/signatureEnvelopeValidator.ts
@@ -1,0 +1,159 @@
+import type { Address } from "viem";
+import { getAddress, isAddressEqual } from "viem";
+
+import type { Eip712MismatchField } from "../../../core/errors/Eip712EnvelopeMismatch.exception.js";
+import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
+import type { Eip712Envelope } from "../../../core/types/eip712.js";
+import {
+    EIP3009_PRIMARY_TYPES,
+    PERMIT2_ADDRESS,
+    PERMIT2_BATCH_PRIMARY_TYPES,
+    PERMIT2_SINGLE_PRIMARY_TYPES,
+} from "../../../core/constants/eip712.js";
+import { Eip712EnvelopeMismatch } from "../../../core/errors/Eip712EnvelopeMismatch.exception.js";
+import { readAddressField } from "../../../core/utils/eip712Readers.js";
+import { isNativeAddress } from "../../../core/utils/token.js";
+import {
+    validateEnvelopeDomain,
+    validatePrimaryType,
+} from "../../../core/validators/eip712EnvelopeValidator.js";
+import { validateEip3009Message } from "../../../core/validators/eip3009MessageValidator.js";
+import { validatePermit2Message } from "../../../core/validators/permit2MessageValidator.js";
+
+const PROVIDER_NAME = "relay";
+
+type Mechanism = "Permit2" | "EIP-3009";
+
+const RELAY_PERMIT2_PRIMARY_TYPES: ReadonlySet<string> = new Set<string>([
+    ...PERMIT2_SINGLE_PRIMARY_TYPES,
+    ...PERMIT2_BATCH_PRIMARY_TYPES,
+]);
+
+const RELAY_PRIMARY_TYPES: ReadonlySet<string> = new Set<string>([
+    ...RELAY_PERMIT2_PRIMARY_TYPES,
+    ...EIP3009_PRIMARY_TYPES,
+]);
+
+/**
+ * Validate a Relay-issued EIP-712 envelope against the user-supplied quote request.
+ *
+ * Acts as the protocol-specific Facade in front of `core/validators/`: dispatches
+ * by `primaryType` to the Permit2 or EIP-3009 path and enforces Relay-specific
+ * invariants (no native input asset, Permit2 domain has no `version`, EIP-3009
+ * domain carries a non-empty `version`, recipient field is not the user).
+ */
+export function validateRelaySignatureEnvelope(
+    envelope: Eip712Envelope,
+    params: QuoteRequest,
+): void {
+    validatePrimaryType(envelope, RELAY_PRIMARY_TYPES, PROVIDER_NAME);
+
+    const maxAmount = params.input.amount !== undefined ? BigInt(params.input.amount) : undefined;
+    const user = getAddress(params.user);
+
+    if (EIP3009_PRIMARY_TYPES.has(envelope.primaryType)) {
+        validateEip3009Envelope(envelope, params, user, maxAmount);
+        return;
+    }
+
+    validatePermit2Envelope(envelope, params, user, maxAmount);
+}
+
+function validatePermit2Envelope(
+    envelope: Eip712Envelope,
+    params: QuoteRequest,
+    user: Address,
+    maxAmount: bigint | undefined,
+): void {
+    guardAgainstNativeAsset(envelope, params, "Permit2");
+    guardPermit2DomainHasNoVersion(envelope);
+    validateEnvelopeDomain(envelope, {
+        chainId: params.input.chainId,
+        verifyingContracts: [PERMIT2_ADDRESS],
+        provider: PROVIDER_NAME,
+    });
+    const spender = readRecipientField(envelope, ["spender"], "spender", user);
+    validatePermit2Message(envelope, {
+        provider: PROVIDER_NAME,
+        spender,
+        inputToken: getAddress(params.input.assetAddress),
+        maxAmount,
+    });
+}
+
+function validateEip3009Envelope(
+    envelope: Eip712Envelope,
+    params: QuoteRequest,
+    user: Address,
+    maxAmount: bigint | undefined,
+): void {
+    guardAgainstNativeAsset(envelope, params, "EIP-3009");
+    validateEnvelopeDomain(envelope, {
+        chainId: params.input.chainId,
+        verifyingContracts: [getAddress(params.input.assetAddress)],
+        provider: PROVIDER_NAME,
+    });
+    guardEip3009DomainVersion(envelope);
+    const to = readRecipientField(envelope, ["to"], "to", user);
+    validateEip3009Message(envelope, {
+        provider: PROVIDER_NAME,
+        user,
+        to,
+        maxValue: maxAmount,
+    });
+}
+
+function readRecipientField(
+    envelope: Eip712Envelope,
+    path: ReadonlyArray<string>,
+    field: Eip712MismatchField,
+    user: Address,
+): Address {
+    const recipient = readAddressField({ envelope, path, field, provider: PROVIDER_NAME });
+    if (isAddressEqual(recipient, user)) {
+        throw new Eip712EnvelopeMismatch({
+            field,
+            provider: PROVIDER_NAME,
+            primaryType: envelope.primaryType,
+            received: recipient,
+            cause: "recipient must not be the user",
+        });
+    }
+    return recipient;
+}
+
+function guardAgainstNativeAsset(
+    envelope: Eip712Envelope,
+    params: QuoteRequest,
+    mechanism: Mechanism,
+): void {
+    if (!isNativeAddress(params.input.assetAddress, "eip155")) return;
+    throw new Eip712EnvelopeMismatch({
+        field: "structure",
+        provider: PROVIDER_NAME,
+        primaryType: envelope.primaryType,
+        cause: `${mechanism} envelope rejected: input asset is the native placeholder`,
+    });
+}
+
+function guardEip3009DomainVersion(envelope: Eip712Envelope): void {
+    const version = envelope.domain.version;
+    if (typeof version === "string" && version.length > 0) return;
+    throw new Eip712EnvelopeMismatch({
+        field: "domainVersion",
+        provider: PROVIDER_NAME,
+        primaryType: envelope.primaryType,
+        received: String(version),
+    });
+}
+
+function guardPermit2DomainHasNoVersion(envelope: Eip712Envelope): void {
+    if (envelope.domain.version === undefined) return;
+    throw new Eip712EnvelopeMismatch({
+        field: "domainVersion",
+        provider: PROVIDER_NAME,
+        primaryType: envelope.primaryType,
+        expected: "absent",
+        received: String(envelope.domain.version),
+    });
+}

--- a/packages/cross-chain/src/protocols/relay/validators/signatureEnvelopeValidator.ts
+++ b/packages/cross-chain/src/protocols/relay/validators/signatureEnvelopeValidator.ts
@@ -1,7 +1,6 @@
 import type { Address } from "viem";
 import { getAddress, isAddressEqual } from "viem";
 
-import type { Eip712MismatchField } from "../../../core/errors/Eip712EnvelopeMismatch.exception.js";
 import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
 import type { Eip712Envelope } from "../../../core/types/eip712.js";
 import {
@@ -23,6 +22,7 @@ import { validatePermit2Message } from "../../../core/validators/permit2MessageV
 const PROVIDER_NAME = "relay";
 
 type Mechanism = "Permit2" | "EIP-3009";
+type RecipientField = "spender" | "to";
 
 const RELAY_PERMIT2_PRIMARY_TYPES: ReadonlySet<string> = new Set<string>([
     ...PERMIT2_SINGLE_PRIMARY_TYPES,
@@ -72,7 +72,7 @@ function validatePermit2Envelope(
         verifyingContracts: [PERMIT2_ADDRESS],
         provider: PROVIDER_NAME,
     });
-    const spender = readRecipientField(envelope, ["spender"], "spender", user);
+    const spender = readRecipientField(envelope, "spender", user);
     validatePermit2Message(envelope, {
         provider: PROVIDER_NAME,
         spender,
@@ -94,7 +94,7 @@ function validateEip3009Envelope(
         provider: PROVIDER_NAME,
     });
     guardEip3009DomainVersion(envelope);
-    const to = readRecipientField(envelope, ["to"], "to", user);
+    const to = readRecipientField(envelope, "to", user);
     validateEip3009Message(envelope, {
         provider: PROVIDER_NAME,
         user,
@@ -105,11 +105,15 @@ function validateEip3009Envelope(
 
 function readRecipientField(
     envelope: Eip712Envelope,
-    path: ReadonlyArray<string>,
-    field: Eip712MismatchField,
+    field: RecipientField,
     user: Address,
 ): Address {
-    const recipient = readAddressField({ envelope, path, field, provider: PROVIDER_NAME });
+    const recipient = readAddressField({
+        envelope,
+        path: [field],
+        field,
+        provider: PROVIDER_NAME,
+    });
     if (isAddressEqual(recipient, user)) {
         throw new Eip712EnvelopeMismatch({
             field,

--- a/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
@@ -599,6 +599,70 @@ describe("adaptQuote — signature only (permit, EIP-2612 token)", () => {
     });
 });
 
+describe("adaptQuote — exact-output amount cap", () => {
+    const QUOTED_INPUT_AMOUNT = "1500000";
+
+    const exactOutputRequest: QuoteRequest = {
+        user: VALID_ADDRESS,
+        input: { chainId: ORIGIN_CHAIN_ID, assetAddress: VALID_ADDRESS },
+        output: {
+            chainId: DESTINATION_CHAIN_ID,
+            assetAddress: VALID_ADDRESS,
+            amount: OUTPUT_AMOUNT,
+        },
+        swapType: "exact-output",
+    };
+
+    function responseWithEnvelopeAmount(envelopeAmount: string): RelayQuoteResponse {
+        const base = makeRelayQuoteResponse();
+        return {
+            ...base,
+            steps: [
+                makeSignatureStep({
+                    items: [
+                        {
+                            status: "incomplete",
+                            data: {
+                                sign: {
+                                    signatureKind: "eip712",
+                                    domain: EIP712_DOMAIN,
+                                    types: EIP712_TYPES,
+                                    value: {
+                                        ...EIP712_VALUE,
+                                        permitted: { token: VALID_ADDRESS, amount: envelopeAmount },
+                                    },
+                                    primaryType: "PermitTransferFrom",
+                                },
+                                post: POST_DATA,
+                            },
+                        },
+                    ],
+                } as Partial<RelayQuoteStep>),
+            ],
+            details: {
+                ...base.details!,
+                currencyIn: { ...base.details!.currencyIn!, amount: QUOTED_INPUT_AMOUNT },
+            },
+        };
+    }
+
+    it("rejects a signature envelope that inflates above the quoted input amount", () => {
+        expect(() =>
+            adaptQuote(exactOutputRequest, responseWithEnvelopeAmount("9999999999"), PROVIDER_ID),
+        ).toThrowError(/amount/);
+    });
+
+    it("accepts a signature envelope matching the quoted input amount", () => {
+        expect(() =>
+            adaptQuote(
+                exactOutputRequest,
+                responseWithEnvelopeAmount(QUOTED_INPUT_AMOUNT),
+                PROVIDER_ID,
+            ),
+        ).not.toThrow();
+    });
+});
+
 describe("adaptQuote — approve + signature (permit, non-EIP-2612 token)", () => {
     it("maps signature step and extracts approve as allowance check", () => {
         const approveCalldata = makeApproveCalldata(SPENDER_ADDRESS, 1000000n);

--- a/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
@@ -17,6 +17,8 @@ import {
 const VALID_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
 const RECIPIENT_ADDRESS = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
 const SPENDER_ADDRESS = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
+const PERMIT2_ADDRESS_FIXTURE = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
+const RELAY_SOLVER_FIXTURE = "0xCCC88a9d1B4ed6b0eABA998850414b24F1C315bE";
 const TOKEN_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const ORIGIN_CHAIN_ID = 1;
 const DESTINATION_CHAIN_ID = 10;
@@ -383,9 +385,10 @@ describe("adaptQuote", () => {
 
 describe("adaptRelaySteps", () => {
     const baseStep = makeRelayQuoteResponse().steps[0]!;
+    const params = makeQuoteRequest();
 
     it("maps incomplete transaction items to SDK steps", () => {
-        const steps = adaptRelaySteps(baseStep);
+        const steps = adaptRelaySteps(baseStep, params);
         expect(steps).toHaveLength(1);
         expect(steps[0]).toMatchObject({
             kind: "transaction",
@@ -400,7 +403,7 @@ describe("adaptRelaySteps", () => {
             { ...baseStep.items[0]!, status: "complete" as const },
             { ...baseStep.items[0]!, status: "incomplete" as const },
         ];
-        expect(adaptRelaySteps({ ...baseStep, items: withComplete })).toHaveLength(1);
+        expect(adaptRelaySteps({ ...baseStep, items: withComplete }, params)).toHaveLength(1);
     });
 
     it("includes gas params when present and omits when '0'", () => {
@@ -414,7 +417,7 @@ describe("adaptRelaySteps", () => {
                 },
             },
         ];
-        const steps = adaptRelaySteps({ ...baseStep, items: withGas });
+        const steps = adaptRelaySteps({ ...baseStep, items: withGas }, params);
         if (steps[0]!.kind === "transaction") {
             expect(steps[0]!.transaction.gas).toBe("21000");
             expect(steps[0]!.transaction.maxFeePerGas).toBe("30000000000");
@@ -423,7 +426,7 @@ describe("adaptRelaySteps", () => {
         const withZeroGas = [
             { ...baseStep.items[0]!, data: { ...baseStep.items[0]!.data, gas: "0" } },
         ];
-        const zeroSteps = adaptRelaySteps({ ...baseStep, items: withZeroGas });
+        const zeroSteps = adaptRelaySteps({ ...baseStep, items: withZeroGas }, params);
         if (zeroSteps[0]!.kind === "transaction") {
             expect(zeroSteps[0]!.transaction.gas).toBeUndefined();
         }
@@ -432,22 +435,32 @@ describe("adaptRelaySteps", () => {
 
 // ── Signature Step Tests ────────────────────────────────
 
+const FUTURE_DEADLINE = Math.floor(Date.now() / 1000) + 3600;
+
 const EIP712_DOMAIN = {
     name: "Permit2",
     chainId: ORIGIN_CHAIN_ID,
-    verifyingContract: VALID_ADDRESS,
+    verifyingContract: PERMIT2_ADDRESS_FIXTURE,
 };
 
 const EIP712_TYPES = {
-    PermitBatch: [
-        { name: "details", type: "PermitDetails[]" },
+    PermitTransferFrom: [
+        { name: "permitted", type: "TokenPermissions" },
         { name: "spender", type: "address" },
+        { name: "nonce", type: "uint256" },
+        { name: "deadline", type: "uint256" },
+    ],
+    TokenPermissions: [
+        { name: "token", type: "address" },
+        { name: "amount", type: "uint256" },
     ],
 };
 
 const EIP712_VALUE = {
-    spender: VALID_ADDRESS,
-    sigDeadline: "1700000000",
+    permitted: { token: VALID_ADDRESS, amount: INPUT_AMOUNT },
+    spender: RELAY_SOLVER_FIXTURE,
+    nonce: "1",
+    deadline: FUTURE_DEADLINE,
 };
 
 const POST_DATA = {
@@ -472,7 +485,7 @@ function makeSignatureStep(overrides?: Partial<RelayQuoteStep>): RelayQuoteStep 
                         domain: EIP712_DOMAIN,
                         types: EIP712_TYPES,
                         value: EIP712_VALUE,
-                        primaryType: "PermitBatch",
+                        primaryType: "PermitTransferFrom",
                     },
                     post: POST_DATA,
                 },
@@ -483,8 +496,10 @@ function makeSignatureStep(overrides?: Partial<RelayQuoteStep>): RelayQuoteStep 
 }
 
 describe("adaptRelaySteps — signature steps", () => {
+    const params = makeQuoteRequest();
+
     it("maps EIP-712 signature step to SDK SignatureStep", () => {
-        const steps = adaptRelaySteps(makeSignatureStep());
+        const steps = adaptRelaySteps(makeSignatureStep(), params);
         expect(steps).toHaveLength(1);
         expect(steps[0]!.kind).toBe("signature");
 
@@ -493,7 +508,7 @@ describe("adaptRelaySteps — signature steps", () => {
             expect(steps[0]!.description).toBe("Sign permit to authorize");
             expect(steps[0]!.signaturePayload.signatureType).toBe("eip712");
             expect(steps[0]!.signaturePayload.domain).toEqual(EIP712_DOMAIN);
-            expect(steps[0]!.signaturePayload.primaryType).toBe("PermitBatch");
+            expect(steps[0]!.signaturePayload.primaryType).toBe("PermitTransferFrom");
             expect(steps[0]!.signaturePayload.types).toEqual(EIP712_TYPES);
             expect(steps[0]!.signaturePayload.message).toEqual(EIP712_VALUE);
         }
@@ -511,11 +526,11 @@ describe("adaptRelaySteps — signature steps", () => {
                 },
             ],
         } as Partial<RelayQuoteStep>);
-        expect(() => adaptRelaySteps(eip191Step)).toThrow(ProviderGetQuoteFailure);
+        expect(() => adaptRelaySteps(eip191Step, params)).toThrow(ProviderGetQuoteFailure);
     });
 
     it("stores post data and step id in metadata", () => {
-        const steps = adaptRelaySteps(makeSignatureStep());
+        const steps = adaptRelaySteps(makeSignatureStep(), params);
         expect(steps[0]!.metadata).toEqual({
             relayPostData: POST_DATA,
             relayStepId: "authorize1",
@@ -533,14 +548,14 @@ describe("adaptRelaySteps — signature steps", () => {
                             domain: EIP712_DOMAIN,
                             types: EIP712_TYPES,
                             value: EIP712_VALUE,
-                            primaryType: "PermitBatch",
+                            primaryType: "PermitTransferFrom",
                         },
                         post: POST_DATA,
                     },
                 },
             ],
         } as Partial<RelayQuoteStep>);
-        expect(adaptRelaySteps(step)).toHaveLength(0);
+        expect(adaptRelaySteps(step, params)).toHaveLength(0);
     });
 });
 

--- a/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
@@ -204,7 +204,7 @@ describe("adaptQuote", () => {
         expect(quote.quoteId).toBeUndefined();
     });
 
-    it("extracts approve steps into order.checks.allowances", () => {
+    it("splits approve steps into order.checks.allowances and keeps the rest in order.steps", () => {
         const approveAmount = 1000000n;
         const approveCalldata = makeApproveCalldata(SPENDER_ADDRESS, approveAmount);
 
@@ -249,65 +249,20 @@ describe("adaptQuote", () => {
 
         const quote = adaptQuote(makeQuoteRequest(), response, PROVIDER_ID);
 
-        expect(quote.order.checks?.allowances).toHaveLength(1);
-        expect(quote.order.checks!.allowances![0]).toEqual({
-            chainId: ORIGIN_CHAIN_ID,
-            tokenAddress: TOKEN_ADDRESS,
-            owner: VALID_ADDRESS,
-            spender: SPENDER_ADDRESS,
-            required: approveAmount.toString(),
-        });
-    });
-
-    it("order.steps only contains non-approve steps", () => {
-        const approveCalldata = makeApproveCalldata(SPENDER_ADDRESS, 1000000n);
-
-        const response = makeRelayQuoteResponse({
-            steps: [
-                {
-                    id: "approve",
-                    action: "Approve token",
-                    description: "Approve USDC",
-                    kind: "transaction",
-                    items: [
-                        {
-                            status: "incomplete",
-                            data: {
-                                to: TOKEN_ADDRESS,
-                                data: approveCalldata,
-                                chainId: ORIGIN_CHAIN_ID,
-                            },
-                        },
-                    ],
-                },
-                {
-                    id: "deposit",
-                    action: "Confirm transaction",
-                    description: STEP_DESCRIPTION,
-                    kind: "transaction",
-                    requestId: REQUEST_ID,
-                    items: [
-                        {
-                            status: "incomplete",
-                            data: {
-                                to: VALID_ADDRESS,
-                                data: TX_DATA,
-                                value: INPUT_AMOUNT,
-                                chainId: ORIGIN_CHAIN_ID,
-                            },
-                        },
-                    ],
-                },
-            ],
-        });
-
-        const quote = adaptQuote(makeQuoteRequest(), response, PROVIDER_ID);
-
+        expect(quote.order.checks?.allowances).toEqual([
+            {
+                chainId: ORIGIN_CHAIN_ID,
+                tokenAddress: TOKEN_ADDRESS,
+                owner: VALID_ADDRESS,
+                spender: SPENDER_ADDRESS,
+                required: approveAmount.toString(),
+            },
+        ]);
         expect(quote.order.steps).toHaveLength(1);
-        expect(quote.order.steps[0]!.kind).toBe("transaction");
-        if (quote.order.steps[0]!.kind === "transaction") {
-            expect(quote.order.steps[0]!.transaction.to).toBe(VALID_ADDRESS);
-        }
+        expect(quote.order.steps[0]).toMatchObject({
+            kind: "transaction",
+            transaction: { to: VALID_ADDRESS },
+        });
     });
 
     it("order.checks is undefined when there are no approve steps", () => {

--- a/packages/cross-chain/test/protocols/relay/validators/signatureEnvelopeValidator.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/validators/signatureEnvelopeValidator.spec.ts
@@ -8,16 +8,16 @@ import { NATIVE_ASSET_ADDRESS } from "../../../../src/core/utils/token.js";
 import { validateRelaySignatureEnvelope } from "../../../../src/protocols/relay/validators/signatureEnvelopeValidator.js";
 
 const RELAY_SOLVER = "0xCCC88a9d1B4ed6b0eABA998850414b24F1C315bE";
-
 const USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
-
 const USER = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
 const TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const RECIPIENT = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8";
+const FAKE_ADDRESS = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 const ORIGIN_CHAIN_ID = 1;
 const DESTINATION_CHAIN_ID = 10;
 const INPUT_AMOUNT = "1000000";
 const FUTURE_DEADLINE = Math.floor(Date.now() / 1000) + 3600;
+const PAST_DEADLINE = Math.floor(Date.now() / 1000) - 3600;
 
 function makeParams(overrides?: Partial<QuoteRequest>): QuoteRequest {
     return {
@@ -27,6 +27,18 @@ function makeParams(overrides?: Partial<QuoteRequest>): QuoteRequest {
         ...overrides,
     };
 }
+
+const eip3009Params = makeParams({
+    input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
+});
+
+const nativeInputParams = makeParams({
+    input: {
+        chainId: ORIGIN_CHAIN_ID,
+        assetAddress: NATIVE_ASSET_ADDRESS,
+        amount: INPUT_AMOUNT,
+    },
+});
 
 function makePermit2Envelope(overrides?: Partial<Eip712Envelope>): Eip712Envelope {
     return {
@@ -66,318 +78,238 @@ function makeEip3009Envelope(overrides?: Partial<Eip712Envelope>): Eip712Envelop
 }
 
 describe("validateRelaySignatureEnvelope", () => {
-    it("accepts a valid Permit2 envelope", () => {
-        expect(() =>
-            validateRelaySignatureEnvelope(makePermit2Envelope(), makeParams()),
-        ).not.toThrow();
-    });
-
-    it("rejects tampered chainId", () => {
-        const envelope = makePermit2Envelope({
-            domain: { chainId: 137, verifyingContract: PERMIT2_ADDRESS },
+    describe("Permit2", () => {
+        it("accepts a valid envelope", () => {
+            expect(() =>
+                validateRelaySignatureEnvelope(makePermit2Envelope(), makeParams()),
+            ).not.toThrow();
         });
-        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
-            /chainId/,
-        );
-    });
 
-    it("rejects a Permit2 envelope whose verifyingContract is not canonical Permit2", () => {
-        const envelope = makePermit2Envelope({
-            domain: {
-                chainId: ORIGIN_CHAIN_ID,
-                verifyingContract: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        it.each([
+            { name: "primaryType outside Relay allow-list", primaryType: "FooBar" },
+            { name: "AllowanceTransfer.Permit", primaryType: "Permit" },
+            { name: "AllowanceTransfer.PermitBatch", primaryType: "PermitBatch" },
+        ])("rejects $name", ({ primaryType }) => {
+            expect(() =>
+                validateRelaySignatureEnvelope(makePermit2Envelope({ primaryType }), makeParams()),
+            ).toThrowError(/primaryType/);
+        });
+
+        it.each([
+            {
+                name: "tampered chainId",
+                domain: { chainId: 137, verifyingContract: PERMIT2_ADDRESS },
+                expected: /chainId/,
             },
-        });
-        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
-            /verifyingContract/,
-        );
-    });
-
-    it("rejects a primaryType outside the Relay allow-list", () => {
-        const envelope = makePermit2Envelope({ primaryType: "FooBar" });
-        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
-            /primaryType/,
-        );
-    });
-
-    it("rejects Permit2 AllowanceTransfer types (Permit / PermitBatch)", () => {
-        // AllowanceTransfer envelopes use `details`, not `permitted`; if they slipped
-        // past the allow-list, validatePermit2Message would reject them as malformed.
-        for (const primaryType of ["Permit", "PermitBatch"]) {
-            const envelope = makePermit2Envelope({ primaryType });
-            expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
-                /primaryType/,
-            );
-        }
-    });
-
-    it("rejects a tampered token in permitted", () => {
-        const envelope = makePermit2Envelope({
-            message: {
-                permitted: {
-                    token: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-                    amount: INPUT_AMOUNT,
+            {
+                name: "non-canonical verifyingContract",
+                domain: { chainId: ORIGIN_CHAIN_ID, verifyingContract: FAKE_ADDRESS },
+                expected: /verifyingContract/,
+            },
+            {
+                name: "domain carrying `version`",
+                domain: {
+                    chainId: ORIGIN_CHAIN_ID,
+                    verifyingContract: PERMIT2_ADDRESS,
+                    version: "1",
                 },
-                spender: RELAY_SOLVER,
-                nonce: "1",
-                deadline: FUTURE_DEADLINE,
+                expected: /domainVersion/,
             },
+        ])("rejects $name", ({ domain, expected }) => {
+            expect(() =>
+                validateRelaySignatureEnvelope(makePermit2Envelope({ domain }), makeParams()),
+            ).toThrowError(expected);
         });
-        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(/token/);
-    });
 
-    it("rejects an inflated amount in permitted", () => {
-        const envelope = makePermit2Envelope({
-            message: {
-                permitted: { token: TOKEN, amount: "99999999999" },
-                spender: RELAY_SOLVER,
-                nonce: "1",
-                deadline: FUTURE_DEADLINE,
+        it.each([
+            {
+                name: "tampered token in `permitted`",
+                message: {
+                    permitted: { token: FAKE_ADDRESS, amount: INPUT_AMOUNT },
+                    spender: RELAY_SOLVER,
+                    nonce: "1",
+                    deadline: FUTURE_DEADLINE,
+                },
+                expected: /token/,
             },
-        });
-        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(/amount/);
-    });
-
-    it("rejects an expired deadline", () => {
-        const envelope = makePermit2Envelope({
-            message: {
-                permitted: { token: TOKEN, amount: INPUT_AMOUNT },
-                spender: RELAY_SOLVER,
-                nonce: "1",
-                deadline: Math.floor(Date.now() / 1000) - 3600,
+            {
+                name: "inflated amount in `permitted`",
+                message: {
+                    permitted: { token: TOKEN, amount: "99999999999" },
+                    spender: RELAY_SOLVER,
+                    nonce: "1",
+                    deadline: FUTURE_DEADLINE,
+                },
+                expected: /amount/,
             },
-        });
-        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
-            /deadline/,
-        );
-    });
-
-    it("rejects a Permit2 envelope whose domain carries `version`", () => {
-        const envelope = makePermit2Envelope({
-            domain: {
-                chainId: ORIGIN_CHAIN_ID,
-                verifyingContract: PERMIT2_ADDRESS,
-                version: "1",
+            {
+                name: "expired deadline",
+                message: {
+                    permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+                    spender: RELAY_SOLVER,
+                    nonce: "1",
+                    deadline: PAST_DEADLINE,
+                },
+                expected: /deadline/,
             },
-        });
-        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
-            /domainVersion/,
-        );
-    });
-
-    it("rejects a Permit2 envelope when the input is the native asset placeholder", () => {
-        const params = makeParams({
-            input: {
-                chainId: ORIGIN_CHAIN_ID,
-                assetAddress: NATIVE_ASSET_ADDRESS,
-                amount: INPUT_AMOUNT,
+            {
+                name: "spender equals the user",
+                message: {
+                    permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+                    spender: USER,
+                    nonce: "1",
+                    deadline: FUTURE_DEADLINE,
+                },
+                expected: /spender/,
             },
-        });
-        expect(() => validateRelaySignatureEnvelope(makePermit2Envelope(), params)).toThrow(
-            Eip712EnvelopeMismatch,
-        );
-    });
-
-    it("accepts a valid EIP-3009 envelope when the input token signed it", () => {
-        const params = makeParams({
-            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
-        });
-        expect(() => validateRelaySignatureEnvelope(makeEip3009Envelope(), params)).not.toThrow();
-    });
-
-    it("accepts TransferWithAuthorization as well as ReceiveWithAuthorization", () => {
-        const params = makeParams({
-            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
-        });
-        const envelope = makeEip3009Envelope({ primaryType: "TransferWithAuthorization" });
-        expect(() => validateRelaySignatureEnvelope(envelope, params)).not.toThrow();
-    });
-
-    it("rejects an EIP-3009 envelope signed by a contract other than the input token", () => {
-        const params = makeParams({
-            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
-        });
-        const envelope = makeEip3009Envelope({
-            domain: {
-                name: "USD Coin",
-                version: "2",
-                chainId: ORIGIN_CHAIN_ID,
-                verifyingContract: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            {
+                name: "spender field missing",
+                message: {
+                    permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+                    nonce: "1",
+                    deadline: FUTURE_DEADLINE,
+                },
+                expected: /spender/,
             },
+            {
+                name: "spender is not a string address",
+                message: {
+                    permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+                    spender: 42,
+                    nonce: "1",
+                    deadline: FUTURE_DEADLINE,
+                },
+                expected: /spender/,
+            },
+        ])("rejects $name", ({ message, expected }) => {
+            expect(() =>
+                validateRelaySignatureEnvelope(makePermit2Envelope({ message }), makeParams()),
+            ).toThrowError(expected);
         });
-        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(
-            /verifyingContract/,
-        );
+
+        it("rejects when input is the native asset placeholder", () => {
+            expect(() =>
+                validateRelaySignatureEnvelope(makePermit2Envelope(), nativeInputParams),
+            ).toThrow(Eip712EnvelopeMismatch);
+        });
     });
 
-    it("rejects an EIP-3009 envelope whose `from` differs from the user", () => {
-        const params = makeParams({
-            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
+    describe("EIP-3009", () => {
+        it.each([
+            { primaryType: "ReceiveWithAuthorization" },
+            { primaryType: "TransferWithAuthorization" },
+        ])("accepts a valid $primaryType envelope", ({ primaryType }) => {
+            expect(() =>
+                validateRelaySignatureEnvelope(makeEip3009Envelope({ primaryType }), eip3009Params),
+            ).not.toThrow();
         });
-        const envelope = makeEip3009Envelope({
-            message: {
-                from: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-                to: RELAY_SOLVER,
-                value: INPUT_AMOUNT,
-                validAfter: 0,
-                validBefore: FUTURE_DEADLINE,
-                nonce: "0xabcd",
-            },
-        });
-        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(/user/);
-    });
 
-    it("rejects an EIP-3009 envelope with an inflated value", () => {
-        const params = makeParams({
-            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
-        });
-        const envelope = makeEip3009Envelope({
-            message: {
-                from: USER,
-                to: RELAY_SOLVER,
-                value: "999999999999",
-                validAfter: 0,
-                validBefore: FUTURE_DEADLINE,
-                nonce: "0xabcd",
+        it.each([
+            {
+                name: "verifyingContract is not the input token",
+                domain: {
+                    name: "USD Coin",
+                    version: "2",
+                    chainId: ORIGIN_CHAIN_ID,
+                    verifyingContract: FAKE_ADDRESS,
+                },
+                expected: /verifyingContract/,
             },
+            {
+                name: "domain missing `version`",
+                domain: {
+                    name: "USD Coin",
+                    chainId: ORIGIN_CHAIN_ID,
+                    verifyingContract: USDC_BASE,
+                },
+                expected: /domainVersion/,
+            },
+            {
+                name: "domain `version` is empty",
+                domain: {
+                    name: "USD Coin",
+                    version: "",
+                    chainId: ORIGIN_CHAIN_ID,
+                    verifyingContract: USDC_BASE,
+                },
+                expected: /domainVersion/,
+            },
+        ])("rejects $name", ({ domain, expected }) => {
+            expect(() =>
+                validateRelaySignatureEnvelope(makeEip3009Envelope({ domain }), eip3009Params),
+            ).toThrowError(expected);
         });
-        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(/amount/);
-    });
 
-    it("rejects an EIP-3009 envelope with an expired validBefore", () => {
-        const params = makeParams({
-            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
-        });
-        const envelope = makeEip3009Envelope({
-            message: {
-                from: USER,
-                to: RELAY_SOLVER,
-                value: INPUT_AMOUNT,
-                validAfter: 0,
-                validBefore: Math.floor(Date.now() / 1000) - 3600,
-                nonce: "0xabcd",
+        it.each([
+            {
+                name: "`from` differs from the user",
+                message: {
+                    from: FAKE_ADDRESS,
+                    to: RELAY_SOLVER,
+                    value: INPUT_AMOUNT,
+                    validAfter: 0,
+                    validBefore: FUTURE_DEADLINE,
+                    nonce: "0xabcd",
+                },
+                expected: /user/,
             },
+            {
+                name: "inflated `value`",
+                message: {
+                    from: USER,
+                    to: RELAY_SOLVER,
+                    value: "999999999999",
+                    validAfter: 0,
+                    validBefore: FUTURE_DEADLINE,
+                    nonce: "0xabcd",
+                },
+                expected: /amount/,
+            },
+            {
+                name: "expired `validBefore`",
+                message: {
+                    from: USER,
+                    to: RELAY_SOLVER,
+                    value: INPUT_AMOUNT,
+                    validAfter: 0,
+                    validBefore: PAST_DEADLINE,
+                    nonce: "0xabcd",
+                },
+                expected: /deadline/,
+            },
+            {
+                name: "`to` equals the user",
+                message: {
+                    from: USER,
+                    to: USER,
+                    value: INPUT_AMOUNT,
+                    validAfter: 0,
+                    validBefore: FUTURE_DEADLINE,
+                    nonce: "0xabcd",
+                },
+                expected: /to/,
+            },
+            {
+                name: "`to` field missing",
+                message: {
+                    from: USER,
+                    value: INPUT_AMOUNT,
+                    validAfter: 0,
+                    validBefore: FUTURE_DEADLINE,
+                    nonce: "0xabcd",
+                },
+                expected: /to/,
+            },
+        ])("rejects $name", ({ message, expected }) => {
+            expect(() =>
+                validateRelaySignatureEnvelope(makeEip3009Envelope({ message }), eip3009Params),
+            ).toThrowError(expected);
         });
-        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(/deadline/);
-    });
 
-    it("rejects an EIP-3009 envelope when the input is the native asset", () => {
-        const params = makeParams({
-            input: {
-                chainId: ORIGIN_CHAIN_ID,
-                assetAddress: NATIVE_ASSET_ADDRESS,
-                amount: INPUT_AMOUNT,
-            },
+        it("rejects when input is the native asset placeholder", () => {
+            expect(() =>
+                validateRelaySignatureEnvelope(makeEip3009Envelope(), nativeInputParams),
+            ).toThrow(Eip712EnvelopeMismatch);
         });
-        expect(() => validateRelaySignatureEnvelope(makeEip3009Envelope(), params)).toThrow(
-            Eip712EnvelopeMismatch,
-        );
-    });
-
-    it("rejects an EIP-3009 envelope whose domain is missing version", () => {
-        const params = makeParams({
-            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
-        });
-        const envelope = makeEip3009Envelope({
-            domain: {
-                name: "USD Coin",
-                chainId: ORIGIN_CHAIN_ID,
-                verifyingContract: USDC_BASE,
-            },
-        });
-        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(
-            /domainVersion/,
-        );
-    });
-
-    it("rejects an EIP-3009 envelope whose domain has an empty version", () => {
-        const params = makeParams({
-            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
-        });
-        const envelope = makeEip3009Envelope({
-            domain: {
-                name: "USD Coin",
-                version: "",
-                chainId: ORIGIN_CHAIN_ID,
-                verifyingContract: USDC_BASE,
-            },
-        });
-        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(
-            /domainVersion/,
-        );
-    });
-
-    it("rejects a Permit2 envelope whose spender equals the user", () => {
-        const envelope = makePermit2Envelope({
-            message: {
-                permitted: { token: TOKEN, amount: INPUT_AMOUNT },
-                spender: USER,
-                nonce: "1",
-                deadline: FUTURE_DEADLINE,
-            },
-        });
-        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
-            /spender/,
-        );
-    });
-
-    it("rejects a Permit2 envelope whose spender field is missing", () => {
-        const envelope = makePermit2Envelope({
-            message: {
-                permitted: { token: TOKEN, amount: INPUT_AMOUNT },
-                nonce: "1",
-                deadline: FUTURE_DEADLINE,
-            },
-        });
-        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
-            /spender/,
-        );
-    });
-
-    it("rejects a Permit2 envelope whose spender is not a string address", () => {
-        const envelope = makePermit2Envelope({
-            message: {
-                permitted: { token: TOKEN, amount: INPUT_AMOUNT },
-                spender: 42,
-                nonce: "1",
-                deadline: FUTURE_DEADLINE,
-            },
-        });
-        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
-            /spender/,
-        );
-    });
-
-    it("rejects an EIP-3009 envelope whose `to` equals the user", () => {
-        const params = makeParams({
-            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
-        });
-        const envelope = makeEip3009Envelope({
-            message: {
-                from: USER,
-                to: USER,
-                value: INPUT_AMOUNT,
-                validAfter: 0,
-                validBefore: FUTURE_DEADLINE,
-                nonce: "0xabcd",
-            },
-        });
-        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(/to/);
-    });
-
-    it("rejects an EIP-3009 envelope whose `to` field is missing", () => {
-        const params = makeParams({
-            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
-        });
-        const envelope = makeEip3009Envelope({
-            message: {
-                from: USER,
-                value: INPUT_AMOUNT,
-                validAfter: 0,
-                validBefore: FUTURE_DEADLINE,
-                nonce: "0xabcd",
-            },
-        });
-        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(/to/);
     });
 });

--- a/packages/cross-chain/test/protocols/relay/validators/signatureEnvelopeValidator.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/validators/signatureEnvelopeValidator.spec.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it } from "vitest";
+
+import type { QuoteRequest } from "../../../../src/core/schemas/quoteRequest.js";
+import type { Eip712Envelope } from "../../../../src/core/types/eip712.js";
+import { PERMIT2_ADDRESS } from "../../../../src/core/constants/eip712.js";
+import { Eip712EnvelopeMismatch } from "../../../../src/core/errors/Eip712EnvelopeMismatch.exception.js";
+import { NATIVE_ASSET_ADDRESS } from "../../../../src/core/utils/token.js";
+import { validateRelaySignatureEnvelope } from "../../../../src/protocols/relay/validators/signatureEnvelopeValidator.js";
+
+const RELAY_SOLVER = "0xCCC88a9d1B4ed6b0eABA998850414b24F1C315bE";
+
+const USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+const USER = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+const TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const RECIPIENT = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8";
+const ORIGIN_CHAIN_ID = 1;
+const DESTINATION_CHAIN_ID = 10;
+const INPUT_AMOUNT = "1000000";
+const FUTURE_DEADLINE = Math.floor(Date.now() / 1000) + 3600;
+
+function makeParams(overrides?: Partial<QuoteRequest>): QuoteRequest {
+    return {
+        user: USER,
+        input: { chainId: ORIGIN_CHAIN_ID, assetAddress: TOKEN, amount: INPUT_AMOUNT },
+        output: { chainId: DESTINATION_CHAIN_ID, assetAddress: TOKEN, recipient: RECIPIENT },
+        ...overrides,
+    };
+}
+
+function makePermit2Envelope(overrides?: Partial<Eip712Envelope>): Eip712Envelope {
+    return {
+        domain: { name: "Permit2", chainId: ORIGIN_CHAIN_ID, verifyingContract: PERMIT2_ADDRESS },
+        primaryType: "PermitTransferFrom",
+        types: {},
+        message: {
+            permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+            spender: RELAY_SOLVER,
+            nonce: "1",
+            deadline: FUTURE_DEADLINE,
+        },
+        ...overrides,
+    };
+}
+
+function makeEip3009Envelope(overrides?: Partial<Eip712Envelope>): Eip712Envelope {
+    return {
+        domain: {
+            name: "USD Coin",
+            version: "2",
+            chainId: ORIGIN_CHAIN_ID,
+            verifyingContract: USDC_BASE,
+        },
+        primaryType: "ReceiveWithAuthorization",
+        types: {},
+        message: {
+            from: USER,
+            to: RELAY_SOLVER,
+            value: INPUT_AMOUNT,
+            validAfter: 0,
+            validBefore: FUTURE_DEADLINE,
+            nonce: "0xabcd",
+        },
+        ...overrides,
+    };
+}
+
+describe("validateRelaySignatureEnvelope", () => {
+    it("accepts a valid Permit2 envelope", () => {
+        expect(() =>
+            validateRelaySignatureEnvelope(makePermit2Envelope(), makeParams()),
+        ).not.toThrow();
+    });
+
+    it("rejects tampered chainId", () => {
+        const envelope = makePermit2Envelope({
+            domain: { chainId: 137, verifyingContract: PERMIT2_ADDRESS },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
+            /chainId/,
+        );
+    });
+
+    it("rejects a Permit2 envelope whose verifyingContract is not canonical Permit2", () => {
+        const envelope = makePermit2Envelope({
+            domain: {
+                chainId: ORIGIN_CHAIN_ID,
+                verifyingContract: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
+            /verifyingContract/,
+        );
+    });
+
+    it("rejects a primaryType outside the Relay allow-list", () => {
+        const envelope = makePermit2Envelope({ primaryType: "FooBar" });
+        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
+            /primaryType/,
+        );
+    });
+
+    it("rejects Permit2 AllowanceTransfer types (Permit / PermitBatch)", () => {
+        // AllowanceTransfer envelopes use `details`, not `permitted`; if they slipped
+        // past the allow-list, validatePermit2Message would reject them as malformed.
+        for (const primaryType of ["Permit", "PermitBatch"]) {
+            const envelope = makePermit2Envelope({ primaryType });
+            expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
+                /primaryType/,
+            );
+        }
+    });
+
+    it("rejects a tampered token in permitted", () => {
+        const envelope = makePermit2Envelope({
+            message: {
+                permitted: {
+                    token: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                    amount: INPUT_AMOUNT,
+                },
+                spender: RELAY_SOLVER,
+                nonce: "1",
+                deadline: FUTURE_DEADLINE,
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(/token/);
+    });
+
+    it("rejects an inflated amount in permitted", () => {
+        const envelope = makePermit2Envelope({
+            message: {
+                permitted: { token: TOKEN, amount: "99999999999" },
+                spender: RELAY_SOLVER,
+                nonce: "1",
+                deadline: FUTURE_DEADLINE,
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(/amount/);
+    });
+
+    it("rejects an expired deadline", () => {
+        const envelope = makePermit2Envelope({
+            message: {
+                permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+                spender: RELAY_SOLVER,
+                nonce: "1",
+                deadline: Math.floor(Date.now() / 1000) - 3600,
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
+            /deadline/,
+        );
+    });
+
+    it("rejects a Permit2 envelope whose domain carries `version`", () => {
+        const envelope = makePermit2Envelope({
+            domain: {
+                chainId: ORIGIN_CHAIN_ID,
+                verifyingContract: PERMIT2_ADDRESS,
+                version: "1",
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
+            /domainVersion/,
+        );
+    });
+
+    it("rejects a Permit2 envelope when the input is the native asset placeholder", () => {
+        const params = makeParams({
+            input: {
+                chainId: ORIGIN_CHAIN_ID,
+                assetAddress: NATIVE_ASSET_ADDRESS,
+                amount: INPUT_AMOUNT,
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(makePermit2Envelope(), params)).toThrow(
+            Eip712EnvelopeMismatch,
+        );
+    });
+
+    it("accepts a valid EIP-3009 envelope when the input token signed it", () => {
+        const params = makeParams({
+            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
+        });
+        expect(() => validateRelaySignatureEnvelope(makeEip3009Envelope(), params)).not.toThrow();
+    });
+
+    it("accepts TransferWithAuthorization as well as ReceiveWithAuthorization", () => {
+        const params = makeParams({
+            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
+        });
+        const envelope = makeEip3009Envelope({ primaryType: "TransferWithAuthorization" });
+        expect(() => validateRelaySignatureEnvelope(envelope, params)).not.toThrow();
+    });
+
+    it("rejects an EIP-3009 envelope signed by a contract other than the input token", () => {
+        const params = makeParams({
+            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
+        });
+        const envelope = makeEip3009Envelope({
+            domain: {
+                name: "USD Coin",
+                version: "2",
+                chainId: ORIGIN_CHAIN_ID,
+                verifyingContract: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(
+            /verifyingContract/,
+        );
+    });
+
+    it("rejects an EIP-3009 envelope whose `from` differs from the user", () => {
+        const params = makeParams({
+            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
+        });
+        const envelope = makeEip3009Envelope({
+            message: {
+                from: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                to: RELAY_SOLVER,
+                value: INPUT_AMOUNT,
+                validAfter: 0,
+                validBefore: FUTURE_DEADLINE,
+                nonce: "0xabcd",
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(/user/);
+    });
+
+    it("rejects an EIP-3009 envelope with an inflated value", () => {
+        const params = makeParams({
+            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
+        });
+        const envelope = makeEip3009Envelope({
+            message: {
+                from: USER,
+                to: RELAY_SOLVER,
+                value: "999999999999",
+                validAfter: 0,
+                validBefore: FUTURE_DEADLINE,
+                nonce: "0xabcd",
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(/amount/);
+    });
+
+    it("rejects an EIP-3009 envelope with an expired validBefore", () => {
+        const params = makeParams({
+            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
+        });
+        const envelope = makeEip3009Envelope({
+            message: {
+                from: USER,
+                to: RELAY_SOLVER,
+                value: INPUT_AMOUNT,
+                validAfter: 0,
+                validBefore: Math.floor(Date.now() / 1000) - 3600,
+                nonce: "0xabcd",
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(/deadline/);
+    });
+
+    it("rejects an EIP-3009 envelope when the input is the native asset", () => {
+        const params = makeParams({
+            input: {
+                chainId: ORIGIN_CHAIN_ID,
+                assetAddress: NATIVE_ASSET_ADDRESS,
+                amount: INPUT_AMOUNT,
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(makeEip3009Envelope(), params)).toThrow(
+            Eip712EnvelopeMismatch,
+        );
+    });
+
+    it("rejects an EIP-3009 envelope whose domain is missing version", () => {
+        const params = makeParams({
+            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
+        });
+        const envelope = makeEip3009Envelope({
+            domain: {
+                name: "USD Coin",
+                chainId: ORIGIN_CHAIN_ID,
+                verifyingContract: USDC_BASE,
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(
+            /domainVersion/,
+        );
+    });
+
+    it("rejects an EIP-3009 envelope whose domain has an empty version", () => {
+        const params = makeParams({
+            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
+        });
+        const envelope = makeEip3009Envelope({
+            domain: {
+                name: "USD Coin",
+                version: "",
+                chainId: ORIGIN_CHAIN_ID,
+                verifyingContract: USDC_BASE,
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(
+            /domainVersion/,
+        );
+    });
+
+    it("rejects a Permit2 envelope whose spender equals the user", () => {
+        const envelope = makePermit2Envelope({
+            message: {
+                permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+                spender: USER,
+                nonce: "1",
+                deadline: FUTURE_DEADLINE,
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
+            /spender/,
+        );
+    });
+
+    it("rejects a Permit2 envelope whose spender field is missing", () => {
+        const envelope = makePermit2Envelope({
+            message: {
+                permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+                nonce: "1",
+                deadline: FUTURE_DEADLINE,
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
+            /spender/,
+        );
+    });
+
+    it("rejects a Permit2 envelope whose spender is not a string address", () => {
+        const envelope = makePermit2Envelope({
+            message: {
+                permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+                spender: 42,
+                nonce: "1",
+                deadline: FUTURE_DEADLINE,
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, makeParams())).toThrowError(
+            /spender/,
+        );
+    });
+
+    it("rejects an EIP-3009 envelope whose `to` equals the user", () => {
+        const params = makeParams({
+            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
+        });
+        const envelope = makeEip3009Envelope({
+            message: {
+                from: USER,
+                to: USER,
+                value: INPUT_AMOUNT,
+                validAfter: 0,
+                validBefore: FUTURE_DEADLINE,
+                nonce: "0xabcd",
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(/to/);
+    });
+
+    it("rejects an EIP-3009 envelope whose `to` field is missing", () => {
+        const params = makeParams({
+            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
+        });
+        const envelope = makeEip3009Envelope({
+            message: {
+                from: USER,
+                value: INPUT_AMOUNT,
+                validAfter: 0,
+                validBefore: FUTURE_DEADLINE,
+                nonce: "0xabcd",
+            },
+        });
+        expect(() => validateRelaySignatureEnvelope(envelope, params)).toThrowError(/to/);
+    });
+});


### PR DESCRIPTION
## Summary

We now run `validateRelaySignatureEnvelope` (from EFI-949) before the wallet sees the Relay signature step. It dispatches by `primaryType` between Permit2 and EIP-3009, checks Relay's domain invariants and the recipient field (`spender` for Permit2, `to` for EIP-3009), and forwards it to the core validators. `adaptSignatureStep` in `quoteResponseAdapter.ts` calls it for every EIP-712 signature item. Tampered envelopes throw `Eip712EnvelopeMismatch`.

## Test plan

I've performed several gasless cross-chain swaps using the UI demo.