### PR TITLE
fix(ui): truncate tx hashes with a single ellipsis (EFI-969)

### DIFF
--- a/examples/ui/app/cross-chain/components/OrderTracking/ErrorView.tsx
+++ b/examples/ui/app/cross-chain/components/OrderTracking/ErrorView.tsx
@@ -1,6 +1,6 @@
 import { useChainConfig } from '../../hooks/useNetworkConfig';
 import { STEP } from '../../types/execution';
-import { formatMessageWithDate } from '../../utils/formatting';
+import { formatMessageWithDate, truncateHash } from '../../utils/formatting';
 import { CloseIcon, ExternalLinkIcon } from '../icons';
 import type { ErrorViewProps } from './types';
 
@@ -85,9 +85,7 @@ export function ErrorView({ state, onReset }: ErrorViewProps) {
             </span>
           </div>
           <div className={`flex items-center gap-2 ${linkHoverText}`}>
-            <span className='text-xs font-mono'>
-              {originTxHash.slice(0, 10)}...{originTxHash.slice(-8)}
-            </span>
+            <span className='text-xs font-mono'>{truncateHash(originTxHash)}</span>
             <ExternalLinkIcon />
           </div>
         </a>

--- a/examples/ui/app/cross-chain/components/OrderTracking/SuccessView.tsx
+++ b/examples/ui/app/cross-chain/components/OrderTracking/SuccessView.tsx
@@ -1,4 +1,5 @@
 import { useChainConfig } from '../../hooks/useNetworkConfig';
+import { truncateHash } from '../../utils/formatting';
 import { CheckIcon, ExternalLinkIcon, WarningIcon } from '../icons';
 import type { SuccessViewProps } from './types';
 
@@ -97,9 +98,7 @@ export function SuccessView({ state, providerId, onReset }: SuccessViewProps) {
               <span className='text-xs text-text-tertiary'>{originChain?.name ?? 'Unknown'}</span>
             </div>
             <div className='flex items-center justify-between text-text-tertiary group-hover:text-accent'>
-              <span className='text-sm font-mono'>
-                {openTxHash.slice(0, 10)}...{openTxHash.slice(-8)}
-              </span>
+              <span className='text-sm font-mono'>{truncateHash(openTxHash)}</span>
               <ExternalLinkIcon />
             </div>
           </a>
@@ -119,9 +118,7 @@ export function SuccessView({ state, providerId, onReset }: SuccessViewProps) {
               <span className='text-xs text-text-tertiary'>{destinationChain?.name ?? 'Unknown'}</span>
             </div>
             <div className='flex items-center justify-between text-text-tertiary group-hover:text-accent'>
-              <span className='text-sm font-mono'>
-                {fillTxHash.slice(0, 10)}...{fillTxHash.slice(-8)}
-              </span>
+              <span className='text-sm font-mono'>{truncateHash(fillTxHash)}</span>
               <ExternalLinkIcon />
             </div>
           </a>

--- a/examples/ui/app/cross-chain/utils/formatting.ts
+++ b/examples/ui/app/cross-chain/utils/formatting.ts
@@ -101,6 +101,16 @@ export function truncateAddress(address: string): string {
 }
 
 /**
+ * Truncates a transaction hash to show first 10 and last 8 characters
+ * @param hash - Full transaction hash
+ * @returns Truncated hash (e.g., "0x12345678…90abcdef")
+ */
+export function truncateHash(hash: string): string {
+  if (hash.length <= 18) return hash;
+  return `${hash.slice(0, 10)}…${hash.slice(-8)}`;
+}
+
+/**
  * Formats a date to a human-readable string
  * @param date - Date object or ISO string
  * @returns Formatted date string (e.g., "Jan 13, 2026 at 8:17 PM")


### PR DESCRIPTION
## Summary

- Transaction hashes in the order tracking views were truncated with three ASCII dots (`...`). They now use a single ellipsis character (`…`).
- The truncation was duplicated inline in three spots. It now lives in one shared `truncateHash` helper.

Before: `0x10d5657f...98c0978d`
After: `0x10d5657f…98c0978d`

## Changes

- Add `truncateHash` in `examples/ui/app/cross-chain/utils/formatting.ts`: keeps the first 10 and last 8 characters joined by `…`, and returns the hash unchanged when it is 18 characters or shorter.
- `SuccessView.tsx`: use `truncateHash` for the origin and fill hashes instead of inline `slice` calls.
- `ErrorView.tsx`: use `truncateHash` for the origin hash instead of inline `slice` calls.

## Test plan

- [x] Complete a cross-chain order in the demo and confirm the Origin and Fill cards show the hash as `0x10d5657f…98c0978d` with one ellipsis.
- [x] Trigger an error or timeout and confirm the origin hash in the error view renders the same way.

Closes EFI-969