### PR TITLE
feat(benchmark): add table, pill and skeleton primitives

### DIFF
--- a/apps/benchmark/app/components/BenchmarkTable.tsx
+++ b/apps/benchmark/app/components/BenchmarkTable.tsx
@@ -1,0 +1,45 @@
+import { Fragment, type ReactNode } from 'react';
+import { cn } from '~/lib/cn';
+
+export interface BenchmarkColumn {
+  key: string;
+  label: string;
+  className?: string;
+}
+
+interface BenchmarkTableProps<T> {
+  columns: readonly BenchmarkColumn[];
+  rows: readonly T[];
+  getRowKey: (row: T) => string;
+  renderRow: (row: T, index: number) => ReactNode;
+  minWidthClass?: string;
+}
+
+export function BenchmarkTable<T>({
+  columns,
+  rows,
+  getRowKey,
+  renderRow,
+  minWidthClass = 'md:min-w-[48rem]',
+}: BenchmarkTableProps<T>) {
+  return (
+    <div className='md:overflow-x-auto'>
+      <table className={cn('w-full table-fixed border-collapse text-left md:table-auto', minWidthClass)}>
+        <thead>
+          <tr className='border-b border-border-subtle font-mono text-caption uppercase tracking-widest text-text-muted'>
+            {columns.map((column) => (
+              <th key={column.key} className={cn('px-3 py-3 font-medium md:px-4', column.className)}>
+                {column.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => (
+            <Fragment key={getRowKey(row)}>{renderRow(row, index)}</Fragment>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/benchmark/app/components/Pill.tsx
+++ b/apps/benchmark/app/components/Pill.tsx
@@ -1,0 +1,31 @@
+import { cn } from '~/lib/cn';
+
+export type PillTone = 'accent' | 'outline' | 'muted' | 'error' | 'success';
+
+interface PillProps {
+  tone: PillTone;
+  title?: string;
+  className?: string;
+  icon?: string;
+  children: React.ReactNode;
+}
+
+const PILL_BASE =
+  'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-mono text-caption uppercase tracking-[0.08em]';
+
+const PILL_TONE: Record<PillTone, string> = {
+  accent: 'bg-accent text-on-accent',
+  outline: 'border border-accent/40 text-accent',
+  muted: 'border border-border-subtle text-text-muted',
+  error: 'border border-error/40 text-error',
+  success: 'border border-success/40 text-success',
+};
+
+export function Pill({ tone, title, className, icon, children }: PillProps) {
+  return (
+    <span title={title} className={cn(PILL_BASE, PILL_TONE[tone], className)}>
+      {icon ? <span aria-hidden='true'>{icon}</span> : null}
+      {children}
+    </span>
+  );
+}

--- a/apps/benchmark/app/components/Skeleton.tsx
+++ b/apps/benchmark/app/components/Skeleton.tsx
@@ -9,7 +9,12 @@ interface SkeletonProps {
 export function Skeleton({ wide = false, reduceMotion = false, className }: SkeletonProps) {
   return (
     <span
-      className={cn('block h-4 bg-border-subtle', !reduceMotion && 'animate-pulse', wide ? 'w-28' : 'w-14', className)}
+      className={cn(
+        'block h-4 bg-border-subtle',
+        !reduceMotion && 'motion-safe:animate-pulse',
+        wide ? 'w-28' : 'w-14',
+        className,
+      )}
     />
   );
 }

--- a/apps/benchmark/app/components/Skeleton.tsx
+++ b/apps/benchmark/app/components/Skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from '~/lib/cn';
+
+interface SkeletonProps {
+  wide?: boolean;
+  reduceMotion?: boolean;
+  className?: string;
+}
+
+export function Skeleton({ wide = false, reduceMotion = false, className }: SkeletonProps) {
+  return (
+    <span
+      className={cn('block h-4 bg-border-subtle', !reduceMotion && 'animate-pulse', wide ? 'w-28' : 'w-14', className)}
+    />
+  );
+}


### PR DESCRIPTION
Adds three shared UI primitives for the benchmark app: `BenchmarkTable`, `Pill`, and `Skeleton`. These are extracted ahead of the larger benchmark page work so the follow-up PRs stay focused on logic, not markup.

`BenchmarkTable` is a generic table wrapper with column config and a `renderRow` callback. `Pill` exposes five tones (accent, outline, muted, error, success) on the same base class. `Skeleton` has a `reduceMotion` toggle so we can drop the pulse where it's distracting.

Closes EFI-964