### PR TITLE
fix(cross-chain): stabilize anvil fork tests with readiness polling

### DIFF
--- a/packages/cross-chain/test/helpers/anvilFork.ts
+++ b/packages/cross-chain/test/helpers/anvilFork.ts
@@ -1,4 +1,5 @@
 import { spawn } from "child_process";
+import type { ChildProcess } from "child_process";
 import type { Chain, PublicClient } from "viem";
 import { createPublicClient, http } from "viem";
 import { afterAll, beforeAll } from "vitest";
@@ -10,11 +11,18 @@ export interface AnvilFork {
     clientManager: PublicClientManager;
 }
 
+const DEFAULT_PORT = 8559;
+const FORK_BLOCK_OFFSET = 32n;
+const READY_TIMEOUT_MS = 20_000;
+const READY_POLL_INTERVAL_MS = 250;
+const RPC_MAX_ATTEMPTS = 3;
+const RPC_RETRY_BACKOFF_MS = 500;
+
 /**
  * Set up an anvil fork for the current describe block.
  * Returns a ref that gets populated in beforeAll.
  */
-export function useAnvilFork(chain: Chain, port = 8559): { current: AnvilFork | null } {
+export function useAnvilFork(chain: Chain, port = DEFAULT_PORT): { current: AnvilFork | null } {
     const ref: { current: AnvilFork | null } = { current: null };
     let stop: (() => void) | null = null;
 
@@ -26,37 +34,104 @@ export function useAnvilFork(chain: Chain, port = 8559): { current: AnvilFork | 
         } catch {
             console.warn("anvil not available, skipping fork tests");
         }
-    }, 15000);
+    }, 45000);
 
     afterAll(() => stop?.());
 
     return ref;
 }
 
-function startAnvil(chain: Chain, port: number): Promise<AnvilFork & { stop: () => void }> {
-    const forkUrl = chain.rpcUrls.default.http[0]!;
+async function startAnvil(chain: Chain, port: number): Promise<AnvilFork & { stop: () => void }> {
+    const forkUrl = resolveForkUrl(chain);
     const rpcUrl = `http://127.0.0.1:${port}`;
+    const forkBlock = await resolveForkBlock(chain, forkUrl);
 
-    return new Promise((resolve, reject) => {
-        const proc = spawn("anvil", [
-            "--fork-url",
-            forkUrl,
-            "--port",
-            String(port),
-            "--silent",
-            "--no-mining",
-        ]);
+    const proc = spawn("anvil", [
+        "--fork-url",
+        forkUrl,
+        "--fork-block-number",
+        String(forkBlock),
+        "--port",
+        String(port),
+        "--silent",
+        "--no-mining",
+    ]);
 
-        proc.on("error", reject);
-        proc.on("exit", (code) => reject(new Error(`anvil exited with code ${code}`)));
+    const client = createPublicClient({ chain, transport: http(rpcUrl) });
 
-        setTimeout(() => {
-            const client = createPublicClient({ chain, transport: http(rpcUrl) });
-            resolve({
-                client,
-                clientManager: new PublicClientManager(client),
-                stop: () => proc.kill(),
-            });
-        }, 4000);
-    });
+    try {
+        await waitForAnvilReady(client, proc);
+    } catch (error) {
+        proc.kill();
+        throw error;
+    }
+
+    return {
+        client,
+        clientManager: new PublicClientManager(client),
+        stop: () => proc.kill(),
+    };
+}
+
+function resolveForkUrl(chain: Chain): string {
+    return process.env[`FORK_RPC_URL_${chain.id}`] ?? chain.rpcUrls.default.http[0]!;
+}
+
+async function resolveForkBlock(chain: Chain, forkUrl: string): Promise<bigint> {
+    const upstream = createPublicClient({ chain, transport: http(forkUrl) });
+    const latest = await withRpcRetry(() => upstream.getBlockNumber());
+    const forkBlock = latest - FORK_BLOCK_OFFSET;
+
+    if (forkBlock <= 0n) {
+        throw new Error(`computed fork block ${forkBlock} is invalid (latest=${latest})`);
+    }
+
+    return forkBlock;
+}
+
+async function waitForAnvilReady(client: PublicClient, proc: ChildProcess): Promise<void> {
+    let failure: Error | null = null;
+    const onExit = (code: number | null): void => {
+        failure = new Error(`anvil exited with code ${code}`);
+    };
+    const onError = (error: Error): void => {
+        failure = error;
+    };
+
+    proc.once("exit", onExit);
+    proc.once("error", onError);
+
+    try {
+        const deadline = Date.now() + READY_TIMEOUT_MS;
+        while (Date.now() < deadline) {
+            if (failure) throw failure;
+            try {
+                await client.getBlockNumber();
+                return;
+            } catch {
+                await delay(READY_POLL_INTERVAL_MS);
+            }
+        }
+        throw new Error("anvil did not become ready in time");
+    } finally {
+        proc.off("exit", onExit);
+        proc.off("error", onError);
+    }
+}
+
+async function withRpcRetry<T>(fn: () => Promise<T>): Promise<T> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= RPC_MAX_ATTEMPTS; attempt++) {
+        try {
+            return await fn();
+        } catch (error) {
+            lastError = error;
+            if (attempt < RPC_MAX_ATTEMPTS) await delay(RPC_RETRY_BACKOFF_MS * attempt);
+        }
+    }
+    throw lastError;
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
Closes EFI-978

## Summary
- The anvil fork test helper resolved after a fixed 4s sleep without ever checking that anvil was listening, so a slow or pruned public RPC left the client pointing at a dead port and the LiFi Open-event fork test failed in CI with `ECONNREFUSED 127.0.0.1:8560`.
- This swaps the sleep for an actual readiness check and hardens the fork startup so the test runs reliably, or skips cleanly when anvil genuinely can't boot.

## Changes
- `test/helpers/anvilFork.ts`: poll the local node with `getBlockNumber()` until it answers instead of sleeping 4s, and bail out if the anvil process exits or errors first (so the test skips instead of failing).
- Retry the upstream block lookup with backoff and pin the fork to `latest - 32`, keeping the fork inside the public RPC retention window.
- Read the fork RPC from `FORK_RPC_URL_<chainId>` when set, falling back to the viem chain default, so CI can inject a private endpoint.
- Bump the `beforeAll` timeout from 15s to 45s to cover the block lookup, retries and polling.

## Test plan
- [x] `pnpm vitest run test/services/lifiOpenedIntentParser.fork.spec.ts test/services/acrossDestinationCalls.fork.spec.ts` passes, run many times in a row with no ECONNREFUSED.
- [x] `pnpm test:cov` green (0 failed).
- [x] `pnpm lint` and `pnpm check-types` clean.