### PR TITLE
feat(cross-chain): accept protocol name strings in createAggregator

### DIFF
--- a/.changeset/across-stable-provider-id.md
+++ b/.changeset/across-stable-provider-id.md
@@ -1,7 +1,7 @@
 ---
-"@wonderland/interop-cross-chain": patch
+"@wonderland/interop-cross-chain": minor
 ---
 
 Use a stable default `providerId` for Across
 
-`AcrossProvider`'s default `providerId` is now the stable `"across"` (matching `relay` and `bungee`), instead of an `across_<uuid>` value generated once at module load. Pass an explicit `providerId` to run several Across providers in the same aggregator.
+`AcrossProvider`'s default `providerId` is now the stable `"across"` (matching `relay` and `bungee`), instead of an `across_<uuid>` value generated once at module load. Because the default is stable, adding two Across providers with default config to the same aggregator now resolves to the same id and throws `DuplicateProvider`; pass an explicit `providerId` to run several Across providers.

--- a/.changeset/across-stable-provider-id.md
+++ b/.changeset/across-stable-provider-id.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Use a stable default `providerId` for Across
+
+`AcrossProvider`'s default `providerId` is now the stable `"across"` (matching `relay` and `bungee`), instead of an `across_<uuid>` value generated once at module load. Pass an explicit `providerId` to run several Across providers in the same aggregator.

--- a/.changeset/aggregator-duplicate-provider.md
+++ b/.changeset/aggregator-duplicate-provider.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Throw `DuplicateProvider` on conflicting provider IDs
+
+`createAggregator` now throws the new `DuplicateProvider` error when two providers resolve to the same `providerId`, instead of silently overwriting one of them. Providers are indexed by a `Map`, so any string (including reserved object keys like `toString` or `__proto__`) is treated as an ordinary id.

--- a/.changeset/aggregator-provider-name-strings.md
+++ b/.changeset/aggregator-provider-name-strings.md
@@ -1,0 +1,10 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Accept protocol name strings in `createAggregator` providers
+
+-   `createAggregator({ providers })` now accepts the optional-config protocol names `"across"`, `"relay"` and `"bungee"` alongside `CrossChainProvider` instances. Names are instantiated with default config via `createCrossChainProvider`, so `providers: ["across", "relay", "bungee"]` works without wiring each provider by hand. `oif` and `lifi-intents` still require instances since their config is mandatory.
+-   The aggregator now throws `DuplicateProvider` when two providers resolve to the same `providerId` instead of silently overwriting one of them.
+-   `AcrossProvider`'s default `providerId` is now the stable `"across"` (matching `relay` and `bungee`), instead of a `across_<uuid>` value that was generated once at module load. Pass an explicit `providerId` to run several Across providers in the same aggregator.
+-   New exported types `AggregatorProvider`, `CreateAggregatorConfig` and `OptionalConfigProtocols`.

--- a/.changeset/aggregator-provider-name-strings.md
+++ b/.changeset/aggregator-provider-name-strings.md
@@ -4,4 +4,4 @@
 
 Accept protocol name strings in `createAggregator` providers
 
-`createAggregator({ providers })` now accepts the optional-config protocol names `"across"`, `"relay"` and `"bungee"` alongside `CrossChainProvider` instances. Names are instantiated with default config via `createCrossChainProvider`, so `providers: ["across", "relay", "bungee"]` works without wiring each provider by hand. `oif` and `lifi-intents` still require instances since their config is mandatory. Adds the exported types `AggregatorProvider`, `CreateAggregatorConfig` and `OptionalConfigProtocols`.
+`createAggregator({ providers })` now accepts the optional-config protocol names `"across"`, `"relay"` and `"bungee"` alongside `CrossChainProvider` instances. Names are instantiated with default config via `createCrossChainProvider`, so `providers: ["across", "relay", "bungee"]` works without wiring each provider by hand. `oif` and `lifi-intents` still require instances since their config is mandatory.

--- a/.changeset/aggregator-provider-name-strings.md
+++ b/.changeset/aggregator-provider-name-strings.md
@@ -4,7 +4,4 @@
 
 Accept protocol name strings in `createAggregator` providers
 
--   `createAggregator({ providers })` now accepts the optional-config protocol names `"across"`, `"relay"` and `"bungee"` alongside `CrossChainProvider` instances. Names are instantiated with default config via `createCrossChainProvider`, so `providers: ["across", "relay", "bungee"]` works without wiring each provider by hand. `oif` and `lifi-intents` still require instances since their config is mandatory.
--   The aggregator now throws `DuplicateProvider` when two providers resolve to the same `providerId` instead of silently overwriting one of them.
--   `AcrossProvider`'s default `providerId` is now the stable `"across"` (matching `relay` and `bungee`), instead of a `across_<uuid>` value that was generated once at module load. Pass an explicit `providerId` to run several Across providers in the same aggregator.
--   New exported types `AggregatorProvider`, `CreateAggregatorConfig` and `OptionalConfigProtocols`.
+`createAggregator({ providers })` now accepts the optional-config protocol names `"across"`, `"relay"` and `"bungee"` alongside `CrossChainProvider` instances. Names are instantiated with default config via `createCrossChainProvider`, so `providers: ["across", "relay", "bungee"]` works without wiring each provider by hand. `oif` and `lifi-intents` still require instances since their config is mandatory. Adds the exported types `AggregatorProvider`, `CreateAggregatorConfig` and `OptionalConfigProtocols`.

--- a/apps/docs/pages/cross-chain/getting-started.mdx
+++ b/apps/docs/pages/cross-chain/getting-started.mdx
@@ -184,7 +184,24 @@ Omit `chainIds` to discover across every chain each provider supports. For a sin
 
 ## Compare quotes from multiple providers
 
-Use the `Aggregator` to fetch and sort quotes from multiple providers at once:
+Use the `Aggregator` to fetch and sort quotes from multiple providers at once. For protocols whose config is optional (`across`, `relay`, `bungee`) you can pass the protocol name directly and the aggregator creates the provider with defaults:
+
+```typescript
+import { createAggregator } from "@wonderland/interop-cross-chain";
+
+const aggregator = createAggregator({
+    providers: ["across", "relay", "bungee"],
+});
+
+const response = await aggregator.getQuotes({
+    /* same QuoteRequest as above */
+});
+
+console.log(`Got ${response.quotes.length} quotes`);
+response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`));
+```
+
+Need custom config — or a provider that requires it, like `oif` / `lifi-intents` — pass an instance instead. You can mix both forms:
 
 ```typescript
 import {
@@ -196,16 +213,11 @@ import {
 const acrossProvider = createCrossChainProvider(PROTOCOLS.ACROSS, { isTestnet: true });
 
 const aggregator = createAggregator({
-    providers: [provider, acrossProvider],
+    providers: ["relay", acrossProvider],
 });
-
-const response = await aggregator.getQuotes({
-    /* same QuoteRequest as above */
-});
-
-console.log(`Got ${response.quotes.length} quotes`);
-response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`));
 ```
+
+Each provider must have a unique `providerId`; passing two that resolve to the same id throws `DuplicateProvider`.
 
 ## Quick reference
 

--- a/apps/docs/pages/cross-chain/getting-started.mdx
+++ b/apps/docs/pages/cross-chain/getting-started.mdx
@@ -187,10 +187,10 @@ Omit `chainIds` to discover across every chain each provider supports. For a sin
 Use the `Aggregator` to fetch and sort quotes from multiple providers at once. For protocols whose config is optional (`across`, `relay`, `bungee`) you can pass the protocol name directly and the aggregator creates the provider with defaults:
 
 ```typescript
-import { createAggregator } from "@wonderland/interop-cross-chain";
+import { createAggregator, PROTOCOLS } from "@wonderland/interop-cross-chain";
 
 const aggregator = createAggregator({
-    providers: ["across", "relay", "bungee"],
+    providers: [PROTOCOLS.ACROSS, PROTOCOLS.RELAY, PROTOCOLS.BUNGEE],
 });
 
 const response = await aggregator.getQuotes({
@@ -201,7 +201,7 @@ console.log(`Got ${response.quotes.length} quotes`);
 response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`));
 ```
 
-Need custom config — or a provider that requires it, like `oif` / `lifi-intents` — pass an instance instead. You can mix both forms:
+Need custom config — or a provider that requires it, like OIF / LiFi Intents — pass an instance instead. You can mix both forms:
 
 ```typescript
 import {
@@ -213,7 +213,7 @@ import {
 const acrossProvider = createCrossChainProvider(PROTOCOLS.ACROSS, { isTestnet: true });
 
 const aggregator = createAggregator({
-    providers: ["relay", acrossProvider],
+    providers: [PROTOCOLS.RELAY, acrossProvider],
 });
 ```
 

--- a/apps/docs/pages/cross-chain/providers.mdx
+++ b/apps/docs/pages/cross-chain/providers.mdx
@@ -53,6 +53,8 @@ createCrossChainProvider("bungee", {
 | `lifi-intents` | `orderServerUrl`  | `providerId`, `headers`                                                                                                                               |
 | `bungee`       | (none)            | `tier`, `apiKey`, `affiliateId`, `feeBps`, `feeTakerAddress`, `submissionModes`, `slippage`, `refuel`, `enableOtherProviders`, `enableMultipleRoutes` |
 
+The optional-config protocols (`across`, `relay`, `bungee`) can also be passed to `createAggregator` by name to get defaults — see [Compare quotes from multiple providers](./getting-started#compare-quotes-from-multiple-providers). Use `createCrossChainProvider` when you need custom config.
+
 ## `isTestnet` semantics
 
 Only `across` and `relay` accept `isTestnet`. What it changes:

--- a/packages/cross-chain/src/core/errors/DuplicateProvider.exception.ts
+++ b/packages/cross-chain/src/core/errors/DuplicateProvider.exception.ts
@@ -1,0 +1,7 @@
+export class DuplicateProvider extends Error {
+    constructor(providerId: string) {
+        super(
+            `Duplicate provider id "${providerId}" — each provider must have a unique providerId`,
+        );
+    }
+}

--- a/packages/cross-chain/src/core/errors/DuplicateProvider.exception.ts
+++ b/packages/cross-chain/src/core/errors/DuplicateProvider.exception.ts
@@ -3,5 +3,6 @@ export class DuplicateProvider extends Error {
         super(
             `Duplicate provider id "${providerId}" — each provider must have a unique providerId`,
         );
+        this.name = "DuplicateProvider";
     }
 }

--- a/packages/cross-chain/src/core/errors/index.ts
+++ b/packages/cross-chain/src/core/errors/index.ts
@@ -4,6 +4,7 @@ export * from "./UnsupportedAction.exception.js";
 export * from "./UnsupportedChainId.exception.js";
 export * from "./UnsupportedProtocol.exception.js";
 export * from "./ProviderNotFound.exception.js";
+export * from "./DuplicateProvider.exception.js";
 export * from "./UnsupportedAddress.exception.js";
 export * from "./ProviderGetQuoteFailure.exception.js";
 export * from "./ProviderGetStatusFailure.exception.js";

--- a/packages/cross-chain/src/core/services/aggregator.ts
+++ b/packages/cross-chain/src/core/services/aggregator.ts
@@ -52,7 +52,7 @@ const getDefaultSortingStrategy = (): SortingStrategy => new BestOutputStrategy(
  * Uses SDK-native types throughout.
  */
 class Aggregator {
-    private readonly providers: Record<string, CrossChainProvider>;
+    private readonly providers: Map<string, CrossChainProvider>;
     private readonly sortingStrategy: SortingStrategy;
     private readonly timeoutMs: number;
     private readonly trackerFactory: AggregatorConfig["trackerFactory"];
@@ -74,17 +74,14 @@ class Aggregator {
             discoveryFactory,
             approvalService,
         } = config;
-        this.providers = providers.reduce(
-            (acc, provider) => {
-                const id = provider.getProviderId();
-                if (acc[id]) {
-                    throw new DuplicateProvider(id);
-                }
-                acc[id] = provider;
-                return acc;
-            },
-            {} as Record<string, CrossChainProvider>,
-        );
+        this.providers = new Map();
+        for (const provider of providers) {
+            const id = provider.getProviderId();
+            if (this.providers.has(id)) {
+                throw new DuplicateProvider(id);
+            }
+            this.providers.set(id, provider);
+        }
         this.sortingStrategy = sortingStrategy ?? getDefaultSortingStrategy();
         this.timeoutMs = timeoutMs ?? DEFAULT_TIMEOUT_MS;
         this.trackerFactory = trackerFactory;
@@ -161,7 +158,7 @@ class Aggregator {
      */
     async getQuotes(params: QuoteRequest): Promise<GetQuotesResponse> {
         const resultQuotes = await Promise.all(
-            Object.values(this.providers).map(async (provider) => {
+            [...this.providers.values()].map(async (provider) => {
                 const isSupported = await this.supportsRequestedAssets(provider, params);
                 if (!isSupported) {
                     return [];
@@ -231,7 +228,7 @@ class Aggregator {
     async submitOrder(quote: ExecutableQuote, signature: Hex): Promise<SubmitOrderResponse> {
         const providerId = quote._providerId;
 
-        const provider = this.providers[providerId];
+        const provider = this.providers.get(providerId);
         if (!provider) {
             throw new ProviderNotFound(providerId);
         }
@@ -251,7 +248,7 @@ class Aggregator {
      * @returns An executable quote containing a TransactionStep
      */
     async buildQuote(providerId: string, params: BuildQuoteRequest): Promise<ExecutableQuote> {
-        const provider = this.providers[providerId];
+        const provider = this.providers.get(providerId);
         if (!provider) {
             throw new ProviderNotFound(providerId);
         }
@@ -377,7 +374,7 @@ class Aggregator {
             return this.trackerCache.get(providerId)!;
         }
 
-        const provider = this.providers[providerId];
+        const provider = this.providers.get(providerId);
         if (!provider) {
             throw new ProviderNotFound(providerId);
         }

--- a/packages/cross-chain/src/core/services/aggregator.ts
+++ b/packages/cross-chain/src/core/services/aggregator.ts
@@ -16,6 +16,7 @@ import type {
 } from "../types/assetDiscovery.js";
 import type { OrderTrackingInfo, WatchOrderParams } from "../types/orderTracking.js";
 import { AssetDiscoveryFailure } from "../errors/AssetDiscoveryFailure.exception.js";
+import { DuplicateProvider } from "../errors/DuplicateProvider.exception.js";
 import { ProviderNotFound } from "../errors/ProviderNotFound.exception.js";
 import { ProviderTimeout } from "../errors/ProviderTimeout.exception.js";
 import { CrossChainProvider } from "../interfaces/crossChainProvider.interface.js";
@@ -75,7 +76,11 @@ class Aggregator {
         } = config;
         this.providers = providers.reduce(
             (acc, provider) => {
-                acc[provider.getProviderId()] = provider;
+                const id = provider.getProviderId();
+                if (acc[id]) {
+                    throw new DuplicateProvider(id);
+                }
+                acc[id] = provider;
                 return acc;
             },
             {} as Record<string, CrossChainProvider>,

--- a/packages/cross-chain/src/external.ts
+++ b/packages/cross-chain/src/external.ts
@@ -14,7 +14,6 @@ export {
     PROTOCOLS,
     type SupportedProtocols,
     type SupportedProtocolsConfigs,
-    type OptionalConfigProtocols,
     // Providers
     AcrossProvider,
     OifProvider,
@@ -28,8 +27,6 @@ export {
     // Aggregator
     Aggregator,
     createAggregator,
-    type AggregatorProvider,
-    type CreateAggregatorConfig,
     // Approval
     createApprovalService,
     ExactAmountStrategy,

--- a/packages/cross-chain/src/external.ts
+++ b/packages/cross-chain/src/external.ts
@@ -14,6 +14,7 @@ export {
     PROTOCOLS,
     type SupportedProtocols,
     type SupportedProtocolsConfigs,
+    type OptionalConfigProtocols,
     // Providers
     AcrossProvider,
     OifProvider,
@@ -27,6 +28,8 @@ export {
     // Aggregator
     Aggregator,
     createAggregator,
+    type AggregatorProvider,
+    type CreateAggregatorConfig,
     // Approval
     createApprovalService,
     ExactAmountStrategy,

--- a/packages/cross-chain/src/factories/aggregatorFactory.ts
+++ b/packages/cross-chain/src/factories/aggregatorFactory.ts
@@ -1,22 +1,23 @@
-import {
-    Aggregator,
-    AggregatorConfig,
-    AssetDiscoveryFactory,
-    OrderTrackerFactory,
-} from "../internal.js";
+import type { AggregatorConfig, CrossChainProvider, OptionalConfigProtocols } from "../internal.js";
+import { Aggregator, AssetDiscoveryFactory, OrderTrackerFactory } from "../internal.js";
+import { createCrossChainProvider } from "./crossChainProviderFactory.js";
 
-/**
- * Create an aggregator with default factories.
- *
- * When `trackerFactory` or `discoveryFactory` are not provided, the defaults
- * (OrderTrackerFactory, AssetDiscoveryFactory) are created automatically.
- *
- * @param config - Configuration including providers, sorting strategy, timeout, and optional factories
- * @returns The aggregator instance
- */
-export const createAggregator = (config: AggregatorConfig): Aggregator => {
+/** A provider instance, or an optional-config protocol name to instantiate with defaults. */
+export type AggregatorProvider = CrossChainProvider | OptionalConfigProtocols;
+
+/** Like {@link AggregatorConfig}, but `providers` also accepts protocol names. */
+export interface CreateAggregatorConfig extends Omit<AggregatorConfig, "providers"> {
+    providers: AggregatorProvider[];
+}
+
+/** Creates an aggregator, resolving protocol names to providers and applying default factories. */
+export const createAggregator = (config: CreateAggregatorConfig): Aggregator => {
+    const providers = config.providers.map((provider) =>
+        typeof provider === "string" ? createCrossChainProvider(provider) : provider,
+    );
     return new Aggregator({
         ...config,
+        providers,
         trackerFactory: config.trackerFactory ?? new OrderTrackerFactory(),
         discoveryFactory: config.discoveryFactory ?? new AssetDiscoveryFactory(),
     });

--- a/packages/cross-chain/src/factories/crossChainProviderFactory.ts
+++ b/packages/cross-chain/src/factories/crossChainProviderFactory.ts
@@ -14,8 +14,8 @@ import {
 } from "../internal.js";
 import { PROTOCOLS } from "./providers.js";
 
-/** Constructor args for a protocol: config is optional for optional-config protocols. */
-type ProtocolArgs<P extends SupportedProtocols> = P extends OptionalConfigProtocols
+/** Constructor args per protocol; `[P]` keeps it non-distributive so a union name still requires config. */
+type ProtocolArgs<P extends SupportedProtocols> = [P] extends [OptionalConfigProtocols]
     ? [config?: SupportedProtocolsConfigs<P>]
     : [config: SupportedProtocolsConfigs<P>];
 

--- a/packages/cross-chain/src/factories/crossChainProviderFactory.ts
+++ b/packages/cross-chain/src/factories/crossChainProviderFactory.ts
@@ -1,11 +1,9 @@
+import type { CrossChainProvider } from "../internal.js";
 import type {
-    AcrossConfigs,
-    BungeeConfigs,
-    LifiIntentsProviderConfig,
-    OifProviderConfig,
-    RelayConfigs,
-} from "../internal.js";
-import type { SupportedProtocols } from "./providers.js";
+    OptionalConfigProtocols,
+    SupportedProtocols,
+    SupportedProtocolsConfigs,
+} from "./providers.js";
 import {
     AcrossProvider,
     BungeeProvider,
@@ -14,50 +12,34 @@ import {
     RelayProvider,
     UnsupportedProtocol,
 } from "../internal.js";
-import { PROTOCOLS } from "./providers.js";
 
-/** Maps each protocol to its provider factory. Source of truth for the types below. */
-const PROTOCOL_FACTORIES = {
-    [PROTOCOLS.ACROSS]: (config?: AcrossConfigs): AcrossProvider =>
-        new AcrossProvider(config ?? {}),
-    [PROTOCOLS.RELAY]: (config?: RelayConfigs): RelayProvider => new RelayProvider(config ?? {}),
-    [PROTOCOLS.BUNGEE]: (config?: BungeeConfigs): BungeeProvider =>
-        new BungeeProvider(config ?? {}),
-    [PROTOCOLS.OIF]: (config: OifProviderConfig): OifProvider => new OifProvider(config),
-    [PROTOCOLS.LIFI_INTENTS]: (config: LifiIntentsProviderConfig): LifiIntentsProvider =>
-        new LifiIntentsProvider(config),
+/** Constructor args for a protocol: config is optional for optional-config protocols. */
+type ProtocolArgs<P extends SupportedProtocols> = P extends OptionalConfigProtocols
+    ? [config?: SupportedProtocolsConfigs<P>]
+    : [config: SupportedProtocolsConfigs<P>];
+
+/** Maps each protocol to its provider factory. */
+const PROTOCOL_FACTORIES: {
+    [P in SupportedProtocols]: (...args: ProtocolArgs<P>) => CrossChainProvider;
+} = {
+    across: (config) => new AcrossProvider(config ?? {}),
+    relay: (config) => new RelayProvider(config ?? {}),
+    bungee: (config) => new BungeeProvider(config ?? {}),
+    oif: (config) => new OifProvider(config),
+    "lifi-intents": (config) => new LifiIntentsProvider(config),
 };
-
-type ProtocolArgs = {
-    [P in SupportedProtocols]: Parameters<(typeof PROTOCOL_FACTORIES)[P]>;
-};
-type ProtocolProviders = {
-    [P in SupportedProtocols]: ReturnType<(typeof PROTOCOL_FACTORIES)[P]>;
-};
-
-/** Config type accepted by a protocol. */
-export type SupportedProtocolsConfigs<P extends SupportedProtocols> = NonNullable<
-    ProtocolArgs[P][0]
->;
-
-/** Protocols whose config is optional. */
-export type OptionalConfigProtocols = {
-    [P in SupportedProtocols]: undefined extends ProtocolArgs[P][0] ? P : never;
-}[SupportedProtocols];
-
-const factories: { [P in SupportedProtocols]: (...args: ProtocolArgs[P]) => ProtocolProviders[P] } =
-    PROTOCOL_FACTORIES;
 
 /**
- * Creates a provider for the given protocol; config is required or optional per protocol.
+ * Creates a provider for the given protocol; config is required for `oif`/`lifi-intents`
+ * and optional for `across`/`relay`/`bungee`.
  *
  * @throws {UnsupportedProtocol} If the protocol is not registered.
  */
 export function createCrossChainProvider<P extends SupportedProtocols>(
     protocolName: P,
-    ...args: ProtocolArgs[P]
-): ProtocolProviders[P] {
-    const factory = factories[protocolName];
+    ...args: ProtocolArgs<P>
+): CrossChainProvider {
+    const factory = PROTOCOL_FACTORIES[protocolName];
     if (!factory) {
         throw new UnsupportedProtocol(protocolName);
     }

--- a/packages/cross-chain/src/factories/crossChainProviderFactory.ts
+++ b/packages/cross-chain/src/factories/crossChainProviderFactory.ts
@@ -12,6 +12,7 @@ import {
     RelayProvider,
     UnsupportedProtocol,
 } from "../internal.js";
+import { PROTOCOLS } from "./providers.js";
 
 /** Constructor args for a protocol: config is optional for optional-config protocols. */
 type ProtocolArgs<P extends SupportedProtocols> = P extends OptionalConfigProtocols
@@ -22,11 +23,11 @@ type ProtocolArgs<P extends SupportedProtocols> = P extends OptionalConfigProtoc
 const PROTOCOL_FACTORIES: {
     [P in SupportedProtocols]: (...args: ProtocolArgs<P>) => CrossChainProvider;
 } = {
-    across: (config) => new AcrossProvider(config ?? {}),
-    relay: (config) => new RelayProvider(config ?? {}),
-    bungee: (config) => new BungeeProvider(config ?? {}),
-    oif: (config) => new OifProvider(config),
-    "lifi-intents": (config) => new LifiIntentsProvider(config),
+    [PROTOCOLS.ACROSS]: (config) => new AcrossProvider(config ?? {}),
+    [PROTOCOLS.RELAY]: (config) => new RelayProvider(config ?? {}),
+    [PROTOCOLS.BUNGEE]: (config) => new BungeeProvider(config ?? {}),
+    [PROTOCOLS.OIF]: (config) => new OifProvider(config),
+    [PROTOCOLS.LIFI_INTENTS]: (config) => new LifiIntentsProvider(config),
 };
 
 /**

--- a/packages/cross-chain/src/factories/crossChainProviderFactory.ts
+++ b/packages/cross-chain/src/factories/crossChainProviderFactory.ts
@@ -1,75 +1,65 @@
 import type {
     AcrossConfigs,
     BungeeConfigs,
-    CrossChainProvider,
     LifiIntentsProviderConfig,
     OifProviderConfig,
     RelayConfigs,
-    SupportedProtocols,
-    SupportedProtocolsConfigs,
 } from "../internal.js";
+import type { SupportedProtocols } from "./providers.js";
 import {
     AcrossProvider,
     BungeeProvider,
     LifiIntentsProvider,
     OifProvider,
-    PROTOCOLS,
     RelayProvider,
     UnsupportedProtocol,
 } from "../internal.js";
+import { PROTOCOLS } from "./providers.js";
 
-type RequiredConfigProtocols = typeof PROTOCOLS.OIF | typeof PROTOCOLS.LIFI_INTENTS;
-type OptionalConfigProtocols =
-    | typeof PROTOCOLS.ACROSS
-    | typeof PROTOCOLS.RELAY
-    | typeof PROTOCOLS.BUNGEE;
+/** Maps each protocol to its provider factory. Source of truth for the types below. */
+const PROTOCOL_FACTORIES = {
+    [PROTOCOLS.ACROSS]: (config?: AcrossConfigs): AcrossProvider =>
+        new AcrossProvider(config ?? {}),
+    [PROTOCOLS.RELAY]: (config?: RelayConfigs): RelayProvider => new RelayProvider(config ?? {}),
+    [PROTOCOLS.BUNGEE]: (config?: BungeeConfigs): BungeeProvider =>
+        new BungeeProvider(config ?? {}),
+    [PROTOCOLS.OIF]: (config: OifProviderConfig): OifProvider => new OifProvider(config),
+    [PROTOCOLS.LIFI_INTENTS]: (config: LifiIntentsProviderConfig): LifiIntentsProvider =>
+        new LifiIntentsProvider(config),
+};
+
+type ProtocolArgs = {
+    [P in SupportedProtocols]: Parameters<(typeof PROTOCOL_FACTORIES)[P]>;
+};
+type ProtocolProviders = {
+    [P in SupportedProtocols]: ReturnType<(typeof PROTOCOL_FACTORIES)[P]>;
+};
+
+/** Config type accepted by a protocol. */
+export type SupportedProtocolsConfigs<P extends SupportedProtocols> = NonNullable<
+    ProtocolArgs[P][0]
+>;
+
+/** Protocols whose config is optional. */
+export type OptionalConfigProtocols = {
+    [P in SupportedProtocols]: undefined extends ProtocolArgs[P][0] ? P : never;
+}[SupportedProtocols];
+
+const factories: { [P in SupportedProtocols]: (...args: ProtocolArgs[P]) => ProtocolProviders[P] } =
+    PROTOCOL_FACTORIES;
 
 /**
- * Creates a CrossChainProvider for a protocol whose configuration is required
- * (currently `oif` and `lifi-intents`).
- * @param protocolName - The protocol identifier
- * @param config - Required protocol configuration
- */
-export function createCrossChainProvider<P extends RequiredConfigProtocols>(
-    protocolName: P,
-    config: SupportedProtocolsConfigs<P>,
-): CrossChainProvider;
-/**
- * Creates a CrossChainProvider for a protocol whose configuration is optional
- * (currently `across`, `relay`, `bungee`).
- * @param protocolName - The protocol identifier
- * @param config - Optional protocol configuration (defaults applied by the provider)
- */
-export function createCrossChainProvider<P extends OptionalConfigProtocols>(
-    protocolName: P,
-    config?: SupportedProtocolsConfigs<P>,
-): CrossChainProvider;
-/**
- * Creates a CrossChainProvider for the specified protocol.
- * @param protocolName - The protocol identifier, constrained to {@link SupportedProtocols}
- * @param config - The configuration for the provider
- * @returns A CrossChainProvider
- * @throws {UnsupportedProtocol} If called with a protocol that is not handled
- *   (only reachable if callers bypass the type system via `as` / `@ts-expect-error`)
+ * Creates a provider for the given protocol; config is required or optional per protocol.
+ *
+ * @throws {UnsupportedProtocol} If the protocol is not registered.
  */
 export function createCrossChainProvider<P extends SupportedProtocols>(
     protocolName: P,
-    config?: SupportedProtocolsConfigs<P>,
-): CrossChainProvider {
-    switch (protocolName) {
-        case PROTOCOLS.ACROSS:
-            return new AcrossProvider((config as AcrossConfigs | undefined) ?? {});
-        case PROTOCOLS.OIF:
-            return new OifProvider(config as OifProviderConfig);
-        case PROTOCOLS.LIFI_INTENTS:
-            return new LifiIntentsProvider(config as LifiIntentsProviderConfig);
-        case PROTOCOLS.RELAY:
-            return new RelayProvider((config as RelayConfigs | undefined) ?? {});
-        case PROTOCOLS.BUNGEE:
-            return new BungeeProvider((config as BungeeConfigs | undefined) ?? {});
-        default: {
-            const _exhaustive: never = protocolName;
-            throw new UnsupportedProtocol(_exhaustive as string);
-        }
+    ...args: ProtocolArgs[P]
+): ProtocolProviders[P] {
+    const factory = factories[protocolName];
+    if (!factory) {
+        throw new UnsupportedProtocol(protocolName);
     }
+    return factory(...args);
 }

--- a/packages/cross-chain/src/factories/providers.ts
+++ b/packages/cross-chain/src/factories/providers.ts
@@ -1,16 +1,3 @@
-import type {
-    AcrossConfigs,
-    AcrossProvider,
-    BungeeConfigs,
-    BungeeProvider,
-    LifiIntentsProvider,
-    LifiIntentsProviderConfig,
-    OifProvider,
-    OifProviderConfig,
-    RelayConfigs,
-    RelayProvider,
-} from "../internal.js";
-
 export const PROTOCOLS = {
     ACROSS: "across",
     OIF: "oif",
@@ -20,19 +7,3 @@ export const PROTOCOLS = {
 } as const;
 
 export type SupportedProtocols = (typeof PROTOCOLS)[keyof typeof PROTOCOLS];
-
-export type SupportedProtocolProviders = {
-    [PROTOCOLS.ACROSS]: AcrossProvider;
-    [PROTOCOLS.OIF]: OifProvider;
-    [PROTOCOLS.LIFI_INTENTS]: LifiIntentsProvider;
-    [PROTOCOLS.RELAY]: RelayProvider;
-    [PROTOCOLS.BUNGEE]: BungeeProvider;
-};
-
-export type SupportedProtocolsConfigs<Protocol extends SupportedProtocols> = {
-    [PROTOCOLS.ACROSS]: AcrossConfigs;
-    [PROTOCOLS.OIF]: OifProviderConfig;
-    [PROTOCOLS.LIFI_INTENTS]: LifiIntentsProviderConfig;
-    [PROTOCOLS.RELAY]: RelayConfigs;
-    [PROTOCOLS.BUNGEE]: BungeeConfigs;
-}[Protocol];

--- a/packages/cross-chain/src/factories/providers.ts
+++ b/packages/cross-chain/src/factories/providers.ts
@@ -18,12 +18,15 @@ export type SupportedProtocols = (typeof PROTOCOLS)[keyof typeof PROTOCOLS];
 
 /** Config type accepted by each protocol. */
 export type SupportedProtocolsConfigs<P extends SupportedProtocols> = {
-    across: AcrossConfigs;
-    relay: RelayConfigs;
-    bungee: BungeeConfigs;
-    oif: OifProviderConfig;
-    "lifi-intents": LifiIntentsProviderConfig;
+    [PROTOCOLS.ACROSS]: AcrossConfigs;
+    [PROTOCOLS.RELAY]: RelayConfigs;
+    [PROTOCOLS.BUNGEE]: BungeeConfigs;
+    [PROTOCOLS.OIF]: OifProviderConfig;
+    [PROTOCOLS.LIFI_INTENTS]: LifiIntentsProviderConfig;
 }[P];
 
 /** Protocols whose config is optional. */
-export type OptionalConfigProtocols = "across" | "relay" | "bungee";
+export type OptionalConfigProtocols =
+    | typeof PROTOCOLS.ACROSS
+    | typeof PROTOCOLS.RELAY
+    | typeof PROTOCOLS.BUNGEE;

--- a/packages/cross-chain/src/factories/providers.ts
+++ b/packages/cross-chain/src/factories/providers.ts
@@ -1,3 +1,11 @@
+import type {
+    AcrossConfigs,
+    BungeeConfigs,
+    LifiIntentsProviderConfig,
+    OifProviderConfig,
+    RelayConfigs,
+} from "../internal.js";
+
 export const PROTOCOLS = {
     ACROSS: "across",
     OIF: "oif",
@@ -7,3 +15,15 @@ export const PROTOCOLS = {
 } as const;
 
 export type SupportedProtocols = (typeof PROTOCOLS)[keyof typeof PROTOCOLS];
+
+/** Config type accepted by each protocol. */
+export type SupportedProtocolsConfigs<P extends SupportedProtocols> = {
+    across: AcrossConfigs;
+    relay: RelayConfigs;
+    bungee: BungeeConfigs;
+    oif: OifProviderConfig;
+    "lifi-intents": LifiIntentsProviderConfig;
+}[P];
+
+/** Protocols whose config is optional. */
+export type OptionalConfigProtocols = "across" | "relay" | "bungee";

--- a/packages/cross-chain/src/protocols/across/schemas.ts
+++ b/packages/cross-chain/src/protocols/across/schemas.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from "uuid";
 import { isHex } from "viem";
 import { z } from "zod";
 
@@ -218,6 +217,6 @@ export const AcrossConfigSchema = z
     .object({
         isTestnet: z.boolean().optional().default(false),
         apiUrl: z.string().optional(),
-        providerId: z.string().default(`across_${uuidv4()}`),
+        providerId: z.string().default("across"),
     })
     .describe("Configuration for the Across provider");

--- a/packages/cross-chain/test/services/aggregator.spec.ts
+++ b/packages/cross-chain/test/services/aggregator.spec.ts
@@ -181,16 +181,11 @@ describe("Aggregator", () => {
             const aggregator = createAggregator({
                 providers: [mockProviderA, mockProviderB],
             });
-            expect(
-                (
-                    aggregator as unknown as {
-                        providers: Record<string, CrossChainProvider>;
-                    }
-                ).providers,
-            ).toEqual({
-                mockProviderA: mockProviderA,
-                mockProviderB: mockProviderB,
-            });
+            const { providers } = aggregator as unknown as {
+                providers: Map<string, CrossChainProvider>;
+            };
+            expect(providers.get("mockProviderA")).toBe(mockProviderA);
+            expect(providers.get("mockProviderB")).toBe(mockProviderB);
         });
 
         it("instantiates providers passed as protocol name strings", () => {
@@ -198,11 +193,11 @@ describe("Aggregator", () => {
                 providers: ["across", "relay", "bungee"],
             });
             const { providers } = aggregator as unknown as {
-                providers: Record<string, CrossChainProvider>;
+                providers: Map<string, CrossChainProvider>;
             };
-            expect(providers.across).toBeInstanceOf(AcrossProvider);
-            expect(providers.relay).toBeInstanceOf(RelayProvider);
-            expect(providers.bungee).toBeInstanceOf(BungeeProvider);
+            expect(providers.get("across")).toBeInstanceOf(AcrossProvider);
+            expect(providers.get("relay")).toBeInstanceOf(RelayProvider);
+            expect(providers.get("bungee")).toBeInstanceOf(BungeeProvider);
         });
 
         it("accepts a mix of protocol name strings and provider instances", () => {
@@ -210,10 +205,10 @@ describe("Aggregator", () => {
                 providers: ["across", mockProviderA],
             });
             const { providers } = aggregator as unknown as {
-                providers: Record<string, CrossChainProvider>;
+                providers: Map<string, CrossChainProvider>;
             };
-            expect(providers.across).toBeInstanceOf(AcrossProvider);
-            expect(providers.mockProviderA).toBe(mockProviderA);
+            expect(providers.get("across")).toBeInstanceOf(AcrossProvider);
+            expect(providers.get("mockProviderA")).toBe(mockProviderA);
         });
 
         it("throws when a string and an instance resolve to the same providerId", () => {
@@ -222,6 +217,14 @@ describe("Aggregator", () => {
                     providers: ["relay", createCrossChainProvider("relay")],
                 }),
             ).toThrow(DuplicateProvider);
+        });
+
+        it("treats reserved object keys as ordinary providerIds", () => {
+            const provider = {
+                protocolName: "reserved",
+                getProviderId: vi.fn(() => "toString"),
+            } as unknown as CrossChainProvider;
+            expect(() => createAggregator({ providers: [provider] })).not.toThrow();
         });
     });
 

--- a/packages/cross-chain/test/services/aggregator.spec.ts
+++ b/packages/cross-chain/test/services/aggregator.spec.ts
@@ -6,9 +6,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     AcrossProvider,
     Aggregator,
+    BungeeProvider,
     createAggregator,
+    createCrossChainProvider,
+    DuplicateProvider,
     OrderTracker,
     OrderTrackerFactory,
+    RelayProvider,
 } from "../../src/external.js";
 import {
     CrossChainProvider,
@@ -187,6 +191,37 @@ describe("Aggregator", () => {
                 mockProviderA: mockProviderA,
                 mockProviderB: mockProviderB,
             });
+        });
+
+        it("instantiates providers passed as protocol name strings", () => {
+            const aggregator = createAggregator({
+                providers: ["across", "relay", "bungee"],
+            });
+            const { providers } = aggregator as unknown as {
+                providers: Record<string, CrossChainProvider>;
+            };
+            expect(providers.across).toBeInstanceOf(AcrossProvider);
+            expect(providers.relay).toBeInstanceOf(RelayProvider);
+            expect(providers.bungee).toBeInstanceOf(BungeeProvider);
+        });
+
+        it("accepts a mix of protocol name strings and provider instances", () => {
+            const aggregator = createAggregator({
+                providers: ["across", mockProviderA],
+            });
+            const { providers } = aggregator as unknown as {
+                providers: Record<string, CrossChainProvider>;
+            };
+            expect(providers.across).toBeInstanceOf(AcrossProvider);
+            expect(providers.mockProviderA).toBe(mockProviderA);
+        });
+
+        it("throws when a string and an instance resolve to the same providerId", () => {
+            expect(() =>
+                createAggregator({
+                    providers: ["relay", createCrossChainProvider("relay")],
+                }),
+            ).toThrow(DuplicateProvider);
         });
     });
 

--- a/packages/cross-chain/test/services/crossChainProviderFactory.spec.ts
+++ b/packages/cross-chain/test/services/crossChainProviderFactory.spec.ts
@@ -3,7 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createCrossChainProvider } from "../../src/factories/crossChainProviderFactory.js";
 import {
     AcrossProvider,
+    BungeeProvider,
     CrossChainProvider,
+    LifiIntentsProvider,
+    OifProvider,
     RelayProvider,
     UnsupportedProtocol,
 } from "../../src/internal.js";
@@ -47,6 +50,29 @@ describe("createCrossChainProvider", () => {
 
         expect(provider).toBeInstanceOf(RelayProvider);
         expect(provider.providerId).toBe("relay-custom");
+    });
+
+    it("creates a BungeeProvider with default config", () => {
+        const provider = createCrossChainProvider("bungee");
+
+        expect(provider).toBeInstanceOf(BungeeProvider);
+    });
+
+    it("creates an OifProvider with required config", () => {
+        const provider = createCrossChainProvider("oif", {
+            solverId: "my-solver",
+            url: "https://solver.example.com",
+        });
+
+        expect(provider).toBeInstanceOf(OifProvider);
+    });
+
+    it("creates a LifiIntentsProvider with required config", () => {
+        const provider = createCrossChainProvider("lifi-intents", {
+            orderServerUrl: "https://order-server.example.com",
+        });
+
+        expect(provider).toBeInstanceOf(LifiIntentsProvider);
     });
 
     it("throws an UnsupportedProtocol error for unsupported protocols", () => {


### PR DESCRIPTION
# 🤖 Linear

Closes EFI-953

## Description

`createAggregator({ providers })` now accepts the optional-config protocol names `"across"`, `"relay"` and `"bungee"` next to `CrossChainProvider` instances, so the common setup no longer needs one `createCrossChainProvider` call per provider. `oif` and `lifi-intents` still take instances because their config is required.

This PR has three parts:

- Refactor: provider creation goes through a single registry that is the source of truth. The factory overloads, the switch and the `as` casts are gone; the config types and the optional-config classification are derived from that table.
- Naming and types: adds the exports `AggregatorProvider`, `CreateAggregatorConfig` and `OptionalConfigProtocols`, and the aggregator now throws `DuplicateProvider` when two providers share a `providerId`.
- Across fix: the default `providerId` used to be a UUID generated once at module load. It is now the stable `"across"`, like `relay` and `bungee`.

The public API does not change.

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm test`
- [x] `pnpm lint`
