### PR TITLE
fix(cross-chain): lower EventBasedFillWatcher block range to 9_000

### DIFF
--- a/.changeset/lower-fill-watcher-block-range.md
+++ b/.changeset/lower-fill-watcher-block-range.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Lower `EventBasedFillWatcher` block range from 40,000 to 9,000.
+
+`arbitrum-one-rpc.publicnode.com` caps `eth_getLogs` at 10,000 blocks and rejected every poll with `exceed maximum block range`. The error was swallowed as "not filled yet", so on-chain tracking for orders destined to Arbitrum (e.g. OIF buildQuote) never detected the `OutputFilled` event and timed out as `Awaiting solver` even when the fill had already happened on-chain. 9,000 sits under every public RPC limit we use (publicnode-arbitrum: 10k, publicnode-base/optimism: 50k) and still gives ~37 min of detection window on Arbitrum, which is plenty for fresh fills.

--- a/packages/cross-chain/src/core/services/EventBasedFillWatcher.ts
+++ b/packages/cross-chain/src/core/services/EventBasedFillWatcher.ts
@@ -69,7 +69,7 @@ export class EventBasedFillWatcher implements FillWatcher {
      *
      * @param params - Parameters for getting the fill
      * @returns Fill event data (null if not filled), order status, and optional failure reason
-     * @note Only searches the last 40,000 blocks. Older fills will not be detected.
+     * @note Only searches the last 9,000 blocks. Older fills will not be detected.
      */
     async getFill(params: GetFillParams): Promise<{
         fillEvent: FillEvent | null;
@@ -89,7 +89,9 @@ export class EventBasedFillWatcher implements FillWatcher {
         try {
             const currentBlock = await publicClient.getBlockNumber();
 
-            const maxBlockRange = 40000n; // Public RPCs limit to 50,000 blocks max
+            // Arbitrum publicnode caps eth_getLogs at 10,000 blocks; other public RPCs allow more.
+            // 9,000 keeps us safely under every common public RPC limit.
+            const maxBlockRange = 9000n;
             const fromBlock = currentBlock > maxBlockRange ? currentBlock - maxBlockRange : 0n;
 
             const logsArgs = this.config.buildLogsArgs(params, contractAddress);

--- a/packages/cross-chain/test/services/EventBasedFillWatcher.spec.ts
+++ b/packages/cross-chain/test/services/EventBasedFillWatcher.spec.ts
@@ -105,7 +105,7 @@ describe("EventBasedFillWatcher", () => {
                     originChainId: mockFillParams.originChainId,
                     orderId: mockFillParams.orderId,
                 },
-                fromBlock: 10000n, // 50000 - 40000
+                fromBlock: 41000n, // 50000 - 9000
                 toBlock: "latest",
             });
         });
@@ -131,7 +131,7 @@ describe("EventBasedFillWatcher", () => {
             expect(result.fillEvent?.orderId).toBe(mockFillParams.orderId);
         });
 
-        it("should query correct block range (current - 40000 blocks)", async () => {
+        it("should query correct block range (current - 9000 blocks)", async () => {
             const currentBlock = 100000n;
             mockGetBlockNumber.mockResolvedValue(currentBlock);
             mockGetLogs.mockResolvedValue([]);
@@ -140,14 +140,14 @@ describe("EventBasedFillWatcher", () => {
 
             expect(mockGetLogs).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    fromBlock: 60000n, // 100000 - 40000
+                    fromBlock: 91000n, // 100000 - 9000
                     toBlock: "latest",
                 }),
             );
         });
 
         it("should use block 0 when current block is less than max range", async () => {
-            const currentBlock = 30000n;
+            const currentBlock = 5000n;
             mockGetBlockNumber.mockResolvedValue(currentBlock);
             mockGetLogs.mockResolvedValue([]);
 
@@ -337,7 +337,7 @@ describe("EventBasedFillWatcher", () => {
         });
 
         it("should use block 0 when current block equals max range", async () => {
-            const currentBlock = 40000n;
+            const currentBlock = 9000n;
             mockGetBlockNumber.mockResolvedValue(currentBlock);
             mockGetLogs.mockResolvedValue([]);
 


### PR DESCRIPTION
## Summary

On-chain fill tracking was broken for any order destined to Arbitrum routed through publicnode.

`EventBasedFillWatcher.getFill` was querying `eth_getLogs` with a 40,000-block range. `arbitrum-one-rpc.publicnode.com` caps that at 10,000 blocks and rejects the request with `exceed maximum block range: 10000`. The error gets swallowed in the `catch` block (treated as "not filled yet"), so the watcher polls forever and the UI sits on `Awaiting solver` until the 3-minute timeout — even when the `OutputFilled` event is already on-chain.

This was reproducible from the demo UI: OIF buildQuote → destination Arbitrum → tracking goes through `watchOrderByTxHash` → `EventBasedFillWatcher` → fail. Verified two QA orders that hit this: both filled on-chain (recipients got their USDC), tracker just couldn't see them.

Other publicnode endpoints still allow 50k (base, optimism), but Arbitrum is the outlier at 10k. 9,000 is safely under every public RPC limit we care about and still gives ~37 minutes of detection window on Arbitrum (more on slower chains), which is plenty for fresh fills — the solver fills in seconds.

## Notes

- Updated the inline comment to reflect the real constraint (the old "50,000 max" claim was true for base/optimism, false for arbitrum).
- Tests adjusted for the new value. Full cross-chain suite passes (1042/1042).