### PR TITLE
fix(cross-chain): bind Across calldata amounts to quote response

### DIFF
--- a/.changeset/across-calldata-amount-binding.md
+++ b/.changeset/across-calldata-amount-binding.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Bind Across calldata amounts to the quote response fields
+
+`AcrossProvider.validateCalldata` now checks the decoded `swapTx.data` `inputAmount` and `outputAmount` against the response's `inputAmount` and `minOutputAmount`, not only against the request. This ties the amounts previewed to the user to the amounts encoded in the deposit calldata, and it covers `exact-output` quotes where the request has no `input.amount` and the calldata `inputAmount` was previously left unchecked.

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -288,8 +288,8 @@ export class AcrossProvider extends CrossChainProvider {
      * Validate that Across calldata matches the user's QuoteRequest.
      * Reuses the existing calldata decoder but compares against SDK types directly.
      */
-    private validateCalldata(params: QuoteRequest, data: Hex): boolean {
-        const result = decodeAcrossCalldata(data);
+    private validateCalldata(params: QuoteRequest, response: AcrossGetQuoteResponse): boolean {
+        const result = decodeAcrossCalldata(response.swapTx.data as Hex);
         if (!result.success) {
             // "unsupported" selector (e.g. complex swap) — can't validate, allow through
             // "invalid" calldata — reject
@@ -316,6 +316,9 @@ export class AcrossProvider extends CrossChainProvider {
         if (!isAddressEqual(decoded.recipient as Address, recipient as Address)) return false;
         if (decoded.destinationChainId !== BigInt(output.chainId)) return false;
 
+        if (decoded.inputAmount !== BigInt(response.inputAmount)) return false;
+        if (decoded.outputAmount !== BigInt(response.minOutputAmount)) return false;
+
         if (input.amount !== undefined) {
             if (decoded.inputAmount !== BigInt(input.amount)) return false;
         }
@@ -334,7 +337,7 @@ export class AcrossProvider extends CrossChainProvider {
             const acrossResponse = await this.getAcrossQuote(acrossParams);
             const quote = this.toSdkQuote(params, acrossResponse);
 
-            if (!this.validateCalldata(params, acrossResponse.swapTx.data as Hex)) {
+            if (!this.validateCalldata(params, acrossResponse)) {
                 throw new ProviderGetQuoteFailure(
                     "Across calldata validation failed",
                     "Decoded deposit calldata does not match the requested intent",

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -59,6 +59,7 @@ import {
     ProviderConfigFailure,
     ProviderGetQuoteFailure,
     toCanonicalNativeAddress,
+    toNonNegativeBigInt,
     withNativePlaceholder,
 } from "../../internal.js";
 import { decodeAcrossCalldata } from "./utils.js";
@@ -316,8 +317,12 @@ export class AcrossProvider extends CrossChainProvider {
         if (!isAddressEqual(decoded.recipient as Address, recipient as Address)) return false;
         if (decoded.destinationChainId !== BigInt(output.chainId)) return false;
 
-        if (decoded.inputAmount !== BigInt(response.inputAmount)) return false;
-        if (decoded.outputAmount !== BigInt(response.minOutputAmount)) return false;
+        const responseInputAmount = toNonNegativeBigInt(response.inputAmount);
+        const responseMinOutputAmount = toNonNegativeBigInt(response.minOutputAmount);
+        if (responseInputAmount === undefined || responseMinOutputAmount === undefined)
+            return false;
+        if (decoded.inputAmount !== responseInputAmount) return false;
+        if (decoded.outputAmount !== responseMinOutputAmount) return false;
 
         if (input.amount !== undefined) {
             if (decoded.inputAmount !== BigInt(input.amount)) return false;

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -321,8 +321,8 @@ export class AcrossProvider extends CrossChainProvider {
         const responseMinOutputAmount = toNonNegativeBigInt(response.minOutputAmount);
         if (responseInputAmount === undefined || responseMinOutputAmount === undefined)
             return false;
-        if (decoded.inputAmount !== responseInputAmount) return false;
-        if (decoded.outputAmount !== responseMinOutputAmount) return false;
+        if (decoded.inputAmount > responseInputAmount) return false;
+        if (decoded.outputAmount < responseMinOutputAmount) return false;
 
         if (input.amount !== undefined) {
             if (decoded.inputAmount !== BigInt(input.amount)) return false;

--- a/packages/cross-chain/test/providers/AcrossProvider.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.spec.ts
@@ -224,7 +224,7 @@ describe("AcrossProvider", () => {
             expect(quotes).toHaveLength(1);
         });
 
-        it("rejects the quote when calldata inputAmount differs from response.inputAmount", async () => {
+        it("rejects the quote when calldata inputAmount exceeds response.inputAmount", async () => {
             mockOnce(encodeAcrossDeposit({ inputAmount: TEST_AMOUNTS.ONE_ETHER * 2n }));
 
             await expect(provider.getQuotes(exactInputRequest)).rejects.toThrow(
@@ -232,7 +232,7 @@ describe("AcrossProvider", () => {
             );
         });
 
-        it("rejects the quote when calldata outputAmount differs from response.minOutputAmount", async () => {
+        it("rejects the quote when calldata outputAmount is below response.minOutputAmount", async () => {
             mockOnce(encodeAcrossDeposit({ outputAmount: MOCK_MIN_OUTPUT_AMOUNT - 1n }));
 
             await expect(provider.getQuotes(exactInputRequest)).rejects.toThrow(
@@ -240,12 +240,28 @@ describe("AcrossProvider", () => {
             );
         });
 
-        it("validates the calldata inputAmount against response.inputAmount in exact-output mode", async () => {
+        it("accepts the quote when calldata outputAmount exceeds response.minOutputAmount", async () => {
+            mockOnce(encodeAcrossDeposit({ outputAmount: MOCK_MIN_OUTPUT_AMOUNT + 1n }));
+
+            const quotes = await provider.getQuotes(exactInputRequest);
+
+            expect(quotes).toHaveLength(1);
+        });
+
+        it("rejects a calldata inputAmount that exceeds response.inputAmount in exact-output mode", async () => {
             mockOnce(encodeAcrossDeposit({ inputAmount: TEST_AMOUNTS.ONE_ETHER * 2n }));
 
             await expect(provider.getQuotes(exactOutputRequest)).rejects.toThrow(
                 "Across calldata validation failed",
             );
+        });
+
+        it("accepts a calldata inputAmount below response.inputAmount in exact-output mode", async () => {
+            mockOnce(encodeAcrossDeposit({ inputAmount: TEST_AMOUNTS.ONE_ETHER / 2n }));
+
+            const quotes = await provider.getQuotes(exactOutputRequest);
+
+            expect(quotes).toHaveLength(1);
         });
 
         it("accepts a matching calldata in exact-output mode", async () => {

--- a/packages/cross-chain/test/providers/AcrossProvider.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.spec.ts
@@ -1,14 +1,57 @@
 import type viem from "viem";
-import { createPublicClient, PublicClient } from "viem";
+import { Address, createPublicClient, encodeFunctionData, Hex, pad, PublicClient } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { QuoteRequest } from "../../src/core/schemas/quoteRequest.js";
 import { httpRequest } from "../../src/core/utils/httpClient.js";
 import { AcrossProvider } from "../../src/external.js";
+import {
+    ACROSS_SPOKE_POOL_DEPOSIT_ABI,
+    AcrossGetQuoteResponse,
+    addressToBytes32,
+} from "../../src/internal.js";
 import { getMockedAcrossApiResponse } from "../mocks/acrossApi.js";
 import { CHAIN_IDS, TEST_ADDRESSES, TEST_AMOUNTS, TESTNET_TOKENS } from "../mocks/fixtures.js";
 
 const MOCK_API_URL = "https://mocked.accross.url/api";
+
+const MOCK_MIN_OUTPUT_AMOUNT = 980_000_000_000_000_000n;
+const ZERO_BYTES32 = pad("0x00" as Hex, { size: 32 });
+
+interface DepositCalldataOverrides {
+    depositor?: Address;
+    recipient?: Address;
+    inputToken?: Address;
+    outputToken?: Address;
+    inputAmount?: bigint;
+    outputAmount?: bigint;
+    destinationChainId?: number;
+}
+
+const encodeAcrossDeposit = (overrides: DepositCalldataOverrides = {}): Hex =>
+    encodeFunctionData({
+        abi: ACROSS_SPOKE_POOL_DEPOSIT_ABI,
+        functionName: "deposit",
+        args: [
+            addressToBytes32(overrides.depositor ?? TEST_ADDRESSES.USER),
+            addressToBytes32(overrides.recipient ?? TEST_ADDRESSES.RECEIVER),
+            addressToBytes32(overrides.inputToken ?? TESTNET_TOKENS.WETH_SEPOLIA),
+            addressToBytes32(overrides.outputToken ?? TESTNET_TOKENS.WETH_BASE_SEPOLIA),
+            overrides.inputAmount ?? TEST_AMOUNTS.ONE_ETHER,
+            overrides.outputAmount ?? MOCK_MIN_OUTPUT_AMOUNT,
+            BigInt(overrides.destinationChainId ?? CHAIN_IDS.BASE_SEPOLIA),
+            ZERO_BYTES32,
+            0,
+            0,
+            0,
+            "0x",
+        ],
+    });
+
+const responseWithCalldata = (data: Hex): AcrossGetQuoteResponse => {
+    const base = getMockedAcrossApiResponse();
+    return { ...base, swapTx: { ...base.swapTx, data } };
+};
 
 vi.mock("../../src/core/utils/httpClient.js", async (importOriginal) => {
     const actual = await importOriginal<typeof import("../../src/core/utils/httpClient.js")>();
@@ -131,6 +174,86 @@ describe("AcrossProvider", () => {
                     recipient: TEST_ADDRESSES.RECEIVER,
                 },
             });
+        });
+    });
+
+    describe("calldata amount binding", () => {
+        const exactInputRequest: QuoteRequest = {
+            user: TEST_ADDRESSES.USER,
+            input: {
+                chainId: CHAIN_IDS.SEPOLIA,
+                assetAddress: TESTNET_TOKENS.WETH_SEPOLIA,
+                amount: TEST_AMOUNTS.ONE_ETHER.toString(),
+            },
+            output: {
+                chainId: CHAIN_IDS.BASE_SEPOLIA,
+                assetAddress: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                recipient: TEST_ADDRESSES.RECEIVER,
+            },
+            swapType: "exact-input",
+        };
+
+        const exactOutputRequest: QuoteRequest = {
+            user: TEST_ADDRESSES.USER,
+            input: {
+                chainId: CHAIN_IDS.SEPOLIA,
+                assetAddress: TESTNET_TOKENS.WETH_SEPOLIA,
+            },
+            output: {
+                chainId: CHAIN_IDS.BASE_SEPOLIA,
+                assetAddress: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                amount: TEST_AMOUNTS.ONE_ETHER.toString(),
+                recipient: TEST_ADDRESSES.RECEIVER,
+            },
+            swapType: "exact-output",
+        };
+
+        const mockOnce = (data: Hex): void => {
+            vi.mocked(httpRequest).mockResolvedValueOnce({
+                status: 200,
+                data: responseWithCalldata(data),
+                headers: new Headers(),
+            });
+        };
+
+        it("accepts the quote when calldata amounts match the response sibling fields", async () => {
+            mockOnce(encodeAcrossDeposit());
+
+            const quotes = await provider.getQuotes(exactInputRequest);
+
+            expect(quotes).toHaveLength(1);
+        });
+
+        it("rejects the quote when calldata inputAmount differs from response.inputAmount", async () => {
+            mockOnce(encodeAcrossDeposit({ inputAmount: TEST_AMOUNTS.ONE_ETHER * 2n }));
+
+            await expect(provider.getQuotes(exactInputRequest)).rejects.toThrow(
+                "Across calldata validation failed",
+            );
+        });
+
+        it("rejects the quote when calldata outputAmount differs from response.minOutputAmount", async () => {
+            mockOnce(encodeAcrossDeposit({ outputAmount: MOCK_MIN_OUTPUT_AMOUNT - 1n }));
+
+            await expect(provider.getQuotes(exactInputRequest)).rejects.toThrow(
+                "Across calldata validation failed",
+            );
+        });
+
+        it("validates the calldata inputAmount against response.inputAmount in exact-output mode", async () => {
+            mockOnce(encodeAcrossDeposit({ inputAmount: TEST_AMOUNTS.ONE_ETHER * 2n }));
+
+            await expect(provider.getQuotes(exactOutputRequest)).rejects.toThrow(
+                "Across calldata validation failed",
+            );
+        });
+
+        it("accepts a matching calldata in exact-output mode", async () => {
+            mockOnce(encodeAcrossDeposit());
+
+            const quotes = await provider.getQuotes(exactOutputRequest);
+
+            expect(quotes).toHaveLength(1);
         });
     });
 

--- a/packages/cross-chain/test/providers/AcrossProvider.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.spec.ts
@@ -255,6 +255,19 @@ describe("AcrossProvider", () => {
 
             expect(quotes).toHaveLength(1);
         });
+
+        it("rejects cleanly when a response amount is not a valid integer", async () => {
+            const base = responseWithCalldata(encodeAcrossDeposit());
+            vi.mocked(httpRequest).mockResolvedValueOnce({
+                status: 200,
+                data: { ...base, inputAmount: "1.5" },
+                headers: new Headers(),
+            });
+
+            await expect(provider.getQuotes(exactInputRequest)).rejects.toThrow(
+                "Across calldata validation failed",
+            );
+        });
     });
 
     describe("fallbackToken", () => {


### PR DESCRIPTION
Linear: EFI-972

The Across quote preview is built from `inputAmount` and `minOutputAmount`, but `validateCalldata` checked `swapTx.data` only against the request. The previewed amounts were never bound to the deposit calldata, and in `exact-output` mode the calldata `inputAmount` was not checked at all.

`validateCalldata` now takes the full response and bounds the decoded deposit amounts against the previewed sibling fields, in both swap modes:

```diff
  if (decoded.destinationChainId !== BigInt(output.chainId)) return false;
+ const responseInputAmount = toNonNegativeBigInt(response.inputAmount);
+ const responseMinOutputAmount = toNonNegativeBigInt(response.minOutputAmount);
+ if (responseInputAmount === undefined || responseMinOutputAmount === undefined) return false;
+ if (decoded.inputAmount > responseInputAmount) return false;
+ if (decoded.outputAmount < responseMinOutputAmount) return false;
```

The bounds reject only the directions that hurt the user: the deposit may not pull more input than previewed, and may not guarantee less output than the previewed floor. Equal-or-better calldata is accepted, so a conservative `minOutputAmount` below the encoded `outputAmount` is fine. Amounts are parsed with `toNonNegativeBigInt`, so a malformed value rejects the quote cleanly instead of throwing.

Tests in `AcrossProvider.spec.ts` cover both directions (over-pull and under-deliver rejected, equal-or-better accepted), the exact-output path, and a non-integer amount.

## Test plan

- Call multiple quotes for Across within the UI application.