### PR TITLE
feat(benchmark): cache and rate-limit quote fetching behind /api/race-quotes

### DIFF
--- a/apps/benchmark/app/api/race-quotes/route.ts
+++ b/apps/benchmark/app/api/race-quotes/route.ts
@@ -66,6 +66,11 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'NO_ROUTE';
+    // `buildQuoteRequest` throws on user-supplied bad amounts; those are client
+    // errors, not upstream failures, so report them as 400 instead of 502.
+    if (message === 'Enter a valid amount') {
+      return NextResponse.json({ error: 'INVALID_AMOUNT' }, { status: 400 });
+    }
     return NextResponse.json({ error: message }, { status: 502 });
   }
 }

--- a/apps/benchmark/app/api/race-quotes/route.ts
+++ b/apps/benchmark/app/api/race-quotes/route.ts
@@ -25,13 +25,18 @@ function parseAssetSymbol(raw: string | null): AssetSymbol | null {
 }
 
 export async function GET(request: NextRequest) {
+  // Only rate-limit when we can identify the caller. If extractClientIp returns
+  // null we'd otherwise throttle every anonymous request under one bucket, so
+  // letting it through is the safer default for this dev tool.
   const ip = extractClientIp(request.headers);
-  const rate = checkRateLimit(ip);
-  if (!rate.allowed) {
-    return NextResponse.json(
-      { error: 'RATE_LIMITED', retryAfter: rate.retryAfter },
-      { status: 429, headers: rate.retryAfter ? { 'Retry-After': String(rate.retryAfter) } : undefined },
-    );
+  if (ip !== null) {
+    const rate = checkRateLimit(ip);
+    if (!rate.allowed) {
+      return NextResponse.json(
+        { error: 'RATE_LIMITED', retryAfter: rate.retryAfter },
+        { status: 429, headers: rate.retryAfter ? { 'Retry-After': String(rate.retryAfter) } : undefined },
+      );
+    }
   }
 
   const { searchParams } = request.nextUrl;

--- a/apps/benchmark/app/api/race-quotes/route.ts
+++ b/apps/benchmark/app/api/race-quotes/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { AssetSymbol } from '~/lib/assets';
+import { ChainId } from '~/lib/chains';
+import { withTimeout } from '~/lib/helpers';
+import { checkRateLimit, extractClientIp } from '~/lib/rateLimit';
+import { getCachedRaceQuotes } from '~/lib/services/cachedQuoteService';
+
+const ROUTE_TIMEOUT_MS = 30_000;
+
+const CHAIN_IDS = new Set<number>(Object.values(ChainId).filter((value): value is number => typeof value === 'number'));
+const ASSET_SYMBOLS = new Set<string>(Object.values(AssetSymbol));
+
+function parseChainId(raw: string | null): ChainId | null {
+  if (!raw) return null;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || !CHAIN_IDS.has(parsed)) return null;
+  return parsed as ChainId;
+}
+
+function parseAssetSymbol(raw: string | null): AssetSymbol | null {
+  if (!raw) return null;
+  if (!ASSET_SYMBOLS.has(raw)) return null;
+  return raw as AssetSymbol;
+}
+
+export async function GET(request: NextRequest) {
+  const ip = extractClientIp(request.headers);
+  const rate = checkRateLimit(ip);
+  if (!rate.allowed) {
+    return NextResponse.json(
+      { error: 'RATE_LIMITED', retryAfter: rate.retryAfter },
+      { status: 429, headers: rate.retryAfter ? { 'Retry-After': String(rate.retryAfter) } : undefined },
+    );
+  }
+
+  const { searchParams } = request.nextUrl;
+  const fromChainId = parseChainId(searchParams.get('fromChainId'));
+  const toChainId = parseChainId(searchParams.get('toChainId'));
+  const assetSymbol = parseAssetSymbol(searchParams.get('assetSymbol'));
+  const amount = searchParams.get('amount')?.trim() ?? '';
+
+  if (fromChainId === null || toChainId === null || assetSymbol === null || amount === '') {
+    return NextResponse.json({ error: 'INVALID_PARAMS' }, { status: 400 });
+  }
+
+  if (fromChainId === toChainId) {
+    return NextResponse.json({ error: 'SAME_CHAIN' }, { status: 400 });
+  }
+
+  const input = { fromChainId, toChainId, assetSymbol, amount };
+  const startedAt = Date.now();
+
+  try {
+    const result = await withTimeout(getCachedRaceQuotes(input), ROUTE_TIMEOUT_MS, 'ROUTE_TIMEOUT');
+    return NextResponse.json({
+      quotes: result.quotes,
+      errors: result.errors,
+      cachedAt: result.cachedAt,
+      cacheHit: result.cachedAt < startedAt,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'NO_ROUTE';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/apps/benchmark/app/components/race-table/raceRows.ts
+++ b/apps/benchmark/app/components/race-table/raceRows.ts
@@ -130,7 +130,12 @@ export function canonicalizeAmount(value: string): string {
     throw new Error('Enter a valid amount');
   }
 
-  return normalized;
+  // Collapse equivalent representations so `1`, `1.0`, `01.00`, `1.50`, `0.50`
+  // all canonicalize to the same string and share a cache entry downstream.
+  const [intPart, fracPart] = normalized.split('.');
+  const intCanonical = intPart.replace(/^0+/, '') || '0';
+  const fracCanonical = fracPart ? fracPart.replace(/0+$/, '') : '';
+  return fracCanonical ? `${intCanonical}.${fracCanonical}` : intCanonical;
 }
 
 function parseAmount(value: string, decimals: number): string {

--- a/apps/benchmark/app/components/race-table/raceRows.ts
+++ b/apps/benchmark/app/components/race-table/raceRows.ts
@@ -111,7 +111,13 @@ export function parseOptionalNumber(value: string | number | undefined): number 
 
 const DECIMAL_AMOUNT_RE = /^\d+(\.\d+)?$/;
 
-function parseAmount(value: string, decimals: number): string {
+/**
+ * Validates and normalizes a user-entered amount string. Returns the canonical
+ * decimal form (no commas) so equivalent inputs like `1,000.00` and `1000.00`
+ * map to the same value. Throws when the input is empty, has malformed
+ * thousand separators, or contains non-decimal characters.
+ */
+export function canonicalizeAmount(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) throw new Error('Enter a valid amount');
 
@@ -124,7 +130,11 @@ function parseAmount(value: string, decimals: number): string {
     throw new Error('Enter a valid amount');
   }
 
-  return parseUnits(normalized, decimals).toString();
+  return normalized;
+}
+
+function parseAmount(value: string, decimals: number): string {
+  return parseUnits(canonicalizeAmount(value), decimals).toString();
 }
 
 function hasValidThousandSeparators(value: string): boolean {

--- a/apps/benchmark/app/components/race-table/useRunRace.ts
+++ b/apps/benchmark/app/components/race-table/useRunRace.ts
@@ -1,12 +1,12 @@
 'use client';
 
 import { useCallback, useRef } from 'react';
-import { buildQuoteRequest, buildRowsFromQuotes, createRows, orderRaceRows } from './raceRows';
+import { buildRowsFromQuotes, createRows, orderRaceRows } from './raceRows';
 import type { RaceRow } from './types';
 import type { NetworkAssets } from '@wonderland/interop-cross-chain';
+import type { QuoteBenchmarkResponse } from '~/lib/types';
 import { withTimeout } from '~/lib/helpers';
 import { useRequestBarStore } from '~/lib/requestBarStore';
-import { quotesService } from '~/lib/services';
 
 const RACE_TIMEOUT_MS = 30_000;
 
@@ -26,16 +26,44 @@ export function useRunRace(chains: NetworkAssets[]) {
 
     try {
       const { request } = useRequestBarStore.getState();
-      const quoteRequest = buildQuoteRequest({ chains, ...request });
-      const response = await withTimeout(quotesService.getQuotes(quoteRequest), RACE_TIMEOUT_MS);
+      const query = new URLSearchParams({
+        fromChainId: String(request.fromChainId),
+        toChainId: String(request.toChainId),
+        assetSymbol: request.assetSymbol,
+        amount: request.amount,
+      });
+      const response = await withTimeout(fetch(`/api/race-quotes?${query.toString()}`), RACE_TIMEOUT_MS);
+
       if (runId !== latestRunId.current) return;
-      setRows(orderRaceRows(buildRowsFromQuotes(response.quotes, response.errors)));
+
+      if (response.status === 429) {
+        setRows(orderRaceRows(createRows('errored', 'RATE LIMITED')));
+        return;
+      }
+
+      if (!response.ok) {
+        const message = await readErrorMessage(response);
+        setRows(orderRaceRows(createRows('errored', message)));
+        return;
+      }
+
+      const payload = (await response.json()) as QuoteBenchmarkResponse;
+      setRows(orderRaceRows(buildRowsFromQuotes(payload.quotes, payload.errors)));
     } catch (error) {
       if (runId !== latestRunId.current) return;
       const message = error instanceof Error ? error.message : 'NO ROUTE';
       setRows(orderRaceRows(createRows('errored', message)));
     }
   }, [chains, setRows]);
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: string };
+    return body.error ?? 'NO ROUTE';
+  } catch {
+    return 'NO ROUTE';
+  }
 }
 
 function toQueryingRows(previous: RaceRow[]): RaceRow[] {

--- a/apps/benchmark/app/components/race-table/useRunRace.ts
+++ b/apps/benchmark/app/components/race-table/useRunRace.ts
@@ -43,11 +43,15 @@ export function useRunRace(chains: NetworkAssets[]) {
 
       if (!response.ok) {
         const message = await readErrorMessage(response);
+        if (runId !== latestRunId.current) return;
         setRows(orderRaceRows(createRows('errored', message)));
         return;
       }
 
       const payload = (await response.json()) as QuoteBenchmarkResponse;
+      // A newer run can fire while we await the JSON body. Re-check before
+      // we publish rows so stale responses can't overwrite fresh ones.
+      if (runId !== latestRunId.current) return;
       setRows(orderRaceRows(buildRowsFromQuotes(payload.quotes, payload.errors)));
     } catch (error) {
       if (runId !== latestRunId.current) return;

--- a/apps/benchmark/app/lib/rateLimit.ts
+++ b/apps/benchmark/app/lib/rateLimit.ts
@@ -58,13 +58,33 @@ function cleanupExpired(now: number): void {
   }
 }
 
-export function extractClientIp(headers: Headers): string {
+const IPV4_RE = /^(\d{1,3}\.){3}\d{1,3}$/;
+const IPV6_RE = /^[0-9a-fA-F:]+$/;
+
+function isPlausibleIp(value: string): boolean {
+  if (IPV4_RE.test(value)) {
+    return value.split('.').every((octet) => {
+      const n = Number(octet);
+      return n >= 0 && n <= 255;
+    });
+  }
+  return IPV6_RE.test(value) && value.includes(':');
+}
+
+/**
+ * Reads the trailing x-forwarded-for entry (proxies append, so the rightmost
+ * value is the one our own infra added and is trustworthy). Returns null when
+ * no plausible IP is available — callers should treat that as "skip rate
+ * limiting" rather than bucketing every anonymous caller under a shared key.
+ */
+export function extractClientIp(headers: Headers): string | null {
   const forwarded = headers.get('x-forwarded-for');
   if (forwarded) {
-    const first = forwarded.split(',')[0]?.trim();
-    if (first) return first;
+    const parts = forwarded.split(',');
+    const last = parts[parts.length - 1]?.trim();
+    if (last && isPlausibleIp(last)) return last;
   }
-  const realIp = headers.get('x-real-ip');
-  if (realIp) return realIp.trim();
-  return 'unknown';
+  const realIp = headers.get('x-real-ip')?.trim();
+  if (realIp && isPlausibleIp(realIp)) return realIp;
+  return null;
 }

--- a/apps/benchmark/app/lib/rateLimit.ts
+++ b/apps/benchmark/app/lib/rateLimit.ts
@@ -72,19 +72,21 @@ function isPlausibleIp(value: string): boolean {
 }
 
 /**
- * Reads the trailing x-forwarded-for entry (proxies append, so the rightmost
- * value is the one our own infra added and is trustworthy). Returns null when
- * no plausible IP is available — callers should treat that as "skip rate
- * limiting" rather than bucketing every anonymous caller under a shared key.
+ * Resolves the client IP for rate-limiting. Prefers `x-real-ip` (set by Vercel
+ * to the actual caller and not spoofable from outside the platform). Falls
+ * back to the leftmost `x-forwarded-for` entry, which is the real client on
+ * Vercel even when multiple hops are present. Returns null when no plausible
+ * IP is available; callers should treat that as "skip rate limiting" rather
+ * than bucketing every anonymous caller under a shared key.
  */
 export function extractClientIp(headers: Headers): string | null {
-  const forwarded = headers.get('x-forwarded-for');
-  if (forwarded) {
-    const parts = forwarded.split(',');
-    const last = parts[parts.length - 1]?.trim();
-    if (last && isPlausibleIp(last)) return last;
-  }
   const realIp = headers.get('x-real-ip')?.trim();
   if (realIp && isPlausibleIp(realIp)) return realIp;
+
+  const forwarded = headers.get('x-forwarded-for');
+  if (forwarded) {
+    const first = forwarded.split(',')[0]?.trim();
+    if (first && isPlausibleIp(first)) return first;
+  }
   return null;
 }

--- a/apps/benchmark/app/lib/rateLimit.ts
+++ b/apps/benchmark/app/lib/rateLimit.ts
@@ -1,0 +1,70 @@
+/**
+ * In-memory token-bucket rate limiter, keyed by IP. 10 requests per 60 seconds,
+ * refilling 1 token every 6 seconds. Suitable for a single Next.js node process;
+ * not durable across deploys or replicas. Swap for Upstash/KV when we go HA.
+ */
+
+const BUCKET_CAPACITY = 10;
+const REFILL_INTERVAL_MS = 6_000;
+const REFILL_AMOUNT = 1;
+const ENTRY_TTL_MS = 5 * 60_000;
+
+interface Bucket {
+  tokens: number;
+  updatedAt: number;
+}
+
+const buckets = new Map<string, Bucket>();
+
+export interface RateLimitResult {
+  allowed: boolean;
+  retryAfter?: number;
+}
+
+export function checkRateLimit(ip: string, now: number = Date.now()): RateLimitResult {
+  cleanupExpired(now);
+
+  const bucket = buckets.get(ip);
+  if (!bucket) {
+    buckets.set(ip, { tokens: BUCKET_CAPACITY - 1, updatedAt: now });
+    return { allowed: true };
+  }
+
+  const elapsed = now - bucket.updatedAt;
+  const refillTokens = Math.floor(elapsed / REFILL_INTERVAL_MS) * REFILL_AMOUNT;
+  if (refillTokens > 0) {
+    bucket.tokens = Math.min(BUCKET_CAPACITY, bucket.tokens + refillTokens);
+    bucket.updatedAt += Math.floor(elapsed / REFILL_INTERVAL_MS) * REFILL_INTERVAL_MS;
+  }
+
+  if (bucket.tokens <= 0) {
+    const timeToNext = REFILL_INTERVAL_MS - (now - bucket.updatedAt);
+    return { allowed: false, retryAfter: Math.max(1, Math.ceil(timeToNext / 1000)) };
+  }
+
+  bucket.tokens -= 1;
+  return { allowed: true };
+}
+
+export function resetRateLimitForTests(): void {
+  buckets.clear();
+}
+
+function cleanupExpired(now: number): void {
+  for (const [ip, bucket] of buckets) {
+    if (now - bucket.updatedAt > ENTRY_TTL_MS) {
+      buckets.delete(ip);
+    }
+  }
+}
+
+export function extractClientIp(headers: Headers): string {
+  const forwarded = headers.get('x-forwarded-for');
+  if (forwarded) {
+    const first = forwarded.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  const realIp = headers.get('x-real-ip');
+  if (realIp) return realIp.trim();
+  return 'unknown';
+}

--- a/apps/benchmark/app/lib/services/cachedQuoteService.ts
+++ b/apps/benchmark/app/lib/services/cachedQuoteService.ts
@@ -25,8 +25,12 @@ export interface CachedRaceQuotesResult extends QuoteBenchmarkResponse {
  */
 const inflight = new Map<string, Promise<CachedRaceQuotesResult>>();
 
+function normalizeAmount(value: string): string {
+  return value.trim().replace(/,/g, '');
+}
+
 export function buildCacheKey(input: CachedRaceQuotesInput): string {
-  return `${input.fromChainId}-${input.toChainId}-${input.assetSymbol}-${input.amount}`;
+  return `${input.fromChainId}-${input.toChainId}-${input.assetSymbol}-${normalizeAmount(input.amount)}`;
 }
 
 async function fetchQuotes(input: CachedRaceQuotesInput): Promise<CachedRaceQuotesResult> {
@@ -48,11 +52,14 @@ const cachedFetch = unstable_cache(fetchQuotes, ['race-quotes'], {
  * cache entries.
  */
 export async function getCachedRaceQuotes(input: CachedRaceQuotesInput): Promise<CachedRaceQuotesResult> {
-  const key = buildCacheKey(input);
+  // Normalize amount up-front so `'1,000.00'` and `'1000.00'` share a cache
+  // entry — buildQuoteRequest performs the same strip later anyway.
+  const normalized = { ...input, amount: normalizeAmount(input.amount) };
+  const key = buildCacheKey(normalized);
   const existing = inflight.get(key);
   if (existing) return existing;
 
-  const promise = cachedFetch(input).finally(() => {
+  const promise = cachedFetch(normalized).finally(() => {
     inflight.delete(key);
   });
   inflight.set(key, promise);

--- a/apps/benchmark/app/lib/services/cachedQuoteService.ts
+++ b/apps/benchmark/app/lib/services/cachedQuoteService.ts
@@ -2,7 +2,7 @@ import { unstable_cache } from 'next/cache';
 import { chainService, quotesService } from '.';
 import type { NetworkAssets } from '@wonderland/interop-cross-chain';
 import type { QuoteBenchmarkResponse } from '~/lib/types';
-import { buildQuoteRequest } from '~/components/race-table/raceRows';
+import { buildQuoteRequest, canonicalizeAmount } from '~/components/race-table/raceRows';
 import { AssetSymbol } from '~/lib/assets';
 import { ChainId } from '~/lib/chains';
 import { withTimeout } from '~/lib/helpers';
@@ -23,8 +23,9 @@ export interface CachedRaceQuotesResult extends QuoteBenchmarkResponse {
 }
 
 /**
- * Module-level coalescing map. Two concurrent requests for the same key share
- * a single upstream call. Entries are cleared in `finally` regardless of outcome.
+ * Module-level coalescing map. The map holds the untimed upstream promise so a
+ * timeout on one caller does not let another start a duplicate fetch for the
+ * same key. Entries clear when the upstream call itself resolves or rejects.
  */
 const inflight = new Map<string, Promise<CachedRaceQuotesResult>>();
 
@@ -81,18 +82,20 @@ export async function getCachedRaceQuotes(
     chainsCache = Promise.resolve(chains);
   }
 
-  // Keep raw amount in the cache key so invalid inputs (e.g. `1,23`) fail
-  // downstream in `parseAmount` instead of being silently coerced.
-  const trimmed = { ...input, amount: input.amount.trim() };
-  const key = buildCacheKey(trimmed);
-  const existing = inflight.get(key);
-  if (existing) return existing;
+  // Validate and normalize the amount up-front: invalid inputs throw before
+  // they hit the cache, and `1000.00` / `1,000.00` collapse to the same key.
+  const canonical = { ...input, amount: canonicalizeAmount(input.amount) };
+  const key = buildCacheKey(canonical);
 
-  // Bound the upstream call so a hung fetch can't keep the inflight entry
-  // alive and starve every concurrent caller behind the same key.
-  const promise = withTimeout(cachedFetch(trimmed), UPSTREAM_TIMEOUT_MS, 'CACHED_QUOTES_TIMEOUT').finally(() => {
-    inflight.delete(key);
-  });
-  inflight.set(key, promise);
-  return promise;
+  let upstream = inflight.get(key);
+  if (!upstream) {
+    upstream = cachedFetch(canonical);
+    upstream.finally(() => inflight.delete(key));
+    inflight.set(key, upstream);
+  }
+
+  // Each caller gets a timeout-bounded view of the shared upstream call. A
+  // timeout only fails that caller; the underlying request keeps running and
+  // its inflight slot stays so concurrent callers don't trigger duplicate work.
+  return withTimeout(upstream, UPSTREAM_TIMEOUT_MS, 'CACHED_QUOTES_TIMEOUT');
 }

--- a/apps/benchmark/app/lib/services/cachedQuoteService.ts
+++ b/apps/benchmark/app/lib/services/cachedQuoteService.ts
@@ -1,5 +1,6 @@
 import { unstable_cache } from 'next/cache';
 import { chainService, quotesService } from '.';
+import type { NetworkAssets } from '@wonderland/interop-cross-chain';
 import type { QuoteBenchmarkResponse } from '~/lib/types';
 import { buildQuoteRequest } from '~/components/race-table/raceRows';
 import { AssetSymbol } from '~/lib/assets';
@@ -33,8 +34,26 @@ export function buildCacheKey(input: CachedRaceQuotesInput): string {
   return `${input.fromChainId}-${input.toChainId}-${input.assetSymbol}-${normalizeAmount(input.amount)}`;
 }
 
+/**
+ * Per-process chain cache. The server component that renders the dropdowns
+ * already calls `chainService.getChains()` to build `initialChains`; on a
+ * cache miss inside this module we'd hit it a second time. Either path
+ * populates the same slot, so whichever runs first warms the other.
+ */
+let chainsCache: Promise<NetworkAssets[]> | null = null;
+
+function getChainsOnce(): Promise<NetworkAssets[]> {
+  if (!chainsCache) {
+    chainsCache = chainService.getChains().catch((error) => {
+      chainsCache = null;
+      throw error;
+    });
+  }
+  return chainsCache;
+}
+
 async function fetchQuotes(input: CachedRaceQuotesInput): Promise<CachedRaceQuotesResult> {
-  const chains = await chainService.getChains();
+  const chains = await getChainsOnce();
   const request = buildQuoteRequest({ chains, ...input });
   const response = await quotesService.getQuotes(request);
   return { ...response, cachedAt: Date.now() };
@@ -50,8 +69,20 @@ const cachedFetch = unstable_cache(fetchQuotes, ['race-quotes'], {
  * calls for the same cache key. The wrapped `unstable_cache` is keyed by both
  * its `keyParts` and the serialized arguments, so distinct inputs get distinct
  * cache entries.
+ *
+ * Pass `chains` when the caller already has the chain list (e.g. a server
+ * component that just rendered the dropdowns) to seed the shared chain cache
+ * and skip a second discovery on cache miss. The chains are deliberately not
+ * part of the cache key — quote responses don't depend on object identity.
  */
-export async function getCachedRaceQuotes(input: CachedRaceQuotesInput): Promise<CachedRaceQuotesResult> {
+export async function getCachedRaceQuotes(
+  input: CachedRaceQuotesInput,
+  chains?: NetworkAssets[],
+): Promise<CachedRaceQuotesResult> {
+  if (chains && !chainsCache) {
+    chainsCache = Promise.resolve(chains);
+  }
+
   // Normalize amount up-front so `'1,000.00'` and `'1000.00'` share a cache
   // entry — buildQuoteRequest performs the same strip later anyway.
   const normalized = { ...input, amount: normalizeAmount(input.amount) };

--- a/apps/benchmark/app/lib/services/cachedQuoteService.ts
+++ b/apps/benchmark/app/lib/services/cachedQuoteService.ts
@@ -5,9 +5,11 @@ import type { QuoteBenchmarkResponse } from '~/lib/types';
 import { buildQuoteRequest } from '~/components/race-table/raceRows';
 import { AssetSymbol } from '~/lib/assets';
 import { ChainId } from '~/lib/chains';
+import { withTimeout } from '~/lib/helpers';
 
 const CACHE_TTL_SECONDS = 30;
 const CACHE_TAG = 'race-quotes';
+const UPSTREAM_TIMEOUT_MS = 25_000;
 
 export interface CachedRaceQuotesInput {
   fromChainId: ChainId;
@@ -26,12 +28,8 @@ export interface CachedRaceQuotesResult extends QuoteBenchmarkResponse {
  */
 const inflight = new Map<string, Promise<CachedRaceQuotesResult>>();
 
-function normalizeAmount(value: string): string {
-  return value.trim().replace(/,/g, '');
-}
-
 export function buildCacheKey(input: CachedRaceQuotesInput): string {
-  return `${input.fromChainId}-${input.toChainId}-${input.assetSymbol}-${normalizeAmount(input.amount)}`;
+  return `${input.fromChainId}-${input.toChainId}-${input.assetSymbol}-${input.amount.trim()}`;
 }
 
 /**
@@ -83,14 +81,16 @@ export async function getCachedRaceQuotes(
     chainsCache = Promise.resolve(chains);
   }
 
-  // Normalize amount up-front so `'1,000.00'` and `'1000.00'` share a cache
-  // entry — buildQuoteRequest performs the same strip later anyway.
-  const normalized = { ...input, amount: normalizeAmount(input.amount) };
-  const key = buildCacheKey(normalized);
+  // Keep raw amount in the cache key so invalid inputs (e.g. `1,23`) fail
+  // downstream in `parseAmount` instead of being silently coerced.
+  const trimmed = { ...input, amount: input.amount.trim() };
+  const key = buildCacheKey(trimmed);
   const existing = inflight.get(key);
   if (existing) return existing;
 
-  const promise = cachedFetch(normalized).finally(() => {
+  // Bound the upstream call so a hung fetch can't keep the inflight entry
+  // alive and starve every concurrent caller behind the same key.
+  const promise = withTimeout(cachedFetch(trimmed), UPSTREAM_TIMEOUT_MS, 'CACHED_QUOTES_TIMEOUT').finally(() => {
     inflight.delete(key);
   });
   inflight.set(key, promise);

--- a/apps/benchmark/app/lib/services/cachedQuoteService.ts
+++ b/apps/benchmark/app/lib/services/cachedQuoteService.ts
@@ -1,0 +1,60 @@
+import { unstable_cache } from 'next/cache';
+import { chainService, quotesService } from '.';
+import type { QuoteBenchmarkResponse } from '~/lib/types';
+import { buildQuoteRequest } from '~/components/race-table/raceRows';
+import { AssetSymbol } from '~/lib/assets';
+import { ChainId } from '~/lib/chains';
+
+const CACHE_TTL_SECONDS = 30;
+const CACHE_TAG = 'race-quotes';
+
+export interface CachedRaceQuotesInput {
+  fromChainId: ChainId;
+  toChainId: ChainId;
+  assetSymbol: AssetSymbol;
+  amount: string;
+}
+
+export interface CachedRaceQuotesResult extends QuoteBenchmarkResponse {
+  cachedAt: number;
+}
+
+/**
+ * Module-level coalescing map. Two concurrent requests for the same key share
+ * a single upstream call. Entries are cleared in `finally` regardless of outcome.
+ */
+const inflight = new Map<string, Promise<CachedRaceQuotesResult>>();
+
+export function buildCacheKey(input: CachedRaceQuotesInput): string {
+  return `${input.fromChainId}-${input.toChainId}-${input.assetSymbol}-${input.amount}`;
+}
+
+async function fetchQuotes(input: CachedRaceQuotesInput): Promise<CachedRaceQuotesResult> {
+  const chains = await chainService.getChains();
+  const request = buildQuoteRequest({ chains, ...input });
+  const response = await quotesService.getQuotes(request);
+  return { ...response, cachedAt: Date.now() };
+}
+
+const cachedFetch = unstable_cache(fetchQuotes, ['race-quotes'], {
+  revalidate: CACHE_TTL_SECONDS,
+  tags: [CACHE_TAG],
+});
+
+/**
+ * Returns cached quotes for the given route, coalescing concurrent in-flight
+ * calls for the same cache key. The wrapped `unstable_cache` is keyed by both
+ * its `keyParts` and the serialized arguments, so distinct inputs get distinct
+ * cache entries.
+ */
+export async function getCachedRaceQuotes(input: CachedRaceQuotesInput): Promise<CachedRaceQuotesResult> {
+  const key = buildCacheKey(input);
+  const existing = inflight.get(key);
+  if (existing) return existing;
+
+  const promise = cachedFetch(input).finally(() => {
+    inflight.delete(key);
+  });
+  inflight.set(key, promise);
+  return promise;
+}

--- a/apps/benchmark/app/lib/services/cachedQuoteService.ts
+++ b/apps/benchmark/app/lib/services/cachedQuoteService.ts
@@ -89,8 +89,11 @@ export async function getCachedRaceQuotes(
 
   let upstream = inflight.get(key);
   if (!upstream) {
-    upstream = cachedFetch(canonical);
-    upstream.finally(() => inflight.delete(key));
+    // Chain `.finally()` into the stored promise so the deletion runs and the
+    // result (or rejection) propagates through the same promise callers await.
+    // A detached `.finally()` would swallow the cleanup chain and surface
+    // upstream rejections as unhandled.
+    upstream = cachedFetch(canonical).finally(() => inflight.delete(key));
     inflight.set(key, upstream);
   }
 

--- a/apps/benchmark/app/page.tsx
+++ b/apps/benchmark/app/page.tsx
@@ -93,12 +93,15 @@ async function loadInitialRace(chains: NetworkAssets[]): Promise<RaceRow[]> {
 
   try {
     const response = await withTimeout(
-      getCachedRaceQuotes({
-        fromChainId: INITIAL_FROM_CHAIN_ID,
-        toChainId: INITIAL_TO_CHAIN_ID,
-        assetSymbol: INITIAL_ASSET_SYMBOL,
-        amount: INITIAL_AMOUNT,
-      }),
+      getCachedRaceQuotes(
+        {
+          fromChainId: INITIAL_FROM_CHAIN_ID,
+          toChainId: INITIAL_TO_CHAIN_ID,
+          assetSymbol: INITIAL_ASSET_SYMBOL,
+          amount: INITIAL_AMOUNT,
+        },
+        chains,
+      ),
       INITIAL_RACE_TIMEOUT_MS,
       'INITIAL_RACE_TIMEOUT',
     );

--- a/apps/benchmark/app/page.tsx
+++ b/apps/benchmark/app/page.tsx
@@ -5,7 +5,7 @@ import { RequestBar } from './components/RequestBar';
 import { SectionFrame } from './components/SectionFrame';
 import { SectionHeader } from './components/SectionHeader';
 import { TopNav } from './components/TopNav';
-import { buildQuoteRequest, buildRowsFromQuotes, createRows, orderRaceRows } from './components/race-table/raceRows';
+import { buildRowsFromQuotes, createRows, orderRaceRows } from './components/race-table/raceRows';
 import { withTimeout } from './lib/helpers';
 import {
   INITIAL_AMOUNT,
@@ -13,7 +13,8 @@ import {
   INITIAL_FROM_CHAIN_ID,
   INITIAL_TO_CHAIN_ID,
 } from './lib/requestBarStore';
-import { chainService, quotesService } from './lib/services';
+import { chainService } from './lib/services';
+import { getCachedRaceQuotes } from './lib/services/cachedQuoteService';
 import type { RaceRow } from './components/race-table/types';
 import type { NetworkAssets } from '@wonderland/interop-cross-chain';
 
@@ -91,15 +92,13 @@ async function loadInitialRace(chains: NetworkAssets[]): Promise<RaceRow[]> {
   if (chains.length === 0) return orderRaceRows(createRows('errored', 'CHAIN DISCOVERY FAILED'));
 
   try {
-    const request = buildQuoteRequest({
-      chains,
-      fromChainId: INITIAL_FROM_CHAIN_ID,
-      toChainId: INITIAL_TO_CHAIN_ID,
-      assetSymbol: INITIAL_ASSET_SYMBOL,
-      amount: INITIAL_AMOUNT,
-    });
     const response = await withTimeout(
-      quotesService.getQuotes(request),
+      getCachedRaceQuotes({
+        fromChainId: INITIAL_FROM_CHAIN_ID,
+        toChainId: INITIAL_TO_CHAIN_ID,
+        assetSymbol: INITIAL_ASSET_SYMBOL,
+        amount: INITIAL_AMOUNT,
+      }),
       INITIAL_RACE_TIMEOUT_MS,
       'INITIAL_RACE_TIMEOUT',
     );

--- a/apps/benchmark/app/page.tsx
+++ b/apps/benchmark/app/page.tsx
@@ -19,7 +19,10 @@ import { getCachedRaceQuotes } from './lib/services/cachedQuoteService';
 import type { RaceRow } from './components/race-table/types';
 import type { NetworkAssets } from '@wonderland/interop-cross-chain';
 
-export const revalidate = 3600;
+// Aligned with `CACHE_TTL_SECONDS` in `cachedQuoteService` so the SSR HTML and
+// the underlying quote cache rotate in lockstep. A longer ISR window would
+// freeze the rendered latencies for up to an hour after a single sample.
+export const revalidate = 30;
 
 const META_LABEL_CLASS = 'font-mono text-label text-text-muted';
 const PACKAGE_URL = 'https://www.npmjs.com/package/@wonderland/interop-cross-chain';


### PR DESCRIPTION
## Summary
Adds a Next.js route handler in front of `quotesService.getQuotes()` so all client traffic goes through our server. The server caches per-route for 30s, coalesces concurrent in-flight requests, and rate-limits per IP. Protects upstream provider APIs (especially LI.FI free tier) from concurrent-user spikes.

- New: `/api/race-quotes` route handler, `cachedQuoteService`, IP rate limit (token bucket, 10/min)
- `useRunRace` now calls the API route instead of importing `quotesService` directly
- Server-side preload in `page.tsx` shares the same cached wrapper, so initial paint and client re-runs use the same cache entry

Closes EFI-967.

## Stack
- Base: feat/benchmark-sdk-trigger (PR #343)
- Predecessors: feat/benchmark-primitives (merged), feat/benchmark-race-ui-mock (merged via #341)

## Verification
- Manual: open the preview in 3 tabs, hit re-run, server logs show 1 upstream call per cache window.
- 11th request in 60s returns 429.
- `pnpm --filter benchmark check-types`, `lint`, `build`, `test:e2e` green.