### PR TITLE
feat(cross-chain): default lifi-intents orderServerUrl

### DIFF
--- a/.changeset/lifi-intents-default-order-server-url.md
+++ b/.changeset/lifi-intents-default-order-server-url.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Default the LiFi Intents `orderServerUrl` to the official endpoint (`https://order.li.fi`). `createCrossChainProvider("lifi-intents")` and `createAggregator({ providers: ["lifi-intents"] })` now work without config; pass `orderServerUrl` to override (e.g. `LIFI_INTENTS_ORDER_SERVER_DEV_URL`). Invalid URLs are still rejected.

--- a/apps/docs/pages/cross-chain/api.mdx
+++ b/apps/docs/pages/cross-chain/api.mdx
@@ -13,13 +13,10 @@ A set of classes and utilities for handling cross-chain operations through vario
 
 -   **createCrossChainProvider**(protocolName: string, config?: ProviderConfig): CrossChainProvider
 
-    Creates a provider instance for a supported cross-chain protocol. Config is optional for Across (uses mainnet defaults), required for OIF and LiFi Intents.
+    Creates a provider instance for a supported cross-chain protocol. Config is optional for Across (uses mainnet defaults), required for OIF.
 
     ```typescript
-    import {
-        createCrossChainProvider,
-        LIFI_INTENTS_ORDER_SERVER_URL,
-    } from "@wonderland/interop-cross-chain";
+    import { createCrossChainProvider } from "@wonderland/interop-cross-chain";
 
     // Across - config optional (defaults to mainnet)
     const provider = createCrossChainProvider("across");
@@ -41,10 +38,8 @@ A set of classes and utilities for handling cross-chain operations through vario
         url: "https://solver.example.com",
     });
 
-    // LiFi Intents - orderServerUrl required
-    const lifiProvider = createCrossChainProvider("lifi-intents", {
-        orderServerUrl: LIFI_INTENTS_ORDER_SERVER_URL,
-    });
+    // LiFi Intents - config optional (defaults to the official order server)
+    const lifiProvider = createCrossChainProvider("lifi-intents");
     ```
 
 ### CrossChainProvider Class

--- a/apps/docs/pages/cross-chain/getting-started.mdx
+++ b/apps/docs/pages/cross-chain/getting-started.mdx
@@ -184,13 +184,13 @@ Omit `chainIds` to discover across every chain each provider supports. For a sin
 
 ## Compare quotes from multiple providers
 
-Use the `Aggregator` to fetch and sort quotes from multiple providers at once. For protocols whose config is optional (`across`, `relay`, `bungee`) you can pass the protocol name directly and the aggregator creates the provider with defaults:
+Use the `Aggregator` to fetch and sort quotes from multiple providers at once. For protocols whose config is optional (`across`, `relay`, `bungee`, `lifi-intents`) you can pass the protocol name directly and the aggregator creates the provider with defaults:
 
 ```typescript
 import { createAggregator, PROTOCOLS } from "@wonderland/interop-cross-chain";
 
 const aggregator = createAggregator({
-    providers: [PROTOCOLS.ACROSS, PROTOCOLS.RELAY, PROTOCOLS.BUNGEE],
+    providers: [PROTOCOLS.ACROSS, PROTOCOLS.RELAY, PROTOCOLS.BUNGEE, PROTOCOLS.LIFI_INTENTS],
 });
 
 const response = await aggregator.getQuotes({
@@ -201,7 +201,7 @@ console.log(`Got ${response.quotes.length} quotes`);
 response.errors.forEach((err) => console.warn(`Provider error: ${err.errorMsg}`));
 ```
 
-Need custom config — or a provider that requires it, like OIF / LiFi Intents — pass an instance instead. You can mix both forms:
+Need custom config — or a provider that requires it, like OIF — pass an instance instead. You can mix both forms:
 
 ```typescript
 import {

--- a/apps/docs/pages/cross-chain/lifi-intents-provider.mdx
+++ b/apps/docs/pages/cross-chain/lifi-intents-provider.mdx
@@ -24,7 +24,7 @@ All quotes return **transaction steps** (user-pays-gas). The provider does not s
 
 | Field            | Type                         | Required | Description                                                    |
 | ---------------- | ---------------------------- | -------- | -------------------------------------------------------------- |
-| `orderServerUrl` | string                       | Yes      | LI.FI order server URL                                         |
+| `orderServerUrl` | string                       | No       | LI.FI order server URL (default: `https://order.li.fi`)        |
 | `providerId`     | string                       | No       | Custom provider identifier (default: `"lifi-intents"`)         |
 | `headers`        | Record&lt;string, string&gt; | No       | Custom HTTP headers sent with all requests to the order server |
 
@@ -33,14 +33,10 @@ All quotes return **transaction steps** (user-pays-gas). The provider does not s
 ### Mainnet
 
 ```ts twoslash
-import {
-    createCrossChainProvider,
-    LIFI_INTENTS_ORDER_SERVER_URL,
-} from "@wonderland/interop-cross-chain";
+import { createCrossChainProvider } from "@wonderland/interop-cross-chain";
 
-const lifiProvider = createCrossChainProvider("lifi-intents", {
-    orderServerUrl: LIFI_INTENTS_ORDER_SERVER_URL, // https://order.li.fi
-});
+// orderServerUrl defaults to https://order.li.fi
+const lifiProvider = createCrossChainProvider("lifi-intents");
 ```
 
 ### Dev Environment
@@ -59,13 +55,9 @@ const lifiProvider = createCrossChainProvider("lifi-intents", {
 ### With Custom Headers
 
 ```typescript
-import {
-    createCrossChainProvider,
-    LIFI_INTENTS_ORDER_SERVER_URL,
-} from "@wonderland/interop-cross-chain";
+import { createCrossChainProvider } from "@wonderland/interop-cross-chain";
 
 const lifiProvider = createCrossChainProvider("lifi-intents", {
-    orderServerUrl: LIFI_INTENTS_ORDER_SERVER_URL,
     headers: { "x-api-key": "your-api-key" },
 });
 ```

--- a/apps/docs/pages/cross-chain/providers.mdx
+++ b/apps/docs/pages/cross-chain/providers.mdx
@@ -33,7 +33,8 @@ createCrossChainProvider("relay", { apiKey: "...", isTestnet: true });
 // OIF — solverId and url are required
 createCrossChainProvider("oif", { solverId: "my-solver", url: "https://solver.example.com" });
 
-// LiFi Intents — orderServerUrl is required
+// LiFi Intents — no required config (defaults to https://order.li.fi)
+createCrossChainProvider("lifi-intents");
 createCrossChainProvider("lifi-intents", { orderServerUrl: "https://..." });
 
 // Bungee — no required config
@@ -50,10 +51,10 @@ createCrossChainProvider("bungee", {
 | `across`       | (none)            | `isTestnet`                                                                                                                                           |
 | `relay`        | (none)            | `apiKey`, `isTestnet`                                                                                                                                 |
 | `oif`          | `solverId`, `url` | —                                                                                                                                                     |
-| `lifi-intents` | `orderServerUrl`  | `providerId`, `headers`                                                                                                                               |
+| `lifi-intents` | (none)            | `orderServerUrl`, `providerId`, `headers`                                                                                                             |
 | `bungee`       | (none)            | `tier`, `apiKey`, `affiliateId`, `feeBps`, `feeTakerAddress`, `submissionModes`, `slippage`, `refuel`, `enableOtherProviders`, `enableMultipleRoutes` |
 
-The optional-config protocols (`across`, `relay`, `bungee`) can also be passed to `createAggregator` by name to get defaults — see [Compare quotes from multiple providers](./getting-started#compare-quotes-from-multiple-providers). Use `createCrossChainProvider` when you need custom config.
+The optional-config protocols (`across`, `relay`, `bungee`, `lifi-intents`) can also be passed to `createAggregator` by name to get defaults — see [Compare quotes from multiple providers](./getting-started#compare-quotes-from-multiple-providers). Use `createCrossChainProvider` when you need custom config.
 
 ## `isTestnet` semantics
 

--- a/packages/cross-chain/src/factories/crossChainProviderFactory.ts
+++ b/packages/cross-chain/src/factories/crossChainProviderFactory.ts
@@ -27,12 +27,12 @@ const PROTOCOL_FACTORIES: {
     [PROTOCOLS.RELAY]: (config) => new RelayProvider(config ?? {}),
     [PROTOCOLS.BUNGEE]: (config) => new BungeeProvider(config ?? {}),
     [PROTOCOLS.OIF]: (config) => new OifProvider(config),
-    [PROTOCOLS.LIFI_INTENTS]: (config) => new LifiIntentsProvider(config),
+    [PROTOCOLS.LIFI_INTENTS]: (config) => new LifiIntentsProvider(config ?? {}),
 };
 
 /**
- * Creates a provider for the given protocol; config is required for `oif`/`lifi-intents`
- * and optional for `across`/`relay`/`bungee`.
+ * Creates a provider for the given protocol; config is required for `oif`
+ * and optional for `across`/`relay`/`bungee`/`lifi-intents`.
  *
  * @throws {UnsupportedProtocol} If the protocol is not registered.
  */

--- a/packages/cross-chain/src/factories/providers.ts
+++ b/packages/cross-chain/src/factories/providers.ts
@@ -29,4 +29,5 @@ export type SupportedProtocolsConfigs<P extends SupportedProtocols> = {
 export type OptionalConfigProtocols =
     | typeof PROTOCOLS.ACROSS
     | typeof PROTOCOLS.RELAY
-    | typeof PROTOCOLS.BUNGEE;
+    | typeof PROTOCOLS.BUNGEE
+    | typeof PROTOCOLS.LIFI_INTENTS;

--- a/packages/cross-chain/src/protocols/lifi-intents/provider.ts
+++ b/packages/cross-chain/src/protocols/lifi-intents/provider.ts
@@ -22,6 +22,7 @@ import {
     ProviderGetQuoteFailure,
 } from "../../internal.js";
 import { adaptOrderStatus, adaptQuoteRequest, adaptQuoteResponse } from "./adapters/index.js";
+import { LIFI_INTENTS_ORDER_SERVER_URL } from "./constants.js";
 import {
     LifiIntentsOrderStatusResponseSchema,
     LifiIntentsProviderConfigSchema,
@@ -41,12 +42,12 @@ export class LifiIntentsProvider extends CrossChainProvider {
     private static readonly REQUEST_TIMEOUT_MS = 30_000;
     private static readonly QUOTE_PATH = "/api/v1/integrator/quote/request";
 
-    constructor(config: LifiIntentsProviderConfig) {
+    constructor(config: LifiIntentsProviderConfig = {}) {
         super();
 
         try {
             const parsed = LifiIntentsProviderConfigSchema.parse(config);
-            this.orderServerUrl = parsed.orderServerUrl;
+            this.orderServerUrl = parsed.orderServerUrl ?? LIFI_INTENTS_ORDER_SERVER_URL;
             this.providerId = parsed.providerId ?? "lifi-intents";
             this.headers = parsed.headers;
         } catch (error) {

--- a/packages/cross-chain/src/protocols/lifi-intents/schemas.ts
+++ b/packages/cross-chain/src/protocols/lifi-intents/schemas.ts
@@ -17,7 +17,7 @@ export type Caip10Address = z.infer<typeof Caip10AddressSchema>;
 // ── Provider Config ─────────────────────────────────────
 
 export const LifiIntentsProviderConfigSchema = z.object({
-    orderServerUrl: z.url(),
+    orderServerUrl: z.url().optional(),
     providerId: z.string().optional(),
     headers: z.record(z.string(), z.string()).optional(),
 });

--- a/packages/cross-chain/test/providers/LifiIntentsProvider.spec.ts
+++ b/packages/cross-chain/test/providers/LifiIntentsProvider.spec.ts
@@ -61,13 +61,6 @@ describe("LifiIntentsProvider", () => {
             }).toThrow(ProviderConfigFailure);
         });
 
-        it("throws for empty config", () => {
-            expect(() => {
-                // @ts-expect-error - Testing invalid config
-                new LifiIntentsProvider({});
-            }).toThrow(ProviderConfigFailure);
-        });
-
         it("throws ProviderConfigFailure for non-ZodError thrown during config", async () => {
             const schemas = await import("../../src/protocols/lifi-intents/schemas.js");
             const spy = vi
@@ -122,6 +115,42 @@ describe("LifiIntentsProvider", () => {
                     headers: { "Content-Type": "application/json" },
                     timeout: 30_000,
                 }),
+            );
+        });
+
+        it("defaults to the production order server when no config is passed", async () => {
+            const defaultProvider = new LifiIntentsProvider();
+
+            vi.mocked(httpRequest).mockResolvedValue({
+                status: 200,
+                data: getMockedLifiQuoteResponse(),
+                headers: new Headers(),
+            });
+
+            await defaultProvider.getQuotes(mockQuoteRequest);
+
+            expect(httpRequest).toHaveBeenCalledWith(
+                "https://order.li.fi/api/v1/integrator/quote/request",
+                expect.anything(),
+            );
+        });
+
+        it("uses the provided orderServerUrl over the default", async () => {
+            const customProvider = new LifiIntentsProvider({
+                orderServerUrl: "https://order-dev.li.fi",
+            });
+
+            vi.mocked(httpRequest).mockResolvedValue({
+                status: 200,
+                data: getMockedLifiQuoteResponse(),
+                headers: new Headers(),
+            });
+
+            await customProvider.getQuotes(mockQuoteRequest);
+
+            expect(httpRequest).toHaveBeenCalledWith(
+                "https://order-dev.li.fi/api/v1/integrator/quote/request",
+                expect.anything(),
             );
         });
 

--- a/packages/cross-chain/test/services/crossChainProviderFactory.spec.ts
+++ b/packages/cross-chain/test/services/crossChainProviderFactory.spec.ts
@@ -67,7 +67,13 @@ describe("createCrossChainProvider", () => {
         expect(provider).toBeInstanceOf(OifProvider);
     });
 
-    it("creates a LifiIntentsProvider with required config", () => {
+    it("creates a LifiIntentsProvider without config (defaults to the official order server)", () => {
+        const provider = createCrossChainProvider("lifi-intents");
+
+        expect(provider).toBeInstanceOf(LifiIntentsProvider);
+    });
+
+    it("creates a LifiIntentsProvider with config", () => {
         const provider = createCrossChainProvider("lifi-intents", {
             orderServerUrl: "https://order-server.example.com",
         });


### PR DESCRIPTION
# 🤖 Linear

Closes EFI-954

## Description

The LiFi Intents provider required `orderServerUrl` even though the SDK already exports the official URL as a constant. It now defaults to `https://order.li.fi`, so `createCrossChainProvider("lifi-intents")` works without config.

`lifi-intents` moves from required-config to `OptionalConfigProtocols`, so `createAggregator({ providers: ["lifi-intents"] })` can take it by name next to `across`, `relay` and `bungee`.

Passing `orderServerUrl` still overrides the default, for example pointing at `LIFI_INTENTS_ORDER_SERVER_DEV_URL`. Invalid URLs are still rejected. Docs and the getting-started recipe drop the `LIFI_INTENTS_ORDER_SERVER_URL` import from the basic example.

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm test`
- [x] `pnpm lint`