### PR TITLE
feat(benchmark): add race table UI with static mock fixture

### DIFF
--- a/apps/benchmark/.gitignore
+++ b/apps/benchmark/.gitignore
@@ -30,3 +30,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# playwright
+/test-results/
+/playwright-report/
+/bench-shots/
+/playwright/.cache/

--- a/apps/benchmark/app/components/RaceTable.tsx
+++ b/apps/benchmark/app/components/RaceTable.tsx
@@ -1,0 +1,1 @@
+export { RaceTable } from './race-table/RaceTable';

--- a/apps/benchmark/app/components/RequestBar.tsx
+++ b/apps/benchmark/app/components/RequestBar.tsx
@@ -8,18 +8,13 @@ import { Label } from './Label';
 import { ASSET_SYMBOLS, ASSETS, AssetSymbol } from '~/lib/assets';
 import { CHAIN_IDS, CHAINS, ChainId } from '~/lib/chains';
 import { cn } from '~/lib/cn';
+import { useRequestBarStore, type RequestPreset } from '~/lib/requestBarStore';
 
-const INITIAL_FROM = ChainId.Base;
-const INITIAL_TO = ChainId.Arbitrum;
-const INITIAL_ASSET = AssetSymbol.USDC;
-const INITIAL_AMOUNT = '1,000.00';
-
-const PRESETS = [
+const PRESETS: RequestPreset[] = [
   { label: '$100', amount: '100.00' },
   { label: '$1k', amount: '1,000.00' },
   { label: '$10k', amount: '10,000.00' },
 ];
-const INITIAL_PRESET = '$1k';
 
 function toChainOptions(exclude?: ChainId): DropdownOption<ChainId>[] {
   return CHAIN_IDS.filter((id) => id !== exclude).map((id) => ({
@@ -38,34 +33,48 @@ function toAssetOptions(): DropdownOption<AssetSymbol>[] {
 }
 
 export function RequestBar() {
-  const [fromChainId, setFromChainId] = useState<ChainId>(INITIAL_FROM);
-  const [toChainId, setToChainId] = useState<ChainId>(INITIAL_TO);
-  const [assetSymbol, setAssetSymbol] = useState<AssetSymbol>(INITIAL_ASSET);
-  const [amount, setAmount] = useState(INITIAL_AMOUNT);
-  const [selectedPreset, setSelectedPreset] = useState<string | null>(INITIAL_PRESET);
+  const request = useRequestBarStore((state) => state.request);
+  const setFromChainId = useRequestBarStore((state) => state.setFromChainId);
+  const setToChainId = useRequestBarStore((state) => state.setToChainId);
+  const setAssetSymbol = useRequestBarStore((state) => state.setAssetSymbol);
+  const setAmount = useRequestBarStore((state) => state.setAmount);
+  const setPreset = useRequestBarStore((state) => state.setPreset);
+  const swapChains = useRequestBarStore((state) => state.swapChains);
   const [arrowSpins, setArrowSpins] = useState(0);
 
+  const fromOptions = useMemo(() => toChainOptions(request.toChainId), [request.toChainId]);
+  const toOptions = useMemo(() => toChainOptions(request.fromChainId), [request.fromChainId]);
+  const assetOptions = useMemo(() => toAssetOptions(), []);
+
+  const handleFromChainChange = (id: ChainId) => {
+    if (id === request.fromChainId) return;
+    setFromChainId(id);
+  };
+
+  const handleToChainChange = (id: ChainId) => {
+    if (id === request.toChainId) return;
+    setToChainId(id);
+  };
+
+  const handleAssetChange = (symbol: AssetSymbol) => {
+    if (symbol === request.assetSymbol) return;
+    setAssetSymbol(symbol);
+  };
+
   const handleSwap = () => {
-    setFromChainId(toChainId);
-    setToChainId(fromChainId);
+    swapChains();
     setArrowSpins((count) => count + 1);
   };
 
-  const fromOptions = useMemo(() => toChainOptions(toChainId), [toChainId]);
-  const toOptions = useMemo(() => toChainOptions(fromChainId), [fromChainId]);
-  const assetOptions = useMemo(() => toAssetOptions(), []);
-
   const handleAmountChange = (value: string) => {
-    setAmount(value);
-    setSelectedPreset(null);
+    setAmount({ amount: value, selectedPreset: null });
   };
 
-  const handlePresetClick = (preset: { label: string; amount: string }) => {
-    setAmount(preset.amount);
-    setSelectedPreset(preset.label);
+  const handlePresetClick = (preset: RequestPreset) => {
+    setPreset(preset);
   };
 
-  // TODO(pr-2): wire to quotesService.runRace.
+  // TODO(pr-c): wire submit to the SDK race trigger.
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
   };
@@ -75,29 +84,29 @@ export function RequestBar() {
       <div className='mx-auto max-w-page px-5 py-3 md:px-12 md:py-4 lg:px-24'>
         <div className='flex flex-col gap-3 md:flex-row md:items-center md:gap-6'>
           <div className='flex items-center gap-3 md:gap-5'>
-            <Dropdown label='FROM' value={fromChainId} options={fromOptions} onChange={setFromChainId} />
+            <Dropdown label='FROM' value={request.fromChainId} options={fromOptions} onChange={handleFromChainChange} />
             <Arrow onSwap={handleSwap} spinKey={arrowSpins} />
-            <Dropdown label='TO' value={toChainId} options={toOptions} onChange={setToChainId} />
+            <Dropdown label='TO' value={request.toChainId} options={toOptions} onChange={handleToChainChange} />
           </div>
 
           <Divider />
           <Dropdown
             label='ASSET'
-            value={assetSymbol}
+            value={request.assetSymbol}
             options={assetOptions}
-            onChange={setAssetSymbol}
+            onChange={handleAssetChange}
             minWidthClass='md:min-w-[6.25rem]'
           />
           <Divider />
 
           <div className='flex flex-1 flex-col gap-3 md:flex-row md:items-center md:gap-4'>
-            <AmountField amount={amount} onChange={handleAmountChange} />
+            <AmountField amount={request.amount} onChange={handleAmountChange} />
             <div className='flex gap-1'>
               {PRESETS.map((preset) => (
                 <PresetPill
                   key={preset.label}
                   label={preset.label}
-                  selected={preset.label === selectedPreset}
+                  selected={preset.label === request.selectedPreset}
                   onClick={() => handlePresetClick(preset)}
                   fillContainer
                 />
@@ -143,7 +152,7 @@ function ReRunButton() {
         onClick={() => setSpinKey((count) => count + 1)}
         className='group inline-flex cursor-pointer items-center gap-2 border border-border bg-surface-elevated px-3 py-2.5 font-mono text-label text-text-secondary transition hover:border-text-secondary hover:text-text-primary active:scale-95'
       >
-        <span aria-hidden='true' className='inline-block text-mark text-text-primary'>
+        <span aria-hidden='true' className='inline-block font-mono text-mark text-text-primary'>
           <span key={spinKey} className='animate-spin-once inline-block'>
             ↻
           </span>

--- a/apps/benchmark/app/components/race-table/RaceTable.tsx
+++ b/apps/benchmark/app/components/race-table/RaceTable.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useReducedMotion } from 'framer-motion';
+import { BenchmarkTable } from '../BenchmarkTable';
+import { RaceTableRow } from './RaceTableRow';
+import { RACE_TABLE_COLUMNS } from './constants';
+import { findBestProvider } from './raceRows';
+import type { RaceRow } from './types';
+import type { NetworkAssets } from '@wonderland/interop-cross-chain';
+import { useRequestBarStore } from '~/lib/requestBarStore';
+
+interface RaceTableProps {
+  initialRows: RaceRow[];
+  initialChains: NetworkAssets[];
+}
+
+export function RaceTable({ initialRows, initialChains }: RaceTableProps) {
+  const request = useRequestBarStore((state) => state.request);
+  const storeRows = useRequestBarStore((state) => state.rows);
+  const reduceMotion = useReducedMotion();
+
+  const rows = storeRows.length > 0 ? storeRows : initialRows;
+
+  const winnerProviderId = useMemo(() => findBestProvider(rows, 'output'), [rows]);
+  const firstProviderId = useMemo(() => findBestProvider(rows, 'latency'), [rows]);
+  const maxLatencyMs = useMemo(
+    () =>
+      rows.reduce((max, row) => {
+        const latency = row.quote?.latencyMs;
+        return latency !== undefined && latency > max ? latency : max;
+      }, 0),
+    [rows],
+  );
+  const outputDecimals = lookupOutputDecimals(initialChains, request.toChainId, request.assetSymbol) ?? 6;
+
+  return (
+    <section aria-label='live quote race results' className='overflow-hidden border border-border bg-surface'>
+      <BenchmarkTable
+        columns={RACE_TABLE_COLUMNS}
+        rows={rows}
+        getRowKey={(row) => row.provider.id}
+        renderRow={(row, index) => (
+          <RaceTableRow
+            row={row}
+            rank={row.status === 'settled' ? index + 1 : null}
+            outputDecimals={outputDecimals}
+            isWinner={row.provider.id === winnerProviderId}
+            isFirst={row.provider.id === firstProviderId}
+            maxLatencyMs={maxLatencyMs}
+            assetSymbol={request.assetSymbol}
+            reduceMotion={Boolean(reduceMotion)}
+          />
+        )}
+      />
+    </section>
+  );
+}
+
+function lookupOutputDecimals(chains: NetworkAssets[], chainId: number, symbol: string): number | undefined {
+  const network = chains.find((entry) => entry.chainId === chainId);
+  const asset = network?.assets.find((entry) => entry.symbol.toUpperCase() === symbol);
+  return asset?.decimals;
+}

--- a/apps/benchmark/app/components/race-table/RaceTable.tsx
+++ b/apps/benchmark/app/components/race-table/RaceTable.tsx
@@ -5,7 +5,7 @@ import { useReducedMotion } from 'framer-motion';
 import { BenchmarkTable } from '../BenchmarkTable';
 import { RaceTableRow } from './RaceTableRow';
 import { RACE_TABLE_COLUMNS } from './constants';
-import { findBestProvider } from './raceRows';
+import { findBestProvider, orderRaceRows } from './raceRows';
 import type { RaceRow } from './types';
 import type { NetworkAssets } from '@wonderland/interop-cross-chain';
 import { useRequestBarStore } from '~/lib/requestBarStore';
@@ -20,7 +20,8 @@ export function RaceTable({ initialRows, initialChains }: RaceTableProps) {
   const storeRows = useRequestBarStore((state) => state.rows);
   const reduceMotion = useReducedMotion();
 
-  const rows = storeRows.length > 0 ? storeRows : initialRows;
+  const rawRows = storeRows.length > 0 ? storeRows : initialRows;
+  const rows = useMemo(() => orderRaceRows(rawRows), [rawRows]);
 
   const winnerProviderId = useMemo(() => findBestProvider(rows, 'output'), [rows]);
   const firstProviderId = useMemo(() => findBestProvider(rows, 'latency'), [rows]);

--- a/apps/benchmark/app/components/race-table/RaceTableRow.tsx
+++ b/apps/benchmark/app/components/race-table/RaceTableRow.tsx
@@ -1,0 +1,283 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { motion } from 'framer-motion';
+import { Icon } from '../Icon';
+import { Pill } from '../Pill';
+import { Skeleton } from '../Skeleton';
+import { parseOptionalNumber } from './raceRows';
+import type { RaceRow, RowStatus } from './types';
+import { AssetSymbol } from '~/lib/assets';
+import { cn } from '~/lib/cn';
+import { formatEta, formatLatency, formatTokenAmount, formatUsd } from '~/lib/formatters';
+
+interface RaceTableRowProps {
+  row: RaceRow;
+  rank: number | null;
+  outputDecimals: number;
+  isWinner: boolean;
+  isFirst: boolean;
+  maxLatencyMs: number;
+  assetSymbol: AssetSymbol;
+  reduceMotion: boolean;
+}
+
+export function RaceTableRow({
+  row,
+  rank,
+  outputDecimals,
+  isWinner,
+  isFirst,
+  maxLatencyMs,
+  assetSymbol,
+  reduceMotion,
+}: RaceTableRowProps) {
+  const isQuerying = row.status === 'querying';
+  const isErrored = row.status === 'errored';
+  const isSettled = row.status === 'settled';
+  const outputUsd = parseOptionalNumber(row.quote?.outputAmountUsd);
+  const outputToken = row.quote?.outputAmount ? formatTokenAmount(row.quote.outputAmount, outputDecimals) : '—';
+  const mobileSubtitle = buildMobileSubtitle(row);
+
+  return (
+    <motion.tr
+      layout={!reduceMotion}
+      initial={reduceMotion ? false : { opacity: 0, y: 6 }}
+      animate={
+        reduceMotion
+          ? { opacity: 1 }
+          : isErrored
+            ? { opacity: 1, x: [0, -3, 3, -2, 0], y: 0 }
+            : isWinner
+              ? {
+                  opacity: 1,
+                  y: 0,
+                  boxShadow: ['0 0 0 rgba(26,58,92,0)', '0 0 28px rgba(26,58,92,0.16)', '0 0 0 rgba(26,58,92,0)'],
+                }
+              : { opacity: 1, y: 0 }
+      }
+      transition={{ duration: 0.2 }}
+      className={cn(
+        'h-20 border-b border-border-subtle align-middle transition-colors last:border-b-0 md:h-[72px]',
+        isWinner && 'bg-accent-soft',
+        isErrored && 'text-text-muted',
+      )}
+    >
+      <td className='w-10 px-3 py-3 md:w-12 md:px-4 md:py-4'>
+        <div className='flex items-center gap-2 font-mono text-label'>
+          {isWinner ? (
+            <span className={cn('inline-block size-1.5 rounded-full', row.provider.colorClass)} aria-hidden='true' />
+          ) : null}
+          <span className={cn('tabular-nums', isWinner ? 'text-accent' : 'text-text-secondary')}>{rank ?? '—'}</span>
+        </div>
+      </td>
+      <td className='px-3 py-3 md:px-4 md:py-4'>
+        <div className='flex items-center gap-2.5 md:gap-3'>
+          <Icon src={row.provider.iconUrl} alt='' size='md' />
+          <div className='flex flex-col gap-0.5'>
+            <span className='font-sans text-mark font-medium tracking-[-0.0125em] text-text-primary md:text-base'>
+              {row.provider.displayName}
+            </span>
+            {mobileSubtitle ? (
+              <span className='font-mono text-caption text-text-muted md:hidden'>{mobileSubtitle}</span>
+            ) : null}
+          </div>
+        </div>
+      </td>
+      <td className='hidden px-4 py-4 md:table-cell'>
+        {isQuerying ? (
+          <Skeleton reduceMotion={reduceMotion} />
+        ) : isSettled && row.quote?.latencyMs !== undefined ? (
+          <div className='flex flex-col gap-1.5'>
+            <span className='font-mono text-mark text-text-primary tabular-nums'>
+              <AnimatedLatency value={row.quote.latencyMs} reduceMotion={reduceMotion} />
+            </span>
+            <LatencyBar
+              latencyMs={row.quote.latencyMs}
+              maxLatencyMs={maxLatencyMs}
+              colorClass={row.provider.colorClass}
+            />
+          </div>
+        ) : (
+          <span className='font-mono text-label text-text-muted'>—</span>
+        )}
+      </td>
+      <td className='px-3 py-3 md:px-4 md:py-4'>
+        {isQuerying ? (
+          <div className='flex justify-end'>
+            <Skeleton wide reduceMotion={reduceMotion} />
+          </div>
+        ) : isSettled ? (
+          <div className='flex flex-col items-end gap-1'>
+            <div className='flex items-baseline gap-1.5'>
+              <span className='font-mono text-mark font-medium text-text-primary tabular-nums'>{outputToken}</span>
+              <span className='font-mono text-caption text-text-muted'>{assetSymbol}</span>
+            </div>
+            {outputUsd > 0 ? (
+              <span className='font-mono text-caption text-text-muted tabular-nums'>
+                <AnimatedUsd
+                  value={outputUsd}
+                  fallback={formatUsd(row.quote?.outputAmountUsd)}
+                  reduceMotion={reduceMotion}
+                />
+              </span>
+            ) : null}
+            <div className='md:hidden'>
+              <StatusPill
+                status={row.status}
+                isWinner={isWinner}
+                isFirst={isFirst}
+                errorMessage={row.errorMessage}
+                reduceMotion={reduceMotion}
+              />
+            </div>
+          </div>
+        ) : (
+          <div className='flex flex-col items-end gap-1'>
+            <span className='font-mono text-label text-text-muted'>—</span>
+            <div className='md:hidden'>
+              <StatusPill
+                status={row.status}
+                isWinner={isWinner}
+                isFirst={isFirst}
+                errorMessage={row.errorMessage}
+                reduceMotion={reduceMotion}
+              />
+            </div>
+          </div>
+        )}
+      </td>
+      <td className='hidden px-4 py-4 text-right md:table-cell'>
+        {isQuerying ? (
+          <Skeleton reduceMotion={reduceMotion} />
+        ) : isSettled ? (
+          <span className='font-mono text-label text-text-secondary tabular-nums'>
+            <AnimatedEta value={row.quote?.eta} reduceMotion={reduceMotion} />
+          </span>
+        ) : (
+          <span className='font-mono text-label text-text-muted'>—</span>
+        )}
+      </td>
+      <td className='hidden px-4 py-4 md:table-cell'>
+        <div className='flex justify-end'>
+          <StatusPill
+            status={row.status}
+            isWinner={isWinner}
+            isFirst={isFirst}
+            errorMessage={row.errorMessage}
+            reduceMotion={reduceMotion}
+          />
+        </div>
+      </td>
+    </motion.tr>
+  );
+}
+
+function buildMobileSubtitle(row: RaceRow): string | null {
+  if (row.status !== 'settled' || !row.quote) return null;
+  const latency = row.quote.latencyMs !== undefined ? formatLatency(row.quote.latencyMs) : null;
+  const eta = row.quote.eta !== undefined ? formatEta(Math.round(row.quote.eta)) : null;
+  return [latency, eta].filter(Boolean).join(' · ') || null;
+}
+
+function LatencyBar({
+  latencyMs,
+  maxLatencyMs,
+  colorClass,
+}: {
+  latencyMs: number;
+  maxLatencyMs: number;
+  colorClass: string;
+}) {
+  const widthPercent = Math.max(4, Math.min(100, (latencyMs / Math.max(maxLatencyMs, 1)) * 100));
+  return (
+    <div className='h-[3px] w-40 max-w-full bg-border-subtle' aria-hidden='true'>
+      <div className={cn('h-full', colorClass)} style={{ width: `${widthPercent}%` }} />
+    </div>
+  );
+}
+
+interface StatusPillProps {
+  status: RowStatus;
+  isWinner: boolean;
+  isFirst: boolean;
+  errorMessage?: string;
+  reduceMotion: boolean;
+}
+
+function StatusPill({ status, isWinner, isFirst, errorMessage, reduceMotion }: StatusPillProps) {
+  if (status === 'errored') {
+    return (
+      <Pill tone='error' title={errorMessage}>
+        no route
+      </Pill>
+    );
+  }
+  if (status === 'querying') {
+    return (
+      <Pill tone='muted' className={reduceMotion ? undefined : 'animate-pulse'}>
+        querying
+      </Pill>
+    );
+  }
+  if (status === 'settled' && isWinner) {
+    return (
+      <Pill tone='accent' icon='★'>
+        winner
+      </Pill>
+    );
+  }
+  if (status === 'settled' && isFirst) {
+    return <Pill tone='outline'>first</Pill>;
+  }
+  return null;
+}
+
+function AnimatedLatency({ value, reduceMotion }: { value?: number; reduceMotion: boolean }) {
+  const animated = useCountUp(value, reduceMotion);
+  return <>{formatLatency(animated)}</>;
+}
+
+function AnimatedEta({ value, reduceMotion }: { value?: number; reduceMotion: boolean }) {
+  const animated = useCountUp(value, reduceMotion);
+  return <>{formatEta(animated === undefined ? undefined : Math.round(animated))}</>;
+}
+
+function AnimatedUsd({ value, fallback, reduceMotion }: { value?: number; fallback: string; reduceMotion: boolean }) {
+  const animated = useCountUp(value, reduceMotion);
+  if (animated === undefined) return <>{fallback}</>;
+  return <>{formatUsd(animated.toString())}</>;
+}
+
+function useCountUp(value: number | undefined, reduceMotion: boolean) {
+  const [display, setDisplay] = useState(value);
+  const previous = useRef(value);
+
+  useEffect(() => {
+    if (value === undefined || reduceMotion) {
+      setDisplay(value);
+      previous.current = value;
+      return;
+    }
+
+    const start = previous.current ?? 0;
+    const end = value;
+    const startedAt = performance.now();
+    let frame = 0;
+
+    const tick = (now: number) => {
+      const progress = Math.min((now - startedAt) / 200, 1);
+      setDisplay(start + (end - start) * progress);
+      if (progress < 1) {
+        frame = requestAnimationFrame(tick);
+      } else {
+        previous.current = end;
+      }
+    };
+
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [reduceMotion, value]);
+
+  return display;
+}

--- a/apps/benchmark/app/components/race-table/constants.ts
+++ b/apps/benchmark/app/components/race-table/constants.ts
@@ -1,0 +1,15 @@
+import type { BenchmarkColumn } from '../BenchmarkTable';
+import { ProviderId, PROVIDERS } from '~/lib/providers';
+
+export const RACE_PROVIDER_IDS = [ProviderId.Across, ProviderId.Relay, ProviderId.Lifi, ProviderId.Bungee] as const;
+
+export const RACE_PROVIDERS = RACE_PROVIDER_IDS.map((providerId) => PROVIDERS[providerId]);
+
+export const RACE_TABLE_COLUMNS: readonly BenchmarkColumn[] = [
+  { key: 'rank', label: 'rank', className: 'w-10 md:w-12' },
+  { key: 'provider', label: 'provider', className: 'md:w-60' },
+  { key: 'latency', label: 'latency', className: 'hidden md:table-cell' },
+  { key: 'output', label: 'output', className: 'text-right md:w-[200px]' },
+  { key: 'eta', label: 'eta', className: 'hidden md:table-cell md:w-[100px] text-right' },
+  { key: 'status', label: 'status', className: 'hidden md:table-cell md:w-[160px] text-right' },
+];

--- a/apps/benchmark/app/components/race-table/raceRows.ts
+++ b/apps/benchmark/app/components/race-table/raceRows.ts
@@ -1,0 +1,66 @@
+import { RACE_PROVIDER_IDS } from './constants';
+import type { RaceRow, RowStatus } from './types';
+import type { ProviderQuoteResult } from '~/lib/types';
+import { PROVIDERS, ProviderId } from '~/lib/providers';
+
+export function createRows(status: RowStatus, errorMessage?: string): RaceRow[] {
+  return RACE_PROVIDER_IDS.map((providerId) => ({ provider: PROVIDERS[providerId], status, errorMessage }));
+}
+
+export function buildRowsFromQuotes(quotes: ProviderQuoteResult[]): RaceRow[] {
+  const quoteByProvider = new Map(quotes.map((quote) => [normalizeProviderId(quote.providerId), quote]));
+
+  return RACE_PROVIDER_IDS.map<RaceRow>((providerId) => {
+    const quote = quoteByProvider.get(providerId);
+    if (quote) return { provider: PROVIDERS[providerId], status: 'settled', quote };
+
+    return { provider: PROVIDERS[providerId], status: 'errored', errorMessage: 'NO ROUTE' };
+  });
+}
+
+export function orderRaceRows(rows: RaceRow[]): RaceRow[] {
+  return [...rows].sort((left, right) => {
+    if (left.status === 'settled' && right.status !== 'settled') return -1;
+    if (right.status === 'settled' && left.status !== 'settled') return 1;
+    if (left.status === 'errored' && right.status !== 'errored') return 1;
+    if (right.status === 'errored' && left.status !== 'errored') return -1;
+
+    if (left.status === 'settled' && right.status === 'settled') {
+      return parseOptionalNumber(right.quote?.outputAmountUsd) - parseOptionalNumber(left.quote?.outputAmountUsd);
+    }
+
+    return providerIndex(left.provider.id) - providerIndex(right.provider.id);
+  });
+}
+
+export function findBestProvider(rows: RaceRow[], metric: 'output' | 'latency'): ProviderId | undefined {
+  const settled = rows.filter((row) => row.status === 'settled' && row.quote);
+  const sorted = [...settled].sort((left, right) => {
+    if (metric === 'output') {
+      return parseOptionalNumber(right.quote?.outputAmountUsd) - parseOptionalNumber(left.quote?.outputAmountUsd);
+    }
+
+    return valueOrInfinity(left.quote?.latencyMs) - valueOrInfinity(right.quote?.latencyMs);
+  });
+
+  return sorted[0]?.provider.id;
+}
+
+export function parseOptionalNumber(value: string | number | undefined): number {
+  if (value === undefined) return 0;
+  const parsed = typeof value === 'number' ? value : Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function normalizeProviderId(providerId: string): ProviderId | undefined {
+  const normalized = providerId.toLowerCase();
+  return RACE_PROVIDER_IDS.find((id) => id === normalized);
+}
+
+function providerIndex(providerId: ProviderId): number {
+  return RACE_PROVIDER_IDS.findIndex((id) => id === providerId);
+}
+
+function valueOrInfinity(value: number | undefined): number {
+  return value === undefined ? Number.POSITIVE_INFINITY : value;
+}

--- a/apps/benchmark/app/components/race-table/types.ts
+++ b/apps/benchmark/app/components/race-table/types.ts
@@ -1,0 +1,16 @@
+import type { ProviderId, ProviderMeta } from '~/lib/providers';
+import type { ProviderQuoteResult } from '~/lib/types';
+
+export type RowStatus = 'idle' | 'querying' | 'settled' | 'errored';
+
+export interface RaceRow {
+  provider: ProviderMeta;
+  status: RowStatus;
+  quote?: ProviderQuoteResult;
+  errorMessage?: string;
+}
+
+export interface BestProviders {
+  winnerProviderId?: ProviderId;
+  fastestProviderId?: ProviderId;
+}

--- a/apps/benchmark/app/lib/providers.ts
+++ b/apps/benchmark/app/lib/providers.ts
@@ -1,14 +1,13 @@
 export enum ProviderId {
   Across = 'across',
   Relay = 'relay',
-  Lifi = 'lifi',
+  Lifi = 'lifi-intents',
   Bungee = 'bungee',
 }
 
 export interface ProviderMeta {
   id: ProviderId;
   displayName: string;
-  monogram: string;
   colorClass: string;
   iconUrl: string;
   hasGlobalFeed: boolean;
@@ -19,7 +18,6 @@ export const PROVIDERS: Record<ProviderId, ProviderMeta> = {
   [ProviderId.Across]: {
     id: ProviderId.Across,
     displayName: 'across',
-    monogram: 'AX',
     colorClass: 'bg-provider-across',
     iconUrl: '/icons/providers/across.svg',
     hasGlobalFeed: true,
@@ -27,15 +25,13 @@ export const PROVIDERS: Record<ProviderId, ProviderMeta> = {
   [ProviderId.Relay]: {
     id: ProviderId.Relay,
     displayName: 'relay',
-    monogram: 'RL',
     colorClass: 'bg-provider-relay',
     iconUrl: '/icons/providers/relay.svg',
     hasGlobalFeed: true,
   },
   [ProviderId.Lifi]: {
     id: ProviderId.Lifi,
-    displayName: 'lifi',
-    monogram: 'LI',
+    displayName: 'lifi-intents',
     colorClass: 'bg-provider-lifi',
     iconUrl: '/icons/providers/lifi.svg',
     hasGlobalFeed: true,
@@ -43,7 +39,6 @@ export const PROVIDERS: Record<ProviderId, ProviderMeta> = {
   [ProviderId.Bungee]: {
     id: ProviderId.Bungee,
     displayName: 'bungee',
-    monogram: 'BG',
     colorClass: 'bg-provider-bungee',
     iconUrl: '/icons/providers/bungee.webp',
     hasGlobalFeed: false,

--- a/apps/benchmark/app/lib/requestBarStore.ts
+++ b/apps/benchmark/app/lib/requestBarStore.ts
@@ -55,8 +55,14 @@ export const useRequestBarStore = create<RequestBarState>((set) => ({
   setFromChainId: (fromChainId) => set((state) => ({ request: { ...state.request, fromChainId } })),
   setToChainId: (toChainId) => set((state) => ({ request: { ...state.request, toChainId } })),
   setAssetSymbol: (assetSymbol) => set((state) => ({ request: { ...state.request, assetSymbol } })),
-  setAmount: ({ amount, selectedPreset = null }) =>
-    set((state) => ({ request: { ...state.request, amount, selectedPreset } })),
+  setAmount: ({ amount, selectedPreset }) =>
+    set((state) => ({
+      request: {
+        ...state.request,
+        amount,
+        selectedPreset: selectedPreset === undefined ? state.request.selectedPreset : selectedPreset,
+      },
+    })),
   setPreset: ({ amount, label }) => set((state) => ({ request: { ...state.request, amount, selectedPreset: label } })),
   swapChains: () =>
     set((state) => ({

--- a/apps/benchmark/app/lib/requestBarStore.ts
+++ b/apps/benchmark/app/lib/requestBarStore.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { create } from 'zustand';
+import { AssetSymbol } from './assets';
+import { ChainId } from './chains';
+import type { RaceRow } from '~/components/race-table/types';
+
+export const INITIAL_FROM_CHAIN_ID = ChainId.Arbitrum;
+export const INITIAL_TO_CHAIN_ID = ChainId.Base;
+export const INITIAL_ASSET_SYMBOL = AssetSymbol.USDC;
+export const INITIAL_AMOUNT = '100.00';
+export const INITIAL_PRESET = '$100';
+
+export interface RequestBarRequest {
+  fromChainId: ChainId;
+  toChainId: ChainId;
+  assetSymbol: AssetSymbol;
+  amount: string;
+  selectedPreset: string | null;
+}
+
+export interface AmountUpdate {
+  amount: string;
+  selectedPreset?: string | null;
+}
+
+export interface RequestPreset {
+  label: string;
+  amount: string;
+}
+
+interface RequestBarState {
+  request: RequestBarRequest;
+  rows: RaceRow[];
+  setFromChainId: (fromChainId: ChainId) => void;
+  setToChainId: (toChainId: ChainId) => void;
+  setAssetSymbol: (assetSymbol: AssetSymbol) => void;
+  setAmount: (update: AmountUpdate) => void;
+  setPreset: (preset: RequestPreset) => void;
+  swapChains: () => void;
+  setRows: (rows: RaceRow[]) => void;
+}
+
+const INITIAL_REQUEST: RequestBarRequest = {
+  fromChainId: INITIAL_FROM_CHAIN_ID,
+  toChainId: INITIAL_TO_CHAIN_ID,
+  assetSymbol: INITIAL_ASSET_SYMBOL,
+  amount: INITIAL_AMOUNT,
+  selectedPreset: INITIAL_PRESET,
+};
+
+export const useRequestBarStore = create<RequestBarState>((set) => ({
+  request: INITIAL_REQUEST,
+  rows: [],
+  setFromChainId: (fromChainId) => set((state) => ({ request: { ...state.request, fromChainId } })),
+  setToChainId: (toChainId) => set((state) => ({ request: { ...state.request, toChainId } })),
+  setAssetSymbol: (assetSymbol) => set((state) => ({ request: { ...state.request, assetSymbol } })),
+  setAmount: ({ amount, selectedPreset = null }) =>
+    set((state) => ({ request: { ...state.request, amount, selectedPreset } })),
+  setPreset: ({ amount, label }) => set((state) => ({ request: { ...state.request, amount, selectedPreset: label } })),
+  swapChains: () =>
+    set((state) => ({
+      request: {
+        ...state.request,
+        fromChainId: state.request.toChainId,
+        toChainId: state.request.fromChainId,
+      },
+    })),
+  setRows: (rows) => set({ rows }),
+}));

--- a/apps/benchmark/app/page.tsx
+++ b/apps/benchmark/app/page.tsx
@@ -1,12 +1,61 @@
 import { Footer } from './components/Footer';
 import { Label } from './components/Label';
+import { RaceTable } from './components/RaceTable';
 import { RequestBar } from './components/RequestBar';
 import { SectionFrame } from './components/SectionFrame';
 import { SectionHeader } from './components/SectionHeader';
 import { TopNav } from './components/TopNav';
+import { PROVIDERS, ProviderId } from './lib/providers';
+import type { RaceRow } from './components/race-table/types';
 
 const META_LABEL_CLASS = 'font-mono text-label text-text-muted';
 const PACKAGE_URL = 'https://www.npmjs.com/package/@wonderland/interop-cross-chain';
+
+// Static mock fixture for the race table. PR C swaps this for live SDK results.
+// Default route: USDC arbitrum -> base, $100. across wins both output and latency.
+const STATIC_MOCK_ROWS: RaceRow[] = [
+  {
+    provider: PROVIDERS[ProviderId.Across],
+    status: 'settled',
+    quote: {
+      providerId: 'across',
+      protocolName: 'Across',
+      latencyMs: 320,
+      eta: 2,
+      outputAmount: '99850000',
+      outputAmountUsd: '99.85',
+    },
+  },
+  {
+    provider: PROVIDERS[ProviderId.Relay],
+    status: 'settled',
+    quote: {
+      providerId: 'relay',
+      protocolName: 'Relay',
+      latencyMs: 480,
+      eta: 4,
+      outputAmount: '99800000',
+      outputAmountUsd: '99.80',
+    },
+  },
+  {
+    provider: PROVIDERS[ProviderId.Lifi],
+    status: 'settled',
+    quote: {
+      providerId: 'lifi-intents',
+      protocolName: 'LI.FI',
+      latencyMs: 1640,
+      eta: 8,
+      outputAmount: '99700000',
+      outputAmountUsd: '99.70',
+    },
+  },
+  {
+    provider: PROVIDERS[ProviderId.Bungee],
+    status: 'errored',
+    errorMessage: 'NO ROUTE',
+  },
+];
 
 export default function Home() {
   return (
@@ -34,7 +83,7 @@ export default function Home() {
               </Label>
             }
           />
-          <SectionPlaceholder label='race table arrives in pr 2' />
+          <RaceTable initialRows={STATIC_MOCK_ROWS} initialChains={[]} />
         </SectionFrame>
 
         <SectionFrame variant='tinted'>

--- a/apps/benchmark/package.json
+++ b/apps/benchmark/package.json
@@ -8,12 +8,14 @@
   "type": "module",
   "scripts": {
     "build": "next build",
+    "check-types": "tsc --noEmit -p ./tsconfig.json",
     "dev": "next dev --turbopack",
     "format": "prettier app --write",
     "format:check": "prettier app --check",
     "lint": "eslint app",
     "lint:fix": "eslint app --fix",
-    "start": "next start"
+    "start": "next start",
+    "test:e2e": "playwright test"
   },
   "lint-staged": {
     "app/**/*.{js,jsx,ts,tsx}": "eslint --cache --fix",
@@ -23,17 +25,20 @@
     "@wonderland/interop-addresses": "workspace:*",
     "@wonderland/interop-cross-chain": "workspace:*",
     "clsx": "2.1.1",
+    "framer-motion": "12.39.0",
     "next": "16.1.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "tailwind-merge": "3.3.1",
-    "viem": "2.37.0"
+    "viem": "2.37.0",
+    "zustand": "5.0.3"
   },
   "devDependencies": {
     "@eslint/compat": "2.0.0",
     "@eslint/eslintrc": "3.3.3",
     "@eslint/js": "9.39.2",
     "@next/eslint-plugin-next": "15.3.3",
+    "@playwright/test": "1.57.0",
     "@tailwindcss/postcss": "4.1.15",
     "@types/node": "22.7.4",
     "@types/react": "19.2.7",

--- a/apps/benchmark/playwright.config.ts
+++ b/apps/benchmark/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'list',
+  timeout: 60_000,
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: devices['Desktop Chrome'] }],
+  webServer: {
+    command: 'pnpm build && pnpm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/apps/benchmark/tests/race.spec.ts
+++ b/apps/benchmark/tests/race.spec.ts
@@ -10,11 +10,11 @@ test('renders the race table with all 4 providers', async ({ page }) => {
 });
 
 test('shows the winner pill on the settled top row', async ({ page }) => {
-  await expect(page.getByText('winner').locator('visible=true').first()).toBeVisible();
+  await expect(page.getByText('winner').filter({ visible: true }).first()).toBeVisible();
 });
 
 test('shows a no-route pill for the errored provider', async ({ page }) => {
-  await expect(page.getByText('no route').locator('visible=true').first()).toBeVisible();
+  await expect(page.getByText('no route').filter({ visible: true }).first()).toBeVisible();
 });
 
 test('preset click updates the amount field', async ({ page }) => {

--- a/apps/benchmark/tests/race.spec.ts
+++ b/apps/benchmark/tests/race.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test('renders the race table with all 4 providers', async ({ page }) => {
+  const table = page.getByRole('region', { name: 'live quote race results' });
+  await expect(table.locator('tbody tr')).toHaveCount(4);
+});
+
+test('shows the winner pill on the settled top row', async ({ page }) => {
+  await expect(page.getByText('winner').locator('visible=true').first()).toBeVisible();
+});
+
+test('shows a no-route pill for the errored provider', async ({ page }) => {
+  await expect(page.getByText('no route').locator('visible=true').first()).toBeVisible();
+});
+
+test('preset click updates the amount field', async ({ page }) => {
+  await page.getByRole('button', { name: '$10k', exact: true }).click();
+  await expect(page.getByLabel('AMOUNT')).toHaveValue('10,000.00');
+});
+
+test('swap button flips the FROM and TO chains', async ({ page }) => {
+  const fromButton = page.getByRole('button', { name: /^from:/i });
+  const toButton = page.getByRole('button', { name: /^to:/i });
+  const fromBefore = await fromButton.textContent();
+  const toBefore = await toButton.textContent();
+
+  await page.getByRole('button', { name: 'swap from and to chains' }).click();
+
+  await expect(fromButton).not.toHaveText(fromBefore ?? '');
+  await expect(toButton).not.toHaveText(toBefore ?? '');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ importers:
             clsx:
                 specifier: 2.1.1
                 version: 2.1.1
+            framer-motion:
+                specifier: 12.39.0
+                version: 12.39.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
             next:
                 specifier: 16.1.0
                 version: 16.1.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -278,6 +281,9 @@ importers:
             viem:
                 specifier: 2.37.0
                 version: 2.37.0(bufferutil@4.0.9)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+            zustand:
+                specifier: 5.0.3
+                version: 5.0.3(@types/react@19.2.7)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0))
         devDependencies:
             "@eslint/compat":
                 specifier: 2.0.0
@@ -291,6 +297,9 @@ importers:
             "@next/eslint-plugin-next":
                 specifier: 15.3.3
                 version: 15.3.3
+            "@playwright/test":
+                specifier: 1.57.0
+                version: 1.57.0
             "@tailwindcss/postcss":
                 specifier: 4.1.15
                 version: 4.1.15
@@ -8708,6 +8717,23 @@ packages:
                 integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==,
             }
 
+    framer-motion@12.39.0:
+        resolution:
+            {
+                integrity: sha512-+vnLfzrv0MzjLzNl+nvNvR7jdg3q4cxxjz/YvzfifHl0TREtL00cs1RoMTxs+1PzLiEqZGV6gYsBY0oEAYZ24w==,
+            }
+        peerDependencies:
+            "@emotion/is-prop-valid": "*"
+            react: ^18.0.0 || ^19.0.0
+            react-dom: ^18.0.0 || ^19.0.0
+        peerDependenciesMeta:
+            "@emotion/is-prop-valid":
+                optional: true
+            react:
+                optional: true
+            react-dom:
+                optional: true
+
     fresh@0.5.2:
         resolution:
             {
@@ -11071,6 +11097,18 @@ packages:
         resolution:
             {
                 integrity: sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==,
+            }
+
+    motion-dom@12.40.0:
+        resolution:
+            {
+                integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==,
+            }
+
+    motion-utils@12.39.0:
+        resolution:
+            {
+                integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==,
             }
 
     motion@10.16.2:
@@ -21044,6 +21082,15 @@ snapshots:
 
     fraction.js@5.3.4: {}
 
+    framer-motion@12.39.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+        dependencies:
+            motion-dom: 12.40.0
+            motion-utils: 12.39.0
+            tslib: 2.8.1
+        optionalDependencies:
+            react: 19.1.0
+            react-dom: 19.1.0(react@19.1.0)
+
     fresh@0.5.2: {}
 
     fs-extra@11.3.3:
@@ -22722,6 +22769,12 @@ snapshots:
             ufo: 1.6.1
 
     modern-ahocorasick@1.1.0: {}
+
+    motion-dom@12.40.0:
+        dependencies:
+            motion-utils: 12.39.0
+
+    motion-utils@12.39.0: {}
 
     motion@10.16.2:
         dependencies:
@@ -25348,5 +25401,11 @@ snapshots:
             "@types/react": 19.2.7
             react: 19.1.0
             use-sync-external-store: 1.4.0(react@19.1.0)
+
+    zustand@5.0.3(@types/react@19.2.7)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0)):
+        optionalDependencies:
+            "@types/react": 19.2.7
+            react: 19.1.0
+            use-sync-external-store: 1.6.0(react@19.1.0)
 
     zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
Second of three PRs splitting out of the closed #326. Race table Section 01 fully assembled with a static mock fixture, no SDK, no network.

- Zustand `requestBarStore` with `request` and `rows`.
- `RaceTable` + `RaceTableRow` per Pencil: rank dot on winner, colored latency bar, single status pill, fixed row height (no layout shift), mobile responsive (no horizontal scroll).
- `RequestBar` handlers update the store; no fetch yet (that's PR C).
- Static mock fixture of 4 rows shows the visual story end-to-end (settled winner / settled / settled / errored).
- Playwright tests assert the visual story; no network calls.

Closes EFI-965.

## Stack
- Base: `dev` (PR A merged in #339)
- Next: PR C wires the real SDK trigger (EFI-966)