### PR TITLE
feat(benchmark): add head-to-head section with mock data

### DIFF
--- a/apps/benchmark/app/components/headtohead/HeadToHead.tsx
+++ b/apps/benchmark/app/components/headtohead/HeadToHead.tsx
@@ -1,0 +1,28 @@
+import { BenchmarkTable } from '../BenchmarkTable';
+import { HeadToHeadRow } from './HeadToHeadRow';
+import { HEAD_TO_HEAD_COLUMNS } from './constants';
+import type { ProviderMetrics } from '~/lib/types/historyMetrics';
+import { computeBestAtBadges } from '~/lib/headToHeadBadges';
+
+interface HeadToHeadProps {
+  metrics: readonly ProviderMetrics[];
+}
+
+export function HeadToHead({ metrics }: HeadToHeadProps) {
+  const badges = computeBestAtBadges(metrics);
+
+  return (
+    <div
+      className='overflow-hidden border border-border bg-surface-elevated'
+      role='region'
+      aria-label='head-to-head comparison'
+    >
+      <BenchmarkTable
+        columns={HEAD_TO_HEAD_COLUMNS}
+        rows={metrics}
+        getRowKey={(row) => row.providerId}
+        renderRow={(row) => <HeadToHeadRow metrics={row} badges={badges.get(row.providerId) ?? []} />}
+      />
+    </div>
+  );
+}

--- a/apps/benchmark/app/components/headtohead/HeadToHeadRow.tsx
+++ b/apps/benchmark/app/components/headtohead/HeadToHeadRow.tsx
@@ -1,23 +1,23 @@
 import { METRICS_ROW_CLASS } from '../metricsTable';
-import { LEADERBOARD_COLUMNS } from './constants';
+import { HEAD_TO_HEAD_COLUMNS } from './constants';
+import type { BestAtBadge } from '~/lib/headToHeadBadges';
 import type { ProviderMetrics } from '~/lib/types/historyMetrics';
 import { cn } from '~/lib/cn';
 import { PROVIDERS } from '~/lib/providers';
 
-interface LeaderboardRowProps {
+interface HeadToHeadRowProps {
   metrics: ProviderMetrics;
-  rank: number;
-  isWinner: boolean;
+  badges: readonly BestAtBadge[];
 }
 
-export function LeaderboardRow({ metrics, rank, isWinner }: LeaderboardRowProps) {
+export function HeadToHeadRow({ metrics, badges }: HeadToHeadRowProps) {
   const provider = PROVIDERS[metrics.providerId];
   const isPlaceholder = !provider.hasGlobalFeed;
-  const ctx = { rank, isWinner, isPlaceholder, provider };
+  const ctx = { provider, isPlaceholder, badges };
 
   return (
-    <tr className={cn(METRICS_ROW_CLASS, isWinner && 'bg-accent-soft', isPlaceholder && 'opacity-55')}>
-      {LEADERBOARD_COLUMNS.map((column) => (
+    <tr className={cn(METRICS_ROW_CLASS, isPlaceholder && 'opacity-55')}>
+      {HEAD_TO_HEAD_COLUMNS.map((column) => (
         <td key={column.key} className={column.tdClass}>
           {column.render(metrics, ctx)}
         </td>

--- a/apps/benchmark/app/components/headtohead/RouteSelector.tsx
+++ b/apps/benchmark/app/components/headtohead/RouteSelector.tsx
@@ -1,0 +1,39 @@
+import { CHAINS, type ChainId } from '~/lib/chains';
+import { cn } from '~/lib/cn';
+
+interface RouteSelectorProps {
+  fromChainId: ChainId;
+  toChainId: ChainId;
+  assetSymbol: string;
+  assetColorClass: string;
+}
+
+/**
+ * Static route summary pill rendered next to the section header. Matches the
+ * shape of the Pencil design's `routeSel`; the caret is decorative — the
+ * actual route still lives in the global request bar at the top of the page.
+ */
+export function RouteSelector({ fromChainId, toChainId, assetSymbol, assetColorClass }: RouteSelectorProps) {
+  const from = CHAINS[fromChainId];
+  const to = CHAINS[toChainId];
+
+  return (
+    <div className='flex items-center gap-3.5 border border-border bg-surface-elevated px-4 py-2.5'>
+      <span className='font-mono text-label uppercase tracking-wider text-text-muted'>ROUTE</span>
+      <div className='flex items-center gap-2 font-mono text-mark text-text-primary'>
+        <Dot className={assetColorClass} />
+        <span>{assetSymbol}</span>
+        <span className='text-text-muted'>·</span>
+        <Dot className={from.colorClass} />
+        <span>{from.displayName}</span>
+        <span className='text-text-muted'>→</span>
+        <Dot className={to.colorClass} />
+        <span>{to.displayName}</span>
+      </div>
+    </div>
+  );
+}
+
+function Dot({ className }: { className: string }) {
+  return <span className={cn('inline-block size-1.5 rounded-full', className)} aria-hidden='true' />;
+}

--- a/apps/benchmark/app/components/headtohead/constants.tsx
+++ b/apps/benchmark/app/components/headtohead/constants.tsx
@@ -1,0 +1,85 @@
+import { ProviderCell } from '../leaderboard/ProviderCell';
+import { formatAvgFee, formatFillCount, formatFillSeconds, formatSuccessRate } from '../leaderboard/formatters';
+import { METRICS_CELL_NUM, METRICS_CELL_NUM_HIDDEN, METRICS_CELL_STACK, type MetricsColumn } from '../metricsTable';
+import type { BestAtBadge } from '~/lib/headToHeadBadges';
+import type { ProviderMeta } from '~/lib/providers';
+import { cn } from '~/lib/cn';
+
+export interface HeadToHeadRowContext {
+  provider: ProviderMeta;
+  isPlaceholder: boolean;
+  badges: readonly BestAtBadge[];
+}
+
+export type HeadToHeadColumn = MetricsColumn<HeadToHeadRowContext>;
+
+export const HEAD_TO_HEAD_COLUMNS: readonly HeadToHeadColumn[] = [
+  {
+    key: 'provider',
+    label: 'PROVIDER',
+    tdClass: METRICS_CELL_STACK,
+    render: (_metrics, ctx) => <ProviderCell provider={ctx.provider} />,
+  },
+  {
+    key: 'fills',
+    label: 'FILLS',
+    className: 'hidden text-right md:table-cell md:w-28',
+    tdClass: `${METRICS_CELL_NUM_HIDDEN} text-text-primary`,
+    render: (metrics) => formatFillCount(metrics.fillCount),
+  },
+  {
+    key: 'success',
+    label: 'SUCCESS',
+    className: 'text-right md:w-28',
+    tdClass: `${METRICS_CELL_NUM} font-medium text-text-primary`,
+    render: (metrics) => formatSuccessRate(metrics.successRate),
+  },
+  {
+    key: 'p50',
+    label: 'P50 FILL',
+    className: 'hidden text-right md:table-cell md:w-28',
+    tdClass: `${METRICS_CELL_NUM_HIDDEN} text-text-primary`,
+    tooltip: 'Median fill time. Half of fills finish faster than this, half slower.',
+    render: (metrics) => formatFillSeconds(metrics.p50FillSeconds),
+  },
+  {
+    key: 'fee',
+    label: 'AVG FEE',
+    className: 'text-right md:w-24',
+    tdClass: `${METRICS_CELL_NUM} text-text-primary`,
+    render: (metrics) => formatAvgFee(metrics.avgFeeUsd),
+  },
+  {
+    key: 'bestAt',
+    label: 'BEST AT',
+    className: 'text-right md:w-48',
+    tdClass: `${METRICS_CELL_STACK} text-right`,
+    render: (_metrics, ctx) => <BestAtCell badges={ctx.badges} />,
+  },
+];
+
+function BestAtCell({ badges }: { badges: readonly BestAtBadge[] }) {
+  if (badges.length === 0) {
+    return <span className='font-mono text-mark text-text-muted'>—</span>;
+  }
+  return (
+    <div className='flex flex-wrap items-center justify-end gap-1.5'>
+      {badges.map((badge) => (
+        <BestAtBadgeChip key={badge} label={badge} />
+      ))}
+    </div>
+  );
+}
+
+function BestAtBadgeChip({ label }: { label: BestAtBadge }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center bg-accent px-2 py-[3px]',
+        'font-mono text-[9px] font-semibold uppercase tracking-[0.08em] text-on-accent',
+      )}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/benchmark/app/components/leaderboard/ProviderCell.tsx
+++ b/apps/benchmark/app/components/leaderboard/ProviderCell.tsx
@@ -1,0 +1,18 @@
+import { Icon } from '../Icon';
+import type { ProviderMeta } from '~/lib/providers';
+
+export function ProviderCell({ provider }: { provider: ProviderMeta }) {
+  return (
+    <div className='flex items-center gap-2.5 md:gap-3'>
+      <Icon src={provider.iconUrl} alt='' size='md' />
+      <span className='font-sans text-mark font-medium tracking-[-0.0125em] text-text-primary md:text-base'>
+        {provider.displayName}
+      </span>
+      {provider.noFeedReason ? (
+        <span className='hidden whitespace-nowrap font-mono text-caption uppercase tracking-[0.06em] text-text-muted md:inline'>
+          {provider.noFeedReason}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/benchmark/app/components/leaderboard/constants.tsx
+++ b/apps/benchmark/app/components/leaderboard/constants.tsx
@@ -1,9 +1,7 @@
-import type { ReactNode } from 'react';
-import { Icon } from '../Icon';
+import { METRICS_CELL_NUM, METRICS_CELL_NUM_HIDDEN, METRICS_CELL_STACK, type MetricsColumn } from '../metricsTable';
+import { ProviderCell } from './ProviderCell';
 import { formatAvgFee, formatFillCount, formatFillSeconds, formatSuccessRate } from './formatters';
-import type { BenchmarkColumn } from '../BenchmarkTable';
 import type { ProviderMeta } from '~/lib/providers';
-import type { ProviderMetrics } from '~/lib/types/historyMetrics';
 import { cn } from '~/lib/cn';
 
 export interface LeaderboardRowContext {
@@ -13,48 +11,41 @@ export interface LeaderboardRowContext {
   provider: ProviderMeta;
 }
 
-export interface LeaderboardColumn extends BenchmarkColumn {
-  tdClass: string;
-  render: (metrics: ProviderMetrics, ctx: LeaderboardRowContext) => ReactNode;
-}
-
-const STACK_CELL = 'px-3 py-4 md:px-4 md:py-5';
-const NUM_CELL = `${STACK_CELL} text-right font-mono text-mark tabular-nums`;
-const NUM_CELL_HIDDEN = `hidden ${NUM_CELL} md:table-cell`;
+export type LeaderboardColumn = MetricsColumn<LeaderboardRowContext>;
 
 export const LEADERBOARD_COLUMNS: readonly LeaderboardColumn[] = [
   {
     key: 'rank',
     label: '#',
     className: 'w-10 md:w-12',
-    tdClass: STACK_CELL,
+    tdClass: METRICS_CELL_STACK,
     render: (_metrics, ctx) => <RankCell {...ctx} />,
   },
   {
     key: 'provider',
     label: 'PROVIDER',
-    tdClass: STACK_CELL,
+    tdClass: METRICS_CELL_STACK,
     render: (_metrics, ctx) => <ProviderCell provider={ctx.provider} />,
   },
   {
     key: 'fills',
     label: 'FILLS 24H',
     className: 'hidden text-right md:table-cell md:w-32',
-    tdClass: `${NUM_CELL_HIDDEN} text-text-primary`,
+    tdClass: `${METRICS_CELL_NUM_HIDDEN} text-text-primary`,
     render: (metrics) => formatFillCount(metrics.fillCount),
   },
   {
     key: 'success',
     label: 'SUCCESS',
     className: 'text-right md:w-32',
-    tdClass: `${NUM_CELL} font-medium text-text-primary`,
+    tdClass: `${METRICS_CELL_NUM} font-medium text-text-primary`,
     render: (metrics) => formatSuccessRate(metrics.successRate),
   },
   {
     key: 'p50',
     label: 'P50 FILL',
     className: 'hidden text-right md:table-cell md:w-32',
-    tdClass: `${NUM_CELL_HIDDEN} text-text-primary`,
+    tdClass: `${METRICS_CELL_NUM_HIDDEN} text-text-primary`,
     tooltip: 'Median fill time. Half of fills finish faster than this, half slower.',
     render: (metrics) => formatFillSeconds(metrics.p50FillSeconds),
   },
@@ -62,7 +53,7 @@ export const LEADERBOARD_COLUMNS: readonly LeaderboardColumn[] = [
     key: 'p99',
     label: 'P99 FILL',
     className: 'hidden text-right md:table-cell md:w-32',
-    tdClass: `${NUM_CELL_HIDDEN} text-text-secondary`,
+    tdClass: `${METRICS_CELL_NUM_HIDDEN} text-text-secondary`,
     tooltip: 'Worst-case fill time. Only 1 in 100 fills is slower than this.',
     render: (metrics) => formatFillSeconds(metrics.p99FillSeconds),
   },
@@ -70,7 +61,7 @@ export const LEADERBOARD_COLUMNS: readonly LeaderboardColumn[] = [
     key: 'fee',
     label: 'AVG FEE',
     className: 'text-right md:w-28',
-    tdClass: `${NUM_CELL} text-text-primary`,
+    tdClass: `${METRICS_CELL_NUM} text-text-primary`,
     render: (metrics) => formatAvgFee(metrics.avgFeeUsd),
   },
 ];
@@ -85,22 +76,6 @@ function RankCell({ rank, isWinner, isPlaceholder, provider }: LeaderboardRowCon
         <span className={cn('inline-block size-1.5 rounded-full', provider.colorClass)} aria-hidden='true' />
       ) : null}
       <span className={cn(isWinner ? 'font-medium text-accent' : 'text-text-secondary')}>{rank}</span>
-    </div>
-  );
-}
-
-function ProviderCell({ provider }: { provider: ProviderMeta }) {
-  return (
-    <div className='flex items-center gap-2.5 md:gap-3'>
-      <Icon src={provider.iconUrl} alt='' size='md' />
-      <span className='font-sans text-mark font-medium tracking-[-0.0125em] text-text-primary md:text-base'>
-        {provider.displayName}
-      </span>
-      {provider.noFeedReason ? (
-        <span className='hidden whitespace-nowrap font-mono text-caption uppercase tracking-[0.06em] text-text-muted md:inline'>
-          {provider.noFeedReason}
-        </span>
-      ) : null}
     </div>
   );
 }

--- a/apps/benchmark/app/components/metricsTable.tsx
+++ b/apps/benchmark/app/components/metricsTable.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+import type { BenchmarkColumn } from './BenchmarkTable';
+import type { ProviderMetrics } from '~/lib/types/historyMetrics';
+
+// Shared cell padding for non-numeric stack cells (rank, provider).
+export const METRICS_CELL_STACK = 'px-3 py-4 md:px-4 md:py-5';
+
+// Right-aligned numeric cell with fixed-width digits.
+export const METRICS_CELL_NUM = `${METRICS_CELL_STACK} text-right font-mono text-mark tabular-nums`;
+
+// Numeric cell that hides on mobile and reveals at the `md` breakpoint.
+export const METRICS_CELL_NUM_HIDDEN = `hidden ${METRICS_CELL_NUM} md:table-cell`;
+
+// Base `<tr>` classes shared by every metrics-style table row.
+export const METRICS_ROW_CLASS = 'h-16 border-b border-border-subtle align-middle last:border-b-0 md:h-[72px]';
+
+export interface MetricsColumn<Ctx> extends BenchmarkColumn {
+  tdClass: string;
+  render: (metrics: ProviderMetrics, ctx: Ctx) => ReactNode;
+}

--- a/apps/benchmark/app/lib/headToHeadBadges.ts
+++ b/apps/benchmark/app/lib/headToHeadBadges.ts
@@ -41,15 +41,20 @@ export function computeBestAtBadges(metrics: readonly ProviderMetrics[]): Map<Pr
 function pickWinner(metrics: readonly ProviderMetrics[], rule: BadgeRule): ProviderMetrics | null {
   const candidates = metrics.filter((m) => {
     const value = rule.select(m);
-    // Only providers with positive activity AND a usable metric qualify; a
-    // provider with zero fills cannot be "cheapest" or "fastest" even if the
-    // service returned a default 0.
-    return value !== null && Number.isFinite(value) && (m.fillCount ?? 0) > 0;
+    // Only providers with positive activity AND a usable, non-negative metric
+    // qualify. Negatives are rejected here because the row formatters render
+    // them as em-dashes, so awarding a badge on a hidden value would mislead.
+    return value !== null && Number.isFinite(value) && value >= 0 && (m.fillCount ?? 0) > 0;
   });
   if (candidates.length === 0) return null;
   return candidates.reduce((best, current) => {
     const a = rule.select(best)!;
     const b = rule.select(current)!;
+    if (a === b) {
+      // Deterministic tie-break by providerId so the winner doesn't flicker
+      // between renders when upstream ordering changes.
+      return current.providerId < best.providerId ? current : best;
+    }
     return rule.direction === 'min' ? (b < a ? current : best) : b > a ? current : best;
   });
 }

--- a/apps/benchmark/app/lib/headToHeadBadges.ts
+++ b/apps/benchmark/app/lib/headToHeadBadges.ts
@@ -1,0 +1,55 @@
+import type { ProviderId } from './providers';
+import type { ProviderMetrics } from './types/historyMetrics';
+
+export type BestAtBadge = 'FASTEST' | 'CHEAPEST' | 'MOST ACTIVE';
+
+type Selector = (metrics: ProviderMetrics) => number | null;
+
+interface BadgeRule {
+  badge: BestAtBadge;
+  select: Selector;
+  direction: 'min' | 'max';
+}
+
+const RULES: readonly BadgeRule[] = [
+  { badge: 'FASTEST', select: (m) => m.p50FillSeconds, direction: 'min' },
+  { badge: 'CHEAPEST', select: (m) => m.avgFeeUsd, direction: 'min' },
+  { badge: 'MOST ACTIVE', select: (m) => m.fillCount, direction: 'max' },
+];
+
+/**
+ * Per-provider best-at badges for the head-to-head section.
+ *
+ * A badge is awarded only to the single best provider in that category, and
+ * only when there is at least one provider with usable data — categories
+ * where every provider returned null or zero fills are skipped entirely.
+ */
+export function computeBestAtBadges(metrics: readonly ProviderMetrics[]): Map<ProviderId, BestAtBadge[]> {
+  const badges = new Map<ProviderId, BestAtBadge[]>();
+
+  for (const rule of RULES) {
+    const winner = pickWinner(metrics, rule);
+    if (!winner) continue;
+    const existing = badges.get(winner.providerId) ?? [];
+    existing.push(rule.badge);
+    badges.set(winner.providerId, existing);
+  }
+
+  return badges;
+}
+
+function pickWinner(metrics: readonly ProviderMetrics[], rule: BadgeRule): ProviderMetrics | null {
+  const candidates = metrics.filter((m) => {
+    const value = rule.select(m);
+    // Only providers with positive activity AND a usable metric qualify; a
+    // provider with zero fills cannot be "cheapest" or "fastest" even if the
+    // service returned a default 0.
+    return value !== null && Number.isFinite(value) && (m.fillCount ?? 0) > 0;
+  });
+  if (candidates.length === 0) return null;
+  return candidates.reduce((best, current) => {
+    const a = rule.select(best)!;
+    const b = rule.select(current)!;
+    return rule.direction === 'min' ? (b < a ? current : best) : b > a ? current : best;
+  });
+}

--- a/apps/benchmark/app/lib/mocks/headToHeadMock.ts
+++ b/apps/benchmark/app/lib/mocks/headToHeadMock.ts
@@ -1,0 +1,48 @@
+import { ProviderId } from '../providers';
+import type { ProviderMetrics } from '../types/historyMetrics';
+
+/**
+ * Fixture mirroring the Pencil design for Section 03 (arbitrum → base, USDC):
+ * - relay wins FASTEST + CHEAPEST
+ * - across wins MOST ACTIVE
+ * - lifi has data but no category win
+ * - bungee is the no-global-feed placeholder
+ */
+export const MOCK_HEAD_TO_HEAD_METRICS: ProviderMetrics[] = [
+  {
+    providerId: ProviderId.Relay,
+    fillCount: 287,
+    successRate: 0.997,
+    p50FillSeconds: 1.2,
+    p99FillSeconds: 3.6,
+    avgFeeUsd: 0.14,
+    volumeUsd: 482_300,
+  },
+  {
+    providerId: ProviderId.Across,
+    fillCount: 342,
+    successRate: 0.994,
+    p50FillSeconds: 1.8,
+    p99FillSeconds: 6.2,
+    avgFeeUsd: 0.31,
+    volumeUsd: 615_700,
+  },
+  {
+    providerId: ProviderId.Lifi,
+    fillCount: 198,
+    successRate: 0.972,
+    p50FillSeconds: 4.1,
+    p99FillSeconds: 14.5,
+    avgFeeUsd: 0.62,
+    volumeUsd: 391_200,
+  },
+  {
+    providerId: ProviderId.Bungee,
+    fillCount: null,
+    successRate: null,
+    p50FillSeconds: null,
+    p99FillSeconds: null,
+    avgFeeUsd: null,
+    volumeUsd: null,
+  },
+];

--- a/apps/benchmark/app/page.tsx
+++ b/apps/benchmark/app/page.tsx
@@ -6,9 +6,12 @@ import { RequestBar } from './components/RequestBar';
 import { SectionFrame } from './components/SectionFrame';
 import { SectionHeader } from './components/SectionHeader';
 import { TopNav } from './components/TopNav';
+import { HeadToHead } from './components/headtohead/HeadToHead';
+import { RouteSelector } from './components/headtohead/RouteSelector';
 import { Leaderboard } from './components/leaderboard/Leaderboard';
 import { buildQuoteRequest, buildRowsFromQuotes, createRows, orderRaceRows } from './components/race-table/raceRows';
 import { withTimeout } from './lib/helpers';
+import { MOCK_HEAD_TO_HEAD_METRICS } from './lib/mocks/headToHeadMock';
 import { MOCK_LEADERBOARD_METRICS } from './lib/mocks/leaderboardMock';
 import {
   INITIAL_AMOUNT,
@@ -72,9 +75,17 @@ export default async function Home() {
           <SectionHeader
             index='03'
             label='head-to-head · by route'
-            title='compare providers on the selected chain pair'
+            title='compare providers on a specific chain pair'
+            rightSlot={
+              <RouteSelector
+                fromChainId={INITIAL_FROM_CHAIN_ID}
+                toChainId={INITIAL_TO_CHAIN_ID}
+                assetSymbol={INITIAL_ASSET_SYMBOL}
+                assetColorClass='bg-asset-usdc'
+              />
+            }
           />
-          <SectionPlaceholder label='comparison table arrives in pr 4' />
+          <HeadToHead metrics={MOCK_HEAD_TO_HEAD_METRICS} />
         </SectionFrame>
       </main>
 
@@ -114,12 +125,4 @@ async function loadInitialRace(chains: NetworkAssets[]): Promise<RaceRow[]> {
   } catch {
     return orderRaceRows(createRows('idle'));
   }
-}
-
-function SectionPlaceholder({ label }: { label: string }) {
-  return (
-    <Label className='flex h-40 w-full items-center justify-center border border-dashed border-border-subtle bg-surface-elevated/40 font-mono text-label uppercase tracking-widest text-text-muted'>
-      {label}
-    </Label>
-  );
 }

--- a/apps/benchmark/tests/headtohead.spec.ts
+++ b/apps/benchmark/tests/headtohead.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test('renders the head-to-head table with all 4 providers', async ({ page }) => {
+  const table = page.getByRole('region', { name: 'head-to-head comparison' });
+  await expect(table.locator('tbody tr')).toHaveCount(4);
+});
+
+test('awards FASTEST and CHEAPEST badges to relay', async ({ page }) => {
+  const table = page.getByRole('region', { name: 'head-to-head comparison' });
+  const relayRow = table.locator('tbody tr').filter({ hasText: 'relay' });
+  await expect(relayRow).toContainText('FASTEST');
+  await expect(relayRow).toContainText('CHEAPEST');
+});
+
+test('awards MOST ACTIVE badge to across', async ({ page }) => {
+  const table = page.getByRole('region', { name: 'head-to-head comparison' });
+  const acrossRow = table.locator('tbody tr').filter({ hasText: 'across' });
+  await expect(acrossRow).toContainText('MOST ACTIVE');
+});
+
+test('bungee row shows em-dashes and no global feed', async ({ page }) => {
+  const table = page.getByRole('region', { name: 'head-to-head comparison' });
+  const bungeeRow = table.locator('tbody tr').filter({ hasText: 'bungee' });
+  await expect(bungeeRow).toContainText('no global feed');
+  // BEST AT cell should render the em-dash (no badges for placeholder).
+  const bestAtCell = bungeeRow.locator('td').last();
+  await expect(bestAtCell).toContainText('—');
+});


### PR DESCRIPTION
Closes EFI-928

Builds the Section 03 head-to-head UI mocked. Branches off `feat/benchmark-leaderboard-mock` because it reuses `historyAggregation`/`ProviderMetrics` introduced there; will auto-rebase to `dev` when #349 merges.

## What's in

- `HeadToHead.tsx` + `HeadToHeadRow.tsx` server-rendered, reuses the `BenchmarkTable<T>` primitive and the column-config pattern from the leaderboard
- Columns per Pencil: PROVIDER, FILLS, SUCCESS, P50 FILL (with tooltip), AVG FEE, BEST AT
- `RouteSelector` pill in the section header echoing the current request bar route (asset dot + from chain → to chain). Static for the mock; will read `requestBarStore` in the wire-up PR
- `lib/headToHeadBadges.ts` computes per-provider `FASTEST` / `CHEAPEST` / `MOST ACTIVE` badges. Single winner per category, skipped entirely if no provider has data
- `lib/mocks/headToHeadMock.ts` matches the Pencil numbers exactly (relay wins FASTEST + CHEAPEST, across wins MOST ACTIVE, lifi has data but no win, bungee is the placeholder)
- Pulled `ProviderCell` out of `leaderboard/constants.tsx` into its own file so both sections share it without duplication

## What's out

- Real history data (depends on Phantom's services + the wire-up PR for #349 to land first)
- `requestBarStore` wiring so the table reactively updates on chain/asset changes
- Empty-state row when the selected route has zero fills across providers (ticket scope, follow-up)

## Pencil

Section 03 frame `fxrDl` — route selector `E85Wc`, table header `arT8B`, badge styling `b1p1`/`b1p2`/`b2p`.