### PR TITLE
feat(cross-chain): wire eip-712 envelope validation into bungee (EFI-950)

### DIFF
--- a/.changeset/eip712-envelope-validation-bungee.md
+++ b/.changeset/eip712-envelope-validation-bungee.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Wire EIP-712 envelope validation into the Bungee signature flow so tampered envelopes are rejected with `Eip712EnvelopeMismatch` before the wallet is prompted to sign.

--- a/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
@@ -142,7 +142,7 @@ function adaptAutoRouteQuote(
     const fees = adaptFees(autoRoute);
     const allowances = extractAllowances(
         autoRoute.approvalData,
-        result.originChainId,
+        params.input.chainId,
         result.input.amount,
     );
 
@@ -263,7 +263,7 @@ function buildTransactionStep(txData: BungeeTxData, description: string): Step |
  */
 function extractAllowances(
     approvalData: BungeeApprovalData | null | undefined,
-    originChainId: number,
+    chainId: number,
     inputAmount: string,
 ): NonNullable<OrderChecks["allowances"]> {
     if (!approvalData) return [];
@@ -271,7 +271,7 @@ function extractAllowances(
     const { spenderAddress, tokenAddress, userAddress } = approvalData;
     return [
         {
-            chainId: originChainId,
+            chainId,
             tokenAddress,
             owner: userAddress,
             spender: spenderAddress,

--- a/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
@@ -138,7 +138,7 @@ function adaptAutoRouteQuote(
     params: QuoteRequest,
 ): Quote {
     const result = response.result;
-    const steps = buildAutoRouteSteps(autoRoute, result.originChainId, params);
+    const steps = buildAutoRouteSteps(autoRoute, params);
     const fees = adaptFees(autoRoute);
     const allowances = extractAllowances(
         autoRoute.approvalData,
@@ -190,13 +190,9 @@ function adaptAutoRouteQuote(
 // ── Step builders ──────────────────────────────────────
 
 /** Build SDK steps from a Bungee auto route. */
-function buildAutoRouteSteps(
-    autoRoute: BungeeAutoRoute,
-    originChainId: number,
-    params: QuoteRequest,
-): Step[] {
+function buildAutoRouteSteps(autoRoute: BungeeAutoRoute, params: QuoteRequest): Step[] {
     if (autoRoute.userOp === "sign" && autoRoute.signTypedData) {
-        return [buildSignatureStep(autoRoute, originChainId, params)];
+        return [buildSignatureStep(autoRoute, params)];
     }
 
     if (autoRoute.userOp === "tx" && autoRoute.txData) {
@@ -208,11 +204,7 @@ function buildAutoRouteSteps(
 }
 
 /** Build a SignatureStep from Bungee permit2 flow. */
-function buildSignatureStep(
-    autoRoute: BungeeAutoRoute,
-    originChainId: number,
-    params: QuoteRequest,
-): Step {
+function buildSignatureStep(autoRoute: BungeeAutoRoute, params: QuoteRequest): Step {
     const signTypedData = autoRoute.signTypedData!;
     const types = signTypedData.types as Record<string, Array<{ name: string; type: string }>>;
     const primaryType = "PermitWitnessTransferFrom";
@@ -229,7 +221,7 @@ function buildSignatureStep(
 
     return {
         kind: "signature" as const,
-        chainId: originChainId,
+        chainId: params.input.chainId,
         description: "Sign permit2 approval for Bungee",
         signaturePayload: {
             signatureType: "eip712" as const,

--- a/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
@@ -1,4 +1,5 @@
 import type { OrderChecks } from "../../../core/schemas/order.js";
+import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
 import type { Quote, Step } from "../../../internal.js";
 import type {
     BungeeApprovalData,
@@ -10,6 +11,7 @@ import type {
     BungeeTxData,
 } from "../schemas.js";
 import { BungeeTxDataSchema } from "../schemas.js";
+import { validateBungeeSignatureEnvelope } from "../validators/signatureEnvelopeValidator.js";
 import { adaptFees } from "./quoteFeeAdapter.js";
 
 /**
@@ -20,13 +22,18 @@ import { adaptFees } from "./quoteFeeAdapter.js";
  *
  * @param response - The Bungee API quote response.
  * @param providerId - The provider identifier to stamp on the quotes.
+ * @param params - The original SDK quote request, used to validate signature envelopes.
  */
-export function adaptQuotes(response: BungeeQuoteResponse, providerId: string): Quote[] {
+export function adaptQuotes(
+    response: BungeeQuoteResponse,
+    providerId: string,
+    params: QuoteRequest,
+): Quote[] {
     const result = response.result;
 
     const autoRoutes = collectAutoRoutes(result);
     return autoRoutes
-        .map((autoRoute) => adaptAutoRouteQuote(response, autoRoute, providerId))
+        .map((autoRoute) => adaptAutoRouteQuote(response, autoRoute, providerId, params))
         .filter((quote) => quote.order.steps.length > 0);
 }
 
@@ -128,9 +135,10 @@ function adaptAutoRouteQuote(
     response: BungeeQuoteResponse,
     autoRoute: BungeeAutoRoute,
     providerId: string,
+    params: QuoteRequest,
 ): Quote {
     const result = response.result;
-    const steps = buildAutoRouteSteps(autoRoute, result.originChainId);
+    const steps = buildAutoRouteSteps(autoRoute, result.originChainId, params);
     const fees = adaptFees(autoRoute);
     const allowances = extractAllowances(
         autoRoute.approvalData,
@@ -182,9 +190,13 @@ function adaptAutoRouteQuote(
 // ── Step builders ──────────────────────────────────────
 
 /** Build SDK steps from a Bungee auto route. */
-function buildAutoRouteSteps(autoRoute: BungeeAutoRoute, originChainId: number): Step[] {
+function buildAutoRouteSteps(
+    autoRoute: BungeeAutoRoute,
+    originChainId: number,
+    params: QuoteRequest,
+): Step[] {
     if (autoRoute.userOp === "sign" && autoRoute.signTypedData) {
-        return [buildSignatureStep(autoRoute, originChainId)];
+        return [buildSignatureStep(autoRoute, originChainId, params)];
     }
 
     if (autoRoute.userOp === "tx" && autoRoute.txData) {
@@ -196,8 +208,24 @@ function buildAutoRouteSteps(autoRoute: BungeeAutoRoute, originChainId: number):
 }
 
 /** Build a SignatureStep from Bungee permit2 flow. */
-function buildSignatureStep(autoRoute: BungeeAutoRoute, originChainId: number): Step {
+function buildSignatureStep(
+    autoRoute: BungeeAutoRoute,
+    originChainId: number,
+    params: QuoteRequest,
+): Step {
     const signTypedData = autoRoute.signTypedData!;
+    const types = signTypedData.types as Record<string, Array<{ name: string; type: string }>>;
+    const primaryType = "PermitWitnessTransferFrom";
+
+    validateBungeeSignatureEnvelope(
+        {
+            domain: signTypedData.domain,
+            primaryType,
+            types,
+            message: signTypedData.values,
+        },
+        params,
+    );
 
     return {
         kind: "signature" as const,
@@ -206,8 +234,8 @@ function buildSignatureStep(autoRoute: BungeeAutoRoute, originChainId: number): 
         signaturePayload: {
             signatureType: "eip712" as const,
             domain: signTypedData.domain,
-            primaryType: "PermitWitnessTransferFrom",
-            types: signTypedData.types as Record<string, Array<{ name: string; type: string }>>,
+            primaryType,
+            types,
             message: signTypedData.values,
         },
     };

--- a/packages/cross-chain/src/protocols/bungee/provider.ts
+++ b/packages/cross-chain/src/protocols/bungee/provider.ts
@@ -237,7 +237,7 @@ export class BungeeProvider extends CrossChainProvider {
             const options: BungeeQuoteOptions = { ...this.quoteOptions, submissionMode: mode };
             const bungeeParams = adaptQuoteRequest(params, options);
             const response = await this.apiService.getQuote(bungeeParams);
-            const autoQuotes = adaptQuotes(response, this.providerId);
+            const autoQuotes = adaptQuotes(response, this.providerId, params);
 
             if (!this.quoteOptions.enableOtherProviders) {
                 return autoQuotes;

--- a/packages/cross-chain/src/protocols/bungee/validators/signatureEnvelopeValidator.ts
+++ b/packages/cross-chain/src/protocols/bungee/validators/signatureEnvelopeValidator.ts
@@ -1,0 +1,272 @@
+import type { Address } from "viem";
+import { getAddress, isAddressEqual } from "viem";
+
+import type { Eip712MismatchField } from "../../../core/errors/Eip712EnvelopeMismatch.exception.js";
+import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
+import type { Eip712Envelope } from "../../../core/types/eip712.js";
+import { PERMIT2_ADDRESS } from "../../../core/constants/eip712.js";
+import { Eip712EnvelopeMismatch } from "../../../core/errors/Eip712EnvelopeMismatch.exception.js";
+import { readAddressField } from "../../../core/utils/eip712Readers.js";
+import { isNativeAddress, toCanonicalNativeAddress } from "../../../core/utils/token.js";
+import { toNonNegativeBigInt } from "../../../core/utils/toNonNegativeBigInt.js";
+import {
+    validateEnvelopeDomain,
+    validatePrimaryType,
+} from "../../../core/validators/eip712EnvelopeValidator.js";
+import { validatePermit2Message } from "../../../core/validators/permit2MessageValidator.js";
+
+const PROVIDER_NAME = "bungee";
+
+const BUNGEE_PRIMARY_TYPES: ReadonlySet<string> = new Set(["PermitWitnessTransferFrom"]);
+
+/**
+ * Validate a Bungee-issued EIP-712 envelope against the user-supplied quote request.
+ *
+ * Bungee uses Permit2 with an extended `witness.basicReq` payload that mirrors
+ * the requested route — sender, receiver, chain ids, tokens, amounts and
+ * bungeeGateway. We cross-check every one of those against the quote request,
+ * so a tampered envelope cannot redirect funds, switch chains or output token,
+ * or inflate the input amount without being rejected with `Eip712EnvelopeMismatch`.
+ */
+export function validateBungeeSignatureEnvelope(
+    envelope: Eip712Envelope,
+    params: QuoteRequest,
+): void {
+    validatePrimaryType(envelope, BUNGEE_PRIMARY_TYPES, PROVIDER_NAME);
+    guardAgainstNativeInputAsset(envelope, params);
+    guardPermit2DomainHasNoVersion(envelope);
+    validateEnvelopeDomain(envelope, {
+        chainId: params.input.chainId,
+        verifyingContracts: [PERMIT2_ADDRESS],
+        provider: PROVIDER_NAME,
+    });
+
+    const user = getAddress(params.user);
+    const spender = readRecipientField(envelope, ["spender"], "spender", user);
+    const maxAmount = params.input.amount !== undefined ? BigInt(params.input.amount) : undefined;
+
+    validatePermit2Message(envelope, {
+        provider: PROVIDER_NAME,
+        spender,
+        inputToken: getAddress(params.input.assetAddress),
+        maxAmount,
+    });
+
+    validateBungeeWitness(envelope, params, user, spender, maxAmount);
+}
+
+function readRecipientField(
+    envelope: Eip712Envelope,
+    path: ReadonlyArray<string>,
+    field: Eip712MismatchField,
+    user: Address,
+): Address {
+    const recipient = readAddressField({ envelope, path, field, provider: PROVIDER_NAME });
+    if (isAddressEqual(recipient, user)) {
+        throw new Eip712EnvelopeMismatch({
+            field,
+            provider: PROVIDER_NAME,
+            primaryType: envelope.primaryType,
+            received: recipient,
+            cause: "recipient must not be the user",
+        });
+    }
+    return recipient;
+}
+
+function validateBungeeWitness(
+    envelope: Eip712Envelope,
+    params: QuoteRequest,
+    user: Address,
+    spender: Address,
+    maxAmount: bigint | undefined,
+): void {
+    const basicReq = readBasicReq(envelope);
+
+    readAddressField({
+        envelope,
+        path: ["witness", "basicReq", "sender"],
+        field: "user",
+        provider: PROVIDER_NAME,
+        expected: user,
+    });
+
+    const expectedReceiver = params.output.recipient ? getAddress(params.output.recipient) : user;
+    readAddressField({
+        envelope,
+        path: ["witness", "basicReq", "receiver"],
+        field: "recipient",
+        provider: PROVIDER_NAME,
+        expected: expectedReceiver,
+    });
+
+    assertUintEquals({
+        envelope,
+        value: basicReq.originChainId,
+        expected: BigInt(params.input.chainId),
+        field: "chainId",
+        cause: "witness.basicReq.originChainId",
+    });
+
+    assertUintEquals({
+        envelope,
+        value: basicReq.destinationChainId,
+        expected: BigInt(params.output.chainId),
+        field: "chainId",
+        cause: "witness.basicReq.destinationChainId",
+    });
+
+    readAddressField({
+        envelope,
+        path: ["witness", "basicReq", "inputToken"],
+        field: "token",
+        provider: PROVIDER_NAME,
+        expected: getAddress(params.input.assetAddress),
+    });
+
+    assertOutputTokenEquals(envelope, basicReq.outputToken, params.output.assetAddress);
+
+    if (maxAmount !== undefined) {
+        assertInputAmountWithinLimit(envelope, basicReq.inputAmount, maxAmount);
+    }
+
+    readAddressField({
+        envelope,
+        path: ["witness", "basicReq", "bungeeGateway"],
+        field: "spender",
+        provider: PROVIDER_NAME,
+        expected: spender,
+    });
+}
+
+function readBasicReq(envelope: Eip712Envelope): Record<string, unknown> {
+    const witness = envelope.message.witness;
+    if (typeof witness !== "object" || witness === null || Array.isArray(witness)) {
+        throw new Eip712EnvelopeMismatch({
+            field: "structure",
+            provider: PROVIDER_NAME,
+            primaryType: envelope.primaryType,
+            cause: "witness object missing",
+        });
+    }
+    const basicReq = (witness as Record<string, unknown>).basicReq;
+    if (typeof basicReq !== "object" || basicReq === null || Array.isArray(basicReq)) {
+        throw new Eip712EnvelopeMismatch({
+            field: "structure",
+            provider: PROVIDER_NAME,
+            primaryType: envelope.primaryType,
+            cause: "witness.basicReq missing",
+        });
+    }
+    return basicReq as Record<string, unknown>;
+}
+
+interface AssertUintEqualsArgs {
+    envelope: Eip712Envelope;
+    value: unknown;
+    expected: bigint;
+    field: Eip712MismatchField;
+    cause: string;
+}
+
+function assertUintEquals(args: AssertUintEqualsArgs): void {
+    const { envelope, value, expected, field, cause } = args;
+    const parsed = toNonNegativeBigInt(value);
+    if (parsed === undefined) {
+        throw new Eip712EnvelopeMismatch({
+            field,
+            provider: PROVIDER_NAME,
+            primaryType: envelope.primaryType,
+            expected,
+            received: String(value),
+            cause,
+        });
+    }
+    if (parsed !== expected) {
+        throw new Eip712EnvelopeMismatch({
+            field,
+            provider: PROVIDER_NAME,
+            primaryType: envelope.primaryType,
+            expected,
+            received: parsed,
+            cause,
+        });
+    }
+}
+
+function assertOutputTokenEquals(
+    envelope: Eip712Envelope,
+    rawOutputToken: unknown,
+    expectedAssetAddress: string,
+): void {
+    const expected = toCanonicalNativeAddress(expectedAssetAddress, "eip155");
+    if (typeof rawOutputToken !== "string") {
+        throw new Eip712EnvelopeMismatch({
+            field: "token",
+            provider: PROVIDER_NAME,
+            primaryType: envelope.primaryType,
+            expected,
+            received: String(rawOutputToken),
+            cause: "witness.basicReq.outputToken",
+        });
+    }
+    const received = toCanonicalNativeAddress(rawOutputToken, "eip155");
+    if (received !== expected) {
+        throw new Eip712EnvelopeMismatch({
+            field: "token",
+            provider: PROVIDER_NAME,
+            primaryType: envelope.primaryType,
+            expected,
+            received,
+            cause: "witness.basicReq.outputToken",
+        });
+    }
+}
+
+function assertInputAmountWithinLimit(
+    envelope: Eip712Envelope,
+    rawAmount: unknown,
+    maxAmount: bigint,
+): void {
+    const parsed = toNonNegativeBigInt(rawAmount);
+    if (parsed === undefined) {
+        throw new Eip712EnvelopeMismatch({
+            field: "amount",
+            provider: PROVIDER_NAME,
+            primaryType: envelope.primaryType,
+            received: String(rawAmount),
+            cause: "witness.basicReq.inputAmount",
+        });
+    }
+    if (parsed > maxAmount) {
+        throw new Eip712EnvelopeMismatch({
+            field: "amount",
+            provider: PROVIDER_NAME,
+            primaryType: envelope.primaryType,
+            expected: maxAmount,
+            received: parsed,
+            cause: "witness.basicReq.inputAmount",
+        });
+    }
+}
+
+function guardAgainstNativeInputAsset(envelope: Eip712Envelope, params: QuoteRequest): void {
+    if (!isNativeAddress(params.input.assetAddress, "eip155")) return;
+    throw new Eip712EnvelopeMismatch({
+        field: "structure",
+        provider: PROVIDER_NAME,
+        primaryType: envelope.primaryType,
+        cause: "Permit2 envelope rejected: input asset is the native placeholder",
+    });
+}
+
+function guardPermit2DomainHasNoVersion(envelope: Eip712Envelope): void {
+    if (envelope.domain.version === undefined) return;
+    throw new Eip712EnvelopeMismatch({
+        field: "domainVersion",
+        provider: PROVIDER_NAME,
+        primaryType: envelope.primaryType,
+        expected: "absent",
+        received: String(envelope.domain.version),
+    });
+}

--- a/packages/cross-chain/src/protocols/bungee/validators/signatureEnvelopeValidator.ts
+++ b/packages/cross-chain/src/protocols/bungee/validators/signatureEnvelopeValidator.ts
@@ -34,7 +34,6 @@ export function validateBungeeSignatureEnvelope(
 ): void {
     validatePrimaryType(envelope, BUNGEE_PRIMARY_TYPES, PROVIDER_NAME);
     guardAgainstNativeInputAsset(envelope, params);
-    guardPermit2DomainHasNoVersion(envelope);
     validateEnvelopeDomain(envelope, {
         chainId: params.input.chainId,
         verifyingContracts: [PERMIT2_ADDRESS],
@@ -257,16 +256,5 @@ function guardAgainstNativeInputAsset(envelope: Eip712Envelope, params: QuoteReq
         provider: PROVIDER_NAME,
         primaryType: envelope.primaryType,
         cause: "Permit2 envelope rejected: input asset is the native placeholder",
-    });
-}
-
-function guardPermit2DomainHasNoVersion(envelope: Eip712Envelope): void {
-    if (envelope.domain.version === undefined) return;
-    throw new Eip712EnvelopeMismatch({
-        field: "domainVersion",
-        provider: PROVIDER_NAME,
-        primaryType: envelope.primaryType,
-        expected: "absent",
-        received: String(envelope.domain.version),
     });
 }

--- a/packages/cross-chain/src/protocols/bungee/validators/signatureEnvelopeValidator.ts
+++ b/packages/cross-chain/src/protocols/bungee/validators/signatureEnvelopeValidator.ts
@@ -68,7 +68,7 @@ function readRecipientField(
             provider: PROVIDER_NAME,
             primaryType: envelope.primaryType,
             received: recipient,
-            cause: "recipient must not be the user",
+            cause: `${field} must not be the user`,
         });
     }
     return recipient;

--- a/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 
+import type { QuoteRequest } from "../../../../src/core/schemas/quoteRequest.js";
 import type {
     BungeeAutoRoute,
     BungeeBuildTxResult,
     BungeeManualRoute,
     BungeeQuoteResponse,
 } from "../../../../src/protocols/bungee/schemas.js";
+import { PERMIT2_ADDRESS } from "../../../../src/core/constants/eip712.js";
 import {
     adaptManualRouteQuote,
     adaptQuotes,
@@ -14,7 +16,94 @@ import {
 const VALID_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
 const RECIPIENT_ADDRESS = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
 const SPENDER_ADDRESS = "0x3a23F943181408EAC424116Af7b7790c94Cb97a5";
+const BUNGEE_GATEWAY = "0xCDeA28EE7bd5bf7710b294d9391E1B6A318D809a";
 const PROVIDER_ID = "bungee";
+const ORIGIN_CHAIN_ID = 1;
+const DESTINATION_CHAIN_ID = 10;
+const INPUT_AMOUNT = "1000000";
+const FUTURE_DEADLINE = Math.floor(Date.now() / 1000) + 3600;
+
+function makeQuoteRequest(overrides?: Partial<QuoteRequest>): QuoteRequest {
+    return {
+        user: VALID_ADDRESS,
+        input: {
+            chainId: ORIGIN_CHAIN_ID,
+            assetAddress: VALID_ADDRESS,
+            amount: INPUT_AMOUNT,
+        },
+        output: {
+            chainId: DESTINATION_CHAIN_ID,
+            assetAddress: VALID_ADDRESS,
+            recipient: RECIPIENT_ADDRESS,
+        },
+        ...overrides,
+    };
+}
+
+function buildSignTypedData(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        domain: {
+            name: "Permit2",
+            chainId: ORIGIN_CHAIN_ID,
+            verifyingContract: PERMIT2_ADDRESS,
+        },
+        types: {
+            PermitWitnessTransferFrom: [
+                { name: "permitted", type: "TokenPermissions" },
+                { name: "spender", type: "address" },
+                { name: "nonce", type: "uint256" },
+                { name: "deadline", type: "uint256" },
+                { name: "witness", type: "Request" },
+            ],
+            TokenPermissions: [
+                { name: "token", type: "address" },
+                { name: "amount", type: "uint256" },
+            ],
+            Request: [{ name: "basicReq", type: "BasicRequest" }],
+            BasicRequest: [
+                { name: "originChainId", type: "uint256" },
+                { name: "destinationChainId", type: "uint256" },
+                { name: "deadline", type: "uint256" },
+                { name: "nonce", type: "uint256" },
+                { name: "sender", type: "address" },
+                { name: "receiver", type: "address" },
+                { name: "delegate", type: "address" },
+                { name: "bungeeGateway", type: "address" },
+                { name: "switchboardId", type: "uint32" },
+                { name: "inputToken", type: "address" },
+                { name: "inputAmount", type: "uint256" },
+                { name: "outputToken", type: "address" },
+                { name: "minOutputAmount", type: "uint256" },
+                { name: "refuelAmount", type: "uint256" },
+            ],
+        },
+        values: {
+            permitted: { token: VALID_ADDRESS, amount: INPUT_AMOUNT },
+            spender: BUNGEE_GATEWAY,
+            nonce: "1",
+            deadline: FUTURE_DEADLINE,
+            witness: {
+                basicReq: {
+                    originChainId: ORIGIN_CHAIN_ID,
+                    destinationChainId: DESTINATION_CHAIN_ID,
+                    deadline: FUTURE_DEADLINE,
+                    nonce: "1",
+                    sender: VALID_ADDRESS,
+                    receiver: RECIPIENT_ADDRESS,
+                    delegate: VALID_ADDRESS,
+                    bungeeGateway: BUNGEE_GATEWAY,
+                    switchboardId: 1,
+                    inputToken: VALID_ADDRESS,
+                    inputAmount: INPUT_AMOUNT,
+                    outputToken: VALID_ADDRESS,
+                    minOutputAmount: "0",
+                    refuelAmount: "0",
+                },
+            },
+        },
+        ...overrides,
+    };
+}
 
 function buildAutoRoute(overrides: Record<string, unknown> = {}): BungeeAutoRoute {
     return {
@@ -22,7 +111,7 @@ function buildAutoRoute(overrides: Record<string, unknown> = {}): BungeeAutoRout
         requestHash: "0xreqhash123",
         output: {
             token: {
-                chainId: 10,
+                chainId: DESTINATION_CHAIN_ID,
                 address: VALID_ADDRESS,
                 name: "USDC",
                 symbol: "USDC",
@@ -41,13 +130,7 @@ function buildAutoRoute(overrides: Record<string, unknown> = {}): BungeeAutoRout
             tokenAddress: VALID_ADDRESS,
             userAddress: VALID_ADDRESS,
         },
-        signTypedData: {
-            domain: { name: "Permit2", chainId: 1 },
-            types: {
-                PermitWitnessTransferFrom: [{ name: "permitted", type: "TokenPermissions" }],
-            },
-            values: { witness: { field: "value" } },
-        },
+        signTypedData: buildSignTypedData(),
         gasFee: {
             gasToken: {
                 chainId: 1,
@@ -201,7 +284,7 @@ function buildManualResponse(): BungeeQuoteResponse {
 describe("adaptQuotes", () => {
     it("creates SignatureStep for sign userOp", () => {
         const response = buildBungeeQuoteResponse();
-        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         expect(quote!.order.steps[0]!.kind).toBe("signature");
 
@@ -226,7 +309,7 @@ describe("adaptQuotes", () => {
             },
         });
 
-        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         expect(quote!.order.steps[0]!.kind).toBe("transaction");
     });
@@ -244,7 +327,7 @@ describe("adaptQuotes", () => {
             },
         });
 
-        const quotes = adaptQuotes(response as never, PROVIDER_ID);
+        const quotes = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         expect(quotes).toHaveLength(0);
     });
@@ -260,14 +343,14 @@ describe("adaptQuotes", () => {
             },
         });
 
-        const quotes = adaptQuotes(response as never, PROVIDER_ID);
+        const quotes = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         expect(quotes).toHaveLength(0);
     });
 
     it("maps preview inputs from response.result.input", () => {
         const response = buildBungeeQuoteResponse();
-        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         expect(quote!.preview.inputs[0]!.amount).toBe("1000000");
         expect(quote!.preview.inputs[0]!.chainId).toBe(1);
@@ -276,7 +359,7 @@ describe("adaptQuotes", () => {
 
     it("maps preview outputs from autoRoute.output", () => {
         const response = buildBungeeQuoteResponse();
-        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         expect(quote!.preview.outputs[0]!.amount).toBe("999000");
         expect(quote!.preview.outputs[0]!.chainId).toBe(10);
@@ -284,7 +367,7 @@ describe("adaptQuotes", () => {
 
     it("exposes minAmountOut as the slippage floor on preview output", () => {
         const response = buildBungeeQuoteResponse();
-        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
         if (!quote) throw new Error("expected a quote");
 
         expect(quote.preview.outputs[0]?.minAmount).toBe("998000");
@@ -300,7 +383,7 @@ describe("adaptQuotes", () => {
             },
         });
 
-        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
         if (!quote) throw new Error("expected a quote");
 
         expect(quote.preview.outputs[0]?.amount).toBe("997500");
@@ -310,7 +393,7 @@ describe("adaptQuotes", () => {
 
     it("maps valueInUsd to preview.amountUsd as decimal string", () => {
         const response = buildBungeeQuoteResponse();
-        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         expect(quote!.preview.inputs[0]!.amountUsd).toBe("1800");
         expect(quote!.preview.outputs[0]!.amountUsd).toBe("999");
@@ -323,7 +406,7 @@ describe("adaptQuotes", () => {
             output: { ...buildAutoRoute().output, valueInUsd: 4.9972825837 },
         });
 
-        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         expect(quote!.preview.inputs[0]!.amountUsd).toBe("1800.42");
         expect(quote!.preview.outputs[0]!.amountUsd).toBe("4.9972825837");
@@ -331,7 +414,7 @@ describe("adaptQuotes", () => {
 
     it("uses input.amount for allowance required (not approvalData.amount)", () => {
         const response = buildBungeeQuoteResponse();
-        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         const allowances = quote!.order.checks?.allowances;
         expect(allowances).toHaveLength(1);
@@ -341,7 +424,7 @@ describe("adaptQuotes", () => {
 
     it("sets tracking orderId from requestHash", () => {
         const response = buildBungeeQuoteResponse();
-        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         expect(quote!.tracking?.orderId).toBe("0xreqhash123");
     });
@@ -355,7 +438,7 @@ describe("adaptQuotes", () => {
             }),
         ];
 
-        const quotes = adaptQuotes(response as never, PROVIDER_ID);
+        const quotes = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         // Preserves Bungee order: autoRoute first, then autoRoutes[]
         expect(quotes[0]!.quoteId).toBe("quote-abc");
@@ -371,7 +454,7 @@ describe("adaptQuotes", () => {
 
     it("sets partialFill and failureHandling", () => {
         const response = buildBungeeQuoteResponse();
-        const [quote] = adaptQuotes(response as never, PROVIDER_ID);
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         expect(quote!.partialFill).toBe(false);
         expect(quote!.failureHandling).toBe("refund-automatic");
@@ -387,7 +470,7 @@ describe("adaptQuotes", () => {
             }),
         ];
 
-        const quotes = adaptQuotes(response as never, PROVIDER_ID);
+        const quotes = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         expect(quotes).toHaveLength(2);
     });
@@ -396,7 +479,7 @@ describe("adaptQuotes", () => {
         const response = buildBungeeQuoteResponse();
         response.result.autoRoute = null as never;
 
-        const quotes = adaptQuotes(response as never, PROVIDER_ID);
+        const quotes = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
 
         expect(quotes).toHaveLength(0);
     });

--- a/packages/cross-chain/test/protocols/bungee/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/provider.spec.ts
@@ -8,6 +8,7 @@ import type {
     BungeeManualRoute,
     BungeeQuoteResponse,
 } from "../../../src/protocols/bungee/schemas.js";
+import { PERMIT2_ADDRESS } from "../../../src/core/constants/eip712.js";
 import { HttpError } from "../../../src/core/errors/HttpError.exception.js";
 import { ProviderConfigFailure } from "../../../src/core/errors/ProviderConfigFailure.exception.js";
 import { ProviderExecuteFailure } from "../../../src/core/errors/ProviderExecuteFailure.exception.js";
@@ -18,6 +19,7 @@ import { BungeeProvider } from "../../../src/protocols/bungee/provider.js";
 // ── Constants ────────────────────────────────────────────
 
 const VALID_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+const BUNGEE_GATEWAY = "0xCDeA28EE7bd5bf7710b294d9391E1B6A318D809a";
 const ORIGIN_CHAIN_ID = 1;
 const DESTINATION_CHAIN_ID = 10;
 const INPUT_AMOUNT = "1000000";
@@ -25,6 +27,7 @@ const OUTPUT_AMOUNT = "999000";
 const API_KEY = "test-key";
 const BUNGEE_BASE_URL = "https://public-backend.bungee.exchange";
 const PROTOCOL_NAME = "bungee";
+const FUTURE_DEADLINE = Math.floor(Date.now() / 1000) + 3600;
 
 // ── Mock & Helpers ───────────────────────────────────────
 
@@ -65,9 +68,65 @@ function makeAutoRoute(overrides: Record<string, unknown> = {}): BungeeAutoRoute
         },
         requestType: "SINGLE_OUTPUT_REQUEST",
         signTypedData: {
-            domain: { name: "Permit2" },
-            types: {},
-            values: { witness: { field: "value" } },
+            domain: {
+                name: "Permit2",
+                chainId: ORIGIN_CHAIN_ID,
+                verifyingContract: PERMIT2_ADDRESS,
+            },
+            types: {
+                PermitWitnessTransferFrom: [
+                    { name: "permitted", type: "TokenPermissions" },
+                    { name: "spender", type: "address" },
+                    { name: "nonce", type: "uint256" },
+                    { name: "deadline", type: "uint256" },
+                    { name: "witness", type: "Request" },
+                ],
+                TokenPermissions: [
+                    { name: "token", type: "address" },
+                    { name: "amount", type: "uint256" },
+                ],
+                Request: [{ name: "basicReq", type: "BasicRequest" }],
+                BasicRequest: [
+                    { name: "originChainId", type: "uint256" },
+                    { name: "destinationChainId", type: "uint256" },
+                    { name: "deadline", type: "uint256" },
+                    { name: "nonce", type: "uint256" },
+                    { name: "sender", type: "address" },
+                    { name: "receiver", type: "address" },
+                    { name: "delegate", type: "address" },
+                    { name: "bungeeGateway", type: "address" },
+                    { name: "switchboardId", type: "uint32" },
+                    { name: "inputToken", type: "address" },
+                    { name: "inputAmount", type: "uint256" },
+                    { name: "outputToken", type: "address" },
+                    { name: "minOutputAmount", type: "uint256" },
+                    { name: "refuelAmount", type: "uint256" },
+                ],
+            },
+            values: {
+                permitted: { token: VALID_ADDRESS, amount: INPUT_AMOUNT },
+                spender: BUNGEE_GATEWAY,
+                nonce: "1",
+                deadline: FUTURE_DEADLINE,
+                witness: {
+                    basicReq: {
+                        originChainId: ORIGIN_CHAIN_ID,
+                        destinationChainId: DESTINATION_CHAIN_ID,
+                        deadline: FUTURE_DEADLINE,
+                        nonce: "1",
+                        sender: VALID_ADDRESS,
+                        receiver: VALID_ADDRESS,
+                        delegate: VALID_ADDRESS,
+                        bungeeGateway: BUNGEE_GATEWAY,
+                        switchboardId: 1,
+                        inputToken: VALID_ADDRESS,
+                        inputAmount: INPUT_AMOUNT,
+                        outputToken: VALID_ADDRESS,
+                        minOutputAmount: "0",
+                        refuelAmount: "0",
+                    },
+                },
+            },
         },
         gasFee: {
             gasToken: {
@@ -582,7 +641,7 @@ describe("BungeeProvider", () => {
             expect(mockPost).toHaveBeenCalledWith(
                 "/api/v1/bungee/submit",
                 expect.objectContaining({
-                    request: { field: "value" },
+                    request: quoteResponse.result.autoRoute!.signTypedData!.values.witness,
                     userSignature: "0xsignature",
                     requestType: "SINGLE_OUTPUT_REQUEST",
                     quoteId: "quote-123",
@@ -592,21 +651,20 @@ describe("BungeeProvider", () => {
 
         it("uses the specific autoRoute from metadata, not result.autoRoute", async () => {
             const quoteResponse = makeBungeeQuoteResponse();
-            // Add a different route in autoRoutes with higher output
-            (quoteResponse.result as Record<string, unknown>).autoRoutes = [
-                makeAutoRoute({
-                    quoteId: "route-better",
-                    output: {
-                        ...makeAutoRoute().output,
-                        amount: "1500000",
-                    },
-                    signTypedData: {
-                        domain: { name: "Permit2" },
-                        types: {},
-                        values: { witness: { betterField: "betterValue" } },
-                    },
-                }),
-            ];
+            const betterRoute = makeAutoRoute({
+                quoteId: "route-better",
+                output: {
+                    ...makeAutoRoute().output,
+                    amount: "1500000",
+                },
+            });
+            // Make this route's witness distinguishable so we can prove the
+            // submit picked the right one.
+            (
+                (betterRoute.signTypedData!.values.witness as Record<string, unknown>)
+                    .basicReq as Record<string, unknown>
+            ).nonce = "route-better-nonce";
+            (quoteResponse.result as Record<string, unknown>).autoRoutes = [betterRoute];
 
             mockGet.mockResolvedValue({
                 status: 200,
@@ -625,14 +683,12 @@ describe("BungeeProvider", () => {
                 headers: new Headers(),
             });
 
-            // Submit with route-better (second quote, from autoRoutes)
             await provider.submitOrder(quotes[1]!, "0xsignature");
 
-            // Should submit with route-better's witness from bungeeAutoRoute metadata
             expect(mockPost).toHaveBeenCalledWith(
                 "/api/v1/bungee/submit",
                 expect.objectContaining({
-                    request: { betterField: "betterValue" },
+                    request: betterRoute.signTypedData!.values.witness,
                     quoteId: "route-better",
                 }),
             );

--- a/packages/cross-chain/test/protocols/bungee/validators/signatureEnvelopeValidator.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/validators/signatureEnvelopeValidator.spec.ts
@@ -124,23 +124,6 @@ describe("validateBungeeSignatureEnvelope", () => {
         );
     });
 
-    it("rejects a Permit2 envelope whose domain carries `version`", () => {
-        const envelope = makeEnvelope(
-            {},
-            {
-                domain: {
-                    name: "Permit2",
-                    chainId: ORIGIN_CHAIN_ID,
-                    verifyingContract: PERMIT2_ADDRESS,
-                    version: "1",
-                },
-            },
-        );
-        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
-            /domainVersion/,
-        );
-    });
-
     it("rejects a tampered domain chainId", () => {
         const envelope = makeEnvelope(
             {},

--- a/packages/cross-chain/test/protocols/bungee/validators/signatureEnvelopeValidator.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/validators/signatureEnvelopeValidator.spec.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from "vitest";
+
+import type { QuoteRequest } from "../../../../src/core/schemas/quoteRequest.js";
+import type { Eip712Envelope } from "../../../../src/core/types/eip712.js";
+import { PERMIT2_ADDRESS } from "../../../../src/core/constants/eip712.js";
+import { Eip712EnvelopeMismatch } from "../../../../src/core/errors/Eip712EnvelopeMismatch.exception.js";
+import { NATIVE_ASSET_ADDRESS } from "../../../../src/core/utils/token.js";
+import { validateBungeeSignatureEnvelope } from "../../../../src/protocols/bungee/validators/signatureEnvelopeValidator.js";
+
+const USER = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+const TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const OUTPUT_TOKEN = "0x0b2c639c533813f4aa9d7837caf62653d097ff85";
+const RECEIVER = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8";
+const BUNGEE_GATEWAY = "0xCDeA28EE7bd5bf7710b294d9391E1B6A318D809a";
+
+const ORIGIN_CHAIN_ID = 1;
+const DESTINATION_CHAIN_ID = 10;
+const INPUT_AMOUNT = "1000000";
+const FUTURE_DEADLINE = Math.floor(Date.now() / 1000) + 3600;
+
+function makeParams(overrides?: Partial<QuoteRequest>): QuoteRequest {
+    return {
+        user: USER,
+        input: { chainId: ORIGIN_CHAIN_ID, assetAddress: TOKEN, amount: INPUT_AMOUNT },
+        output: {
+            chainId: DESTINATION_CHAIN_ID,
+            assetAddress: OUTPUT_TOKEN,
+            recipient: RECEIVER,
+        },
+        ...overrides,
+    };
+}
+
+function makeBasicReq(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        originChainId: ORIGIN_CHAIN_ID,
+        destinationChainId: DESTINATION_CHAIN_ID,
+        deadline: FUTURE_DEADLINE,
+        nonce: "1",
+        sender: USER,
+        receiver: RECEIVER,
+        delegate: USER,
+        bungeeGateway: BUNGEE_GATEWAY,
+        switchboardId: 1,
+        inputToken: TOKEN,
+        inputAmount: INPUT_AMOUNT,
+        outputToken: OUTPUT_TOKEN,
+        minOutputAmount: "0",
+        refuelAmount: "0",
+        ...overrides,
+    };
+}
+
+function makeEnvelope(
+    messageOverrides: Record<string, unknown> = {},
+    envelopeOverrides: Partial<Eip712Envelope> = {},
+): Eip712Envelope {
+    return {
+        domain: {
+            name: "Permit2",
+            chainId: ORIGIN_CHAIN_ID,
+            verifyingContract: PERMIT2_ADDRESS,
+        },
+        primaryType: "PermitWitnessTransferFrom",
+        types: {},
+        message: {
+            permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+            spender: BUNGEE_GATEWAY,
+            nonce: "1",
+            deadline: FUTURE_DEADLINE,
+            witness: { basicReq: makeBasicReq() },
+            ...messageOverrides,
+        },
+        ...envelopeOverrides,
+    };
+}
+
+describe("validateBungeeSignatureEnvelope", () => {
+    it("accepts a valid Permit2 envelope with full witness", () => {
+        expect(() => validateBungeeSignatureEnvelope(makeEnvelope(), makeParams())).not.toThrow();
+    });
+
+    it("defaults the expected receiver to the user when params.output.recipient is omitted", () => {
+        const params = makeParams({
+            output: { chainId: DESTINATION_CHAIN_ID, assetAddress: OUTPUT_TOKEN },
+        });
+        const envelope = makeEnvelope({
+            witness: { basicReq: makeBasicReq({ receiver: USER }) },
+        });
+        expect(() => validateBungeeSignatureEnvelope(envelope, params)).not.toThrow();
+    });
+
+    it("accepts the EIP-7528 native placeholder as the witness outputToken when params output is zero address", () => {
+        const params = makeParams({
+            output: {
+                chainId: DESTINATION_CHAIN_ID,
+                assetAddress: "0x0000000000000000000000000000000000000000",
+                recipient: RECEIVER,
+            },
+        });
+        const envelope = makeEnvelope({
+            witness: { basicReq: makeBasicReq({ outputToken: NATIVE_ASSET_ADDRESS }) },
+        });
+        expect(() => validateBungeeSignatureEnvelope(envelope, params)).not.toThrow();
+    });
+
+    it("rejects a primary type outside the Bungee allow-list", () => {
+        const envelope = makeEnvelope({}, { primaryType: "PermitTransferFrom" });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
+            /primaryType/,
+        );
+    });
+
+    it("rejects an envelope when the input asset is the native placeholder", () => {
+        const params = makeParams({
+            input: {
+                chainId: ORIGIN_CHAIN_ID,
+                assetAddress: NATIVE_ASSET_ADDRESS,
+                amount: INPUT_AMOUNT,
+            },
+        });
+        expect(() => validateBungeeSignatureEnvelope(makeEnvelope(), params)).toThrow(
+            Eip712EnvelopeMismatch,
+        );
+    });
+
+    it("rejects a Permit2 envelope whose domain carries `version`", () => {
+        const envelope = makeEnvelope(
+            {},
+            {
+                domain: {
+                    name: "Permit2",
+                    chainId: ORIGIN_CHAIN_ID,
+                    verifyingContract: PERMIT2_ADDRESS,
+                    version: "1",
+                },
+            },
+        );
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
+            /domainVersion/,
+        );
+    });
+
+    it("rejects a tampered domain chainId", () => {
+        const envelope = makeEnvelope(
+            {},
+            {
+                domain: { name: "Permit2", chainId: 137, verifyingContract: PERMIT2_ADDRESS },
+            },
+        );
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
+            /chainId/,
+        );
+    });
+
+    it("rejects a Permit2 envelope whose verifyingContract is not canonical Permit2", () => {
+        const envelope = makeEnvelope(
+            {},
+            {
+                domain: {
+                    name: "Permit2",
+                    chainId: ORIGIN_CHAIN_ID,
+                    verifyingContract: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                },
+            },
+        );
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
+            /verifyingContract/,
+        );
+    });
+
+    it("rejects when the envelope spender equals the user", () => {
+        const envelope = makeEnvelope({ spender: USER });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
+            /spender/,
+        );
+    });
+
+    it("rejects when the envelope spender is missing", () => {
+        const envelope: Eip712Envelope = {
+            domain: {
+                name: "Permit2",
+                chainId: ORIGIN_CHAIN_ID,
+                verifyingContract: PERMIT2_ADDRESS,
+            },
+            primaryType: "PermitWitnessTransferFrom",
+            types: {},
+            message: {
+                permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+                nonce: "1",
+                deadline: FUTURE_DEADLINE,
+                witness: { basicReq: makeBasicReq() },
+            },
+        };
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
+            /spender/,
+        );
+    });
+
+    it("rejects a tampered permitted.token", () => {
+        const envelope = makeEnvelope({
+            permitted: {
+                token: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                amount: INPUT_AMOUNT,
+            },
+        });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(/token/);
+    });
+
+    it("rejects an inflated permitted.amount", () => {
+        const envelope = makeEnvelope({
+            permitted: { token: TOKEN, amount: "99999999999" },
+        });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
+            /amount/,
+        );
+    });
+
+    it("rejects an expired deadline", () => {
+        const envelope = makeEnvelope({ deadline: Math.floor(Date.now() / 1000) - 3600 });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
+            /deadline/,
+        );
+    });
+
+    it("rejects when witness object is missing", () => {
+        const envelope: Eip712Envelope = {
+            domain: {
+                name: "Permit2",
+                chainId: ORIGIN_CHAIN_ID,
+                verifyingContract: PERMIT2_ADDRESS,
+            },
+            primaryType: "PermitWitnessTransferFrom",
+            types: {},
+            message: {
+                permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+                spender: BUNGEE_GATEWAY,
+                nonce: "1",
+                deadline: FUTURE_DEADLINE,
+            },
+        };
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrow(
+            Eip712EnvelopeMismatch,
+        );
+    });
+
+    it("rejects when witness.basicReq is missing", () => {
+        const envelope = makeEnvelope({ witness: { otherField: "x" } });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrow(
+            Eip712EnvelopeMismatch,
+        );
+    });
+
+    it("rejects when witness.basicReq.sender differs from the user", () => {
+        const envelope = makeEnvelope({
+            witness: { basicReq: makeBasicReq({ sender: RECEIVER }) },
+        });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(/user/);
+    });
+
+    it("rejects when witness.basicReq.receiver differs from params.output.recipient", () => {
+        const envelope = makeEnvelope({
+            witness: { basicReq: makeBasicReq({ receiver: USER }) },
+        });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
+            /recipient/,
+        );
+    });
+
+    it("rejects when witness.basicReq.originChainId mismatches params.input.chainId", () => {
+        const envelope = makeEnvelope({
+            witness: { basicReq: makeBasicReq({ originChainId: 137 }) },
+        });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
+            /chainId/,
+        );
+    });
+
+    it("rejects when witness.basicReq.destinationChainId mismatches params.output.chainId", () => {
+        const envelope = makeEnvelope({
+            witness: { basicReq: makeBasicReq({ destinationChainId: 42161 }) },
+        });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
+            /chainId/,
+        );
+    });
+
+    it("rejects when witness.basicReq.inputToken mismatches params.input.assetAddress", () => {
+        const envelope = makeEnvelope({
+            witness: {
+                basicReq: makeBasicReq({
+                    inputToken: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                }),
+            },
+        });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(/token/);
+    });
+
+    it("rejects when witness.basicReq.outputToken mismatches params.output.assetAddress", () => {
+        const envelope = makeEnvelope({
+            witness: {
+                basicReq: makeBasicReq({
+                    outputToken: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                }),
+            },
+        });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(/token/);
+    });
+
+    it("rejects when witness.basicReq.inputAmount exceeds params.input.amount", () => {
+        const envelope = makeEnvelope({
+            witness: { basicReq: makeBasicReq({ inputAmount: "99999999999" }) },
+        });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
+            /amount/,
+        );
+    });
+
+    it("rejects when witness.basicReq.bungeeGateway diverges from values.spender", () => {
+        const envelope = makeEnvelope({
+            witness: {
+                basicReq: makeBasicReq({
+                    bungeeGateway: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                }),
+            },
+        });
+        expect(() => validateBungeeSignatureEnvelope(envelope, makeParams())).toThrowError(
+            /spender/,
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Hooks the core EIP-712 envelope validators (EFI-949) into the Bungee signature flow. Before any signature step reaches the wallet, the Bungee quote adapter now runs `validateBungeeSignatureEnvelope`, which cross-checks every field of the Permit2 + witness payload (chain ids, tokens, amounts, recipient, gateway) against the user's quote request and rejects tampered envelopes with a typed `Eip712EnvelopeMismatch`.

## Test plan

Cross-chain swaps in gasless mode from the demo UI:

- [ ] USDC mainnet → USDC optimism — signature prompted, sign and submit, order fills.
- [ ] USDC mainnet → USDC arbitrum — signature prompted, order fills.
- [ ] USDC mainnet → USDC base — signature prompted, order fills.
- [ ] USDT mainnet → USDT optimism — signature prompted, order fills.
- [ ] DAI mainnet → USDC optimism — signature prompted, order fills.
- [ ] WETH mainnet → WETH optimism — signature prompted, order fills.
- [ ] USDC arbitrum → USDC optimism — signature prompted, order fills.
- [ ] ETH mainnet (native) → WETH optimism — no signature step (gasless fallbacks to transaction step), regular execute flow works.