### PR TITLE
refactor(ui): use switch toggle for off-chain signature mode

### DIFF
--- a/examples/ui/app/cross-chain/components/SubmissionModeSwitch.tsx
+++ b/examples/ui/app/cross-chain/components/SubmissionModeSwitch.tsx
@@ -1,29 +1,44 @@
 'use client';
 
 import { useCrossChainStore } from '../stores/crossChainStore';
-import { TabSwitch } from './TabSwitch';
-import type { SubmissionMode } from '@wonderland/interop-cross-chain';
+import { BoltIcon } from './icons';
 
 interface SubmissionModeSwitchProps {
   disabled?: boolean;
 }
 
-const OPTIONS: { value: SubmissionMode; label: string }[] = [
-  { value: 'user-transaction', label: 'Transactions' },
-  { value: 'gasless', label: 'Gasless' },
-];
-
 export function SubmissionModeSwitch({ disabled = false }: SubmissionModeSwitchProps) {
   const submissionMode = useCrossChainStore((s) => s.submissionMode);
   const setSubmissionMode = useCrossChainStore((s) => s.setSubmissionMode);
+  const isGasless = submissionMode === 'gasless';
+
+  const handleToggle = () => {
+    setSubmissionMode(isGasless ? 'user-transaction' : 'gasless');
+  };
 
   return (
-    <TabSwitch
-      options={OPTIONS}
-      value={submissionMode}
-      onChange={setSubmissionMode}
-      ariaLabel='Submission mode selection'
-      disabled={disabled}
-    />
+    <div className='flex items-center justify-between px-3 py-2.5 rounded-xl bg-background/40 border border-border/40'>
+      <div className='flex items-center gap-2'>
+        <BoltIcon className='w-3.5 h-3.5 text-accent' />
+        <span className='text-sm font-medium text-text-primary'>Off-chain signature</span>
+      </div>
+      <button
+        type='button'
+        role='switch'
+        aria-checked={isGasless}
+        aria-label='Toggle off-chain signature'
+        disabled={disabled}
+        onClick={handleToggle}
+        className={`relative inline-flex items-center w-9 h-5 rounded-full transition-colors duration-200 ${
+          isGasless ? 'bg-accent' : 'bg-background/80 border border-border/60'
+        } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+      >
+        <span
+          className={`inline-block w-4 h-4 rounded-full bg-white shadow-sm transition-transform duration-200 ${
+            isGasless ? 'translate-x-[18px]' : 'translate-x-0.5'
+          }`}
+        />
+      </button>
+    </div>
   );
 }

--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -286,7 +286,16 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
         {mode === 'getQuotes' && (
           <div className='flex flex-col gap-2'>
             <SubmissionModeSwitch disabled={isDisabled} />
-            {submissionMode === 'gasless' && <GaslessApprovalNotice />}
+            <div
+              aria-hidden={submissionMode !== 'gasless'}
+              className={`grid transition-[grid-template-rows,opacity] duration-200 ease-out ${
+                submissionMode === 'gasless' ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+              }`}
+            >
+              <div className='overflow-hidden'>
+                <GaslessApprovalNotice />
+              </div>
+            </div>
           </div>
         )}
 

--- a/examples/ui/app/cross-chain/components/SwapForm.tsx
+++ b/examples/ui/app/cross-chain/components/SwapForm.tsx
@@ -284,7 +284,7 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
         />
 
         {mode === 'getQuotes' && (
-          <div className='flex flex-col gap-2'>
+          <div className='flex flex-col'>
             <SubmissionModeSwitch disabled={isDisabled} />
             <div
               aria-hidden={submissionMode !== 'gasless'}
@@ -293,7 +293,9 @@ export function SwapForm({ onSubmit, onInputChange, isLoading = false, isDisable
               }`}
             >
               <div className='overflow-hidden'>
-                <GaslessApprovalNotice />
+                <div className='pt-2'>
+                  <GaslessApprovalNotice />
+                </div>
               </div>
             </div>
           </div>

--- a/examples/ui/app/cross-chain/services/sdk.ts
+++ b/examples/ui/app/cross-chain/services/sdk.ts
@@ -40,7 +40,35 @@ function isEnabledForMode(providerId: string, submissionMode: SubmissionMode): b
   return config !== undefined && (submissionMode !== 'gasless' || config.supportsGasless);
 }
 
-export function buildExecutor(isTestnet: boolean, submissionMode: SubmissionMode = 'user-transaction'): Aggregator {
+interface ExecutorPair {
+  'user-transaction': Aggregator;
+  gasless: Aggregator;
+}
+
+let cachedExecutors: { isTestnet: boolean; pair: ExecutorPair } | null = null;
+
+/**
+ * Returns the executor for the given submission mode, building and prefetching both on first call
+ * (or whenever `isTestnet` changes). Keeping both instances alive preserves the SDK's internal
+ * asset discovery cache across submission-mode toggles.
+ *
+ * NOTE: a real dApp would typically commit to one submission mode and instantiate a single
+ * executor. We keep both warm because this demo lets the user flip between modes at runtime.
+ */
+export function getExecutor(isTestnet: boolean, submissionMode: SubmissionMode): Aggregator {
+  if (cachedExecutors?.isTestnet !== isTestnet) {
+    const pair: ExecutorPair = {
+      'user-transaction': buildExecutor(isTestnet, 'user-transaction'),
+      gasless: buildExecutor(isTestnet, 'gasless'),
+    };
+    void pair['user-transaction'].discoverAssets();
+    void pair.gasless.discoverAssets();
+    cachedExecutors = { isTestnet, pair };
+  }
+  return cachedExecutors.pair[submissionMode];
+}
+
+function buildExecutor(isTestnet: boolean, submissionMode: SubmissionMode = 'user-transaction'): Aggregator {
   const rpcUrls = isTestnet ? TESTNET_RPC_URLS : MAINNET_RPC_URLS;
   const oifSolverId = isTestnet ? 'testnet-solver' : 'mainnet-solver';
   const lifiUrl = isTestnet ? LIFI_INTENTS_ORDER_SERVER_DEV_URL : LIFI_INTENTS_ORDER_SERVER_URL;

--- a/examples/ui/app/cross-chain/services/sdk.ts
+++ b/examples/ui/app/cross-chain/services/sdk.ts
@@ -68,6 +68,7 @@ export function getExecutor(isTestnet: boolean, submissionMode: SubmissionMode):
   return cachedExecutors.pair[submissionMode];
 }
 
+/** Internal helper for {@link getExecutor}. Builds a single executor; bypasses the warm-pair cache. */
 function buildExecutor(isTestnet: boolean, submissionMode: SubmissionMode = 'user-transaction'): Aggregator {
   const rpcUrls = isTestnet ? TESTNET_RPC_URLS : MAINNET_RPC_URLS;
   const oifSolverId = isTestnet ? 'testnet-solver' : 'mainnet-solver';

--- a/examples/ui/app/cross-chain/stores/crossChainStore.ts
+++ b/examples/ui/app/cross-chain/stores/crossChainStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { buildExecutor } from '../services/sdk';
+import { getExecutor } from '../services/sdk';
 import {
   readBuildModeFromUrl,
   readGaslessSubmissionFromUrl,
@@ -40,7 +40,7 @@ if (typeof window !== 'undefined' && initialSubmissionMode !== preferredSubmissi
 
 export const useCrossChainStore = create<CrossChainState>((set, get) => ({
   isTestnet: initialIsTestnet,
-  executor: buildExecutor(initialIsTestnet, initialSubmissionMode),
+  executor: getExecutor(initialIsTestnet, initialSubmissionMode),
   mode: initialMode,
   buildQuoteProviderId: 'across',
   submissionMode: initialSubmissionMode,
@@ -48,7 +48,7 @@ export const useCrossChainStore = create<CrossChainState>((set, get) => ({
   setIsTestnet: (isTestnet) => {
     if (isTestnet === get().isTestnet) return;
     writeIsTestnetParam(isTestnet);
-    set({ isTestnet, executor: buildExecutor(isTestnet, get().submissionMode) });
+    set({ isTestnet, executor: getExecutor(isTestnet, get().submissionMode) });
   },
 
   setMode: (mode) => {
@@ -62,7 +62,7 @@ export const useCrossChainStore = create<CrossChainState>((set, get) => ({
       set({
         mode,
         submissionMode: nextSubmissionMode,
-        executor: buildExecutor(get().isTestnet, nextSubmissionMode),
+        executor: getExecutor(get().isTestnet, nextSubmissionMode),
       });
     } else {
       set({ mode });
@@ -74,6 +74,6 @@ export const useCrossChainStore = create<CrossChainState>((set, get) => ({
   setSubmissionMode: (submissionMode) => {
     if (submissionMode === get().submissionMode) return;
     writeGaslessSubmissionParam(submissionMode === 'gasless');
-    set({ submissionMode, executor: buildExecutor(get().isTestnet, submissionMode) });
+    set({ submissionMode, executor: getExecutor(get().isTestnet, submissionMode) });
   },
 }));


### PR DESCRIPTION
Proposed on top of #331.

Replaces the nested TabSwitch inside Get Quotes with a single-row labeled switch ("Off-chain signature"). The Transactions/Gasless tab inside a tab read as two competing controls; a switch reads as an option on the existing form.

The approval notice now expands/collapses with a grid-rows transition instead of mount/unmount, so toggling the switch animates the explanation in and out.

No store or behaviour changes — `submissionMode` still flips between `user-transaction` and `gasless`, just through a different control.