### PR TITLE
fix(ui): keep OIF supportedTypes unfiltered

### DIFF
--- a/examples/ui/app/cross-chain/services/sdk.ts
+++ b/examples/ui/app/cross-chain/services/sdk.ts
@@ -57,12 +57,12 @@ export function buildExecutor(isTestnet: boolean, submissionMode: SubmissionMode
   }
 
   if (isEnabledForMode('oif', submissionMode)) {
+    // OIF mainnet-solver doesn't quote user-open-v0; skip the filter (EFI-958).
     providers.push(
       createCrossChainProvider(PROTOCOLS.OIF, {
         solverId: oifSolverId,
         url: OIF_API_URL,
         providerId: 'oif',
-        submissionModes,
       }),
     );
   }


### PR DESCRIPTION
## Summary

PR #328 (submission mode toggle) started passing `submissionModes: [mode]` to the OIF provider. The adapter then filters `supportedTypes` down to `["oif-user-open-v0"]` in `user-transaction` mode. The mainnet-solver does not quote that type, so every Get Quotes call against OIF in the default mode returns `AGGREGATION_ERROR / All solvers failed to provide quotes`.

This restores OIF's previous behaviour by not passing `submissionModes`, so the adapter keeps all three `supportedTypes` and the solver responds (currently always with `oif-3009-v0` for the mockUSDC tokens). The submission mode toggle keeps working for Relay and Bungee.

Closes EFI-958