### PR TITLE
fix(cross-chain): reject OIF orders with unverified array entries (EFI-982)

### DIFF
--- a/.changeset/oif-reject-unverified-order-entries.md
+++ b/.changeset/oif-reject-unverified-order-entries.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Reject OIF orders that carry unverified extra entries
+
+OIF order validation only checks `inputs[0]`, so any extra entry in an order's `permitted`, `commitments`, or `allowances` array went through unverified — a solver could use that to slip in transfers the SDK never cross-checked against the user's intent. Escrow, resource-lock, and user-open orders with more than one such entry are now rejected, and `oif-user-open-v0` throws the new `UnverifiedOrderEntries` error in that case.

--- a/packages/cross-chain/src/core/errors/UnverifiedOrderEntries.exception.ts
+++ b/packages/cross-chain/src/core/errors/UnverifiedOrderEntries.exception.ts
@@ -1,0 +1,17 @@
+import { ProviderGetQuoteFailure } from "./ProviderGetQuoteFailure.exception.js";
+
+/** Thrown when a solver-returned order has more array entries than the SDK verifies against the intent. */
+export class UnverifiedOrderEntries extends ProviderGetQuoteFailure {
+    public readonly orderType: string;
+    public readonly field: string;
+    public readonly count: number;
+
+    constructor(orderType: string, field: string, count: number) {
+        super(
+            `${orderType} order carries ${count} "${field}" entries; only one is supported, the rest are unverified`,
+        );
+        this.orderType = orderType;
+        this.field = field;
+        this.count = count;
+    }
+}

--- a/packages/cross-chain/src/core/errors/UnverifiedOrderEntries.exception.ts
+++ b/packages/cross-chain/src/core/errors/UnverifiedOrderEntries.exception.ts
@@ -1,12 +1,15 @@
 import { ProviderGetQuoteFailure } from "./ProviderGetQuoteFailure.exception.js";
 
+export type UnverifiedOrderType = "oif-escrow-v0" | "oif-resource-lock-v0" | "oif-user-open-v0";
+export type UnverifiedOrderField = "permitted" | "commitments" | "allowances";
+
 /** Thrown when a solver-returned order has more array entries than the SDK verifies against the intent. */
 export class UnverifiedOrderEntries extends ProviderGetQuoteFailure {
-    public readonly orderType: string;
-    public readonly field: string;
+    public readonly orderType: UnverifiedOrderType;
+    public readonly field: UnverifiedOrderField;
     public readonly count: number;
 
-    constructor(orderType: string, field: string, count: number) {
+    constructor(orderType: UnverifiedOrderType, field: UnverifiedOrderField, count: number) {
         super(
             `${orderType} order carries ${count} "${field}" entries; only one is supported, the rest are unverified`,
         );

--- a/packages/cross-chain/src/core/errors/index.ts
+++ b/packages/cross-chain/src/core/errors/index.ts
@@ -26,3 +26,4 @@ export * from "./HttpError.exception.js";
 export * from "./HttpTimeout.exception.js";
 export * from "./HttpNetworkError.exception.js";
 export * from "./Eip712EnvelopeMismatch.exception.js";
+export * from "./UnverifiedOrderEntries.exception.js";

--- a/packages/cross-chain/src/protocols/oif/adapters/orderAdapter.ts
+++ b/packages/cross-chain/src/protocols/oif/adapters/orderAdapter.ts
@@ -19,6 +19,7 @@ import type {
     TransactionStep,
 } from "../../../core/schemas/order.js";
 import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
+import { UnverifiedOrderEntries } from "../../../core/errors/UnverifiedOrderEntries.exception.js";
 import { toInteropAccountId } from "../../../core/utils/interopAccountId.js";
 import {
     validateOif3009SignatureEnvelope,
@@ -91,6 +92,11 @@ function fromOifUserOpenOrder(order: {
         }>;
     };
 }): Order {
+    const allowanceCount = order.checks?.allowances?.length ?? 0;
+    if (allowanceCount > 1) {
+        throw new UnverifiedOrderEntries("oif-user-open-v0", "allowances", allowanceCount);
+    }
+
     const txData =
         order.openIntentTx.data instanceof Uint8Array
             ? bytesToHex(order.openIntentTx.data)

--- a/packages/cross-chain/src/protocols/oif/adapters/orderAdapter.ts
+++ b/packages/cross-chain/src/protocols/oif/adapters/orderAdapter.ts
@@ -13,6 +13,10 @@ import type {
 import { bytesToHex } from "viem";
 
 import type {
+    UnverifiedOrderField,
+    UnverifiedOrderType,
+} from "../../../core/errors/UnverifiedOrderEntries.exception.js";
+import type {
     Order,
     OrderChecks,
     SignatureStep,
@@ -55,9 +59,26 @@ function toSignatureStep(
     };
 }
 
+function assertSingleEntry(
+    entries: readonly unknown[] | undefined,
+    orderType: UnverifiedOrderType,
+    field: UnverifiedOrderField,
+): void {
+    const count = entries?.length ?? 0;
+    if (count > 1) {
+        throw new UnverifiedOrderEntries(orderType, field, count);
+    }
+}
+
 // ── OIF Order Converters ─────────────────────────────────
 
 function fromOifEscrowOrder(order: OifEscrowOrder, params: QuoteRequest): Order {
+    assertSingleEntry(
+        (order.payload.message as { permitted?: unknown[] }).permitted,
+        "oif-escrow-v0",
+        "permitted",
+    );
+
     validateOifEscrowSignatureEnvelope(order, params);
     return {
         steps: [toSignatureStep(order.payload)],
@@ -74,6 +95,12 @@ function fromOif3009Order(order: Oif3009Order, params: QuoteRequest): Order {
 }
 
 function fromOifResourceLockOrder(order: OifResourceLockOrder): Order {
+    assertSingleEntry(
+        (order.payload.message as { commitments?: unknown[] }).commitments,
+        "oif-resource-lock-v0",
+        "commitments",
+    );
+
     return {
         steps: [toSignatureStep(order.payload)],
         lock: { type: "compact-resource-lock" },
@@ -92,10 +119,7 @@ function fromOifUserOpenOrder(order: {
         }>;
     };
 }): Order {
-    const allowanceCount = order.checks?.allowances?.length ?? 0;
-    if (allowanceCount > 1) {
-        throw new UnverifiedOrderEntries("oif-user-open-v0", "allowances", allowanceCount);
-    }
+    assertSingleEntry(order.checks?.allowances, "oif-user-open-v0", "allowances");
 
     const txData =
         order.openIntentTx.data instanceof Uint8Array

--- a/packages/cross-chain/src/protocols/oif/validators/oifEscrowValidator.ts
+++ b/packages/cross-chain/src/protocols/oif/validators/oifEscrowValidator.ts
@@ -18,6 +18,7 @@ export async function validateEscrowOrder(
 
     const message = payload.message as EscrowMessage;
     if (!message.permitted?.length) return false;
+    if (message.permitted.length > 1) return false;
 
     // TODO: Support multiple inputs (OIF standard supports multi-token intents via permitted[])
     const input = userIntent.intent.inputs[0];

--- a/packages/cross-chain/src/protocols/oif/validators/oifResourceLockValidator.ts
+++ b/packages/cross-chain/src/protocols/oif/validators/oifResourceLockValidator.ts
@@ -24,6 +24,7 @@ export async function validateResourceLockOrder(
     if (message.expires === undefined) return false;
     if (!message.sponsor) return false;
     if (!message.commitments?.length) return false;
+    if (message.commitments.length > 1) return false;
 
     const commitment = message.commitments[0];
     if (!commitment) return false;

--- a/packages/cross-chain/src/protocols/oif/validators/oifUserOpenValidator.ts
+++ b/packages/cross-chain/src/protocols/oif/validators/oifUserOpenValidator.ts
@@ -12,6 +12,7 @@ export async function validateUserOpenOrder(
 
     const allowances = order.checks.allowances;
     if (!allowances.length) return false;
+    if (allowances.length > 1) return false;
 
     const allowance = allowances[0];
     if (!allowance) return false;

--- a/packages/cross-chain/test/adapters/orderAdapter.spec.ts
+++ b/packages/cross-chain/test/adapters/orderAdapter.spec.ts
@@ -4,6 +4,7 @@ import { pad } from "viem";
 import { describe, expect, it } from "vitest";
 
 import type { QuoteRequest } from "../../src/core/schemas/quoteRequest.js";
+import { UnverifiedOrderEntries } from "../../src/external.js";
 import { adaptOifOrder } from "../../src/protocols/oif/adapters/orderAdapter.js";
 
 function toErc7930(chainId: number, address: string): string {
@@ -172,6 +173,27 @@ describe("orderAdapter", () => {
             };
             expect(() => adaptOifOrder(oifOrder)).toThrowError(/QuoteRequest required/);
         });
+
+        it("rejects an order carrying more than one permitted entry", () => {
+            const oifOrder = {
+                type: "oif-escrow-v0" as const,
+                payload: {
+                    signatureType: "eip712" as const,
+                    domain: { name: "Permit2", chainId: 1, verifyingContract: PERMIT2 },
+                    primaryType: "PermitBatchWitnessTransferFrom",
+                    types: VALID_PERMIT2_TYPES,
+                    message: {
+                        ...VALID_PERMIT2_MESSAGE,
+                        permitted: [
+                            { token: USDC_MAINNET, amount: "1000000" },
+                            { token: USDC_MAINNET, amount: "0" },
+                        ],
+                    },
+                },
+            };
+
+            expect(() => adaptOifOrder(oifOrder, mockParams())).toThrow(UnverifiedOrderEntries);
+        });
     });
 
     describe("adaptOifOrder — oif-3009-v0", () => {
@@ -245,6 +267,27 @@ describe("orderAdapter", () => {
             expect(result.steps[0]!.kind).toBe("signature");
             expect(result.lock).toEqual({ type: "compact-resource-lock" });
             expect(result.steps[0]!.chainId).toBe(8453);
+        });
+
+        it("rejects an order carrying more than one commitment", () => {
+            const oifOrder = {
+                type: "oif-resource-lock-v0" as const,
+                payload: {
+                    signatureType: "eip712" as const,
+                    domain: { name: "The Compact", version: "1", chainId: 8453 },
+                    primaryType: "BatchCompact",
+                    types: { BatchCompact: [{ name: "arbiter", type: "address" }] },
+                    message: {
+                        arbiter: "0xabc",
+                        commitments: [
+                            { token: USDC_MAINNET, amount: "1000000" },
+                            { token: USDC_MAINNET, amount: "0" },
+                        ],
+                    },
+                },
+            };
+
+            expect(() => adaptOifOrder(oifOrder)).toThrow(UnverifiedOrderEntries);
         });
     });
 

--- a/packages/cross-chain/test/mocks/oif/quotes.ts
+++ b/packages/cross-chain/test/mocks/oif/quotes.ts
@@ -75,6 +75,8 @@ export interface EscrowOverrides {
     amount?: string;
     /** Override user in message.witness (20-byte address) */
     user?: string;
+    /** Extra permitted entries smuggled beyond the verified inputs[0] */
+    extraPermitted?: Array<{ token: string; amount: string }>;
 }
 
 export function getMockedOifQuoteResponse(overrides?: EscrowOverrides): GetQuoteResponse {
@@ -98,6 +100,7 @@ export function getMockedOifQuoteResponse(overrides?: EscrowOverrides): GetQuote
                                     token: overrides?.token ?? OIF_ADDRESSES.TOKEN,
                                     amount: overrides?.amount ?? OIF_AMOUNTS.INPUT,
                                 },
+                                ...(overrides?.extraPermitted ?? []),
                             ],
                             spender: OIF_ADDRESSES.SPENDER,
                             nonce: "123",
@@ -171,6 +174,8 @@ export interface ResourceLockOverrides {
     amount?: string;
     /** Override sponsor address (20-byte address) */
     sponsor?: string;
+    /** Extra commitments smuggled beyond the verified inputs[0] */
+    extraCommitments?: Array<{ token: string; amount: string }>;
 }
 
 export function getMockedOifResourceLockQuoteResponse(
@@ -201,6 +206,7 @@ export function getMockedOifResourceLockQuoteResponse(
                                     token: overrides?.token ?? OIF_ADDRESSES.TOKEN,
                                     amount: overrides?.amount ?? OIF_AMOUNTS.INPUT,
                                 },
+                                ...(overrides?.extraCommitments ?? []),
                             ],
                         },
                         types: {
@@ -305,6 +311,8 @@ export interface UserOpenOverrides {
     allowanceSpender?: string;
     /** Override allowances.required (drain more tokens) */
     allowanceRequired?: string;
+    /** Extra allowances smuggled beyond the verified inputs[0] */
+    extraAllowances?: Array<{ token: string; user: string; spender: string; required: string }>;
 }
 
 export function getMockedOifUserOpenQuoteResponse(overrides?: UserOpenOverrides): GetQuoteResponse {
@@ -330,6 +338,7 @@ export function getMockedOifUserOpenQuoteResponse(overrides?: UserOpenOverrides)
                                 spender: allowanceSpender,
                                 required: overrides?.allowanceRequired ?? OIF_AMOUNTS.INPUT,
                             },
+                            ...(overrides?.extraAllowances ?? []),
                         ],
                     },
                 },

--- a/packages/cross-chain/test/providers/OifProvider.spec.ts
+++ b/packages/cross-chain/test/providers/OifProvider.spec.ts
@@ -9,9 +9,13 @@ import {
     OifProvider,
     ProviderExecuteFailure,
     ProviderGetQuoteFailure,
+    UnverifiedOrderEntries,
 } from "../../src/external.js";
 import { OIF_ADDRESSES } from "../mocks/fixtures.js";
 import {
+    AMOUNTS,
+    ATTACKER_ADDRESSES,
+    ATTACKER_INTEROP_ADDRESSES,
     getMockedOifQuoteResponse,
     getMockedOifResourceLockQuoteResponse,
     getMockedOifUserOpenQuoteResponse,
@@ -172,6 +176,41 @@ describe("OifProvider", () => {
 
             await expect(provider.getQuotes(mockQuoteRequest)).rejects.toThrow(
                 ProviderGetQuoteFailure,
+            );
+        });
+
+        it("rejects an escrow quote that smuggles an extra permitted entry", async () => {
+            vi.mocked(httpRequest).mockResolvedValue({
+                status: 200,
+                data: getMockedOifQuoteResponse({
+                    extraPermitted: [{ token: ATTACKER_ADDRESSES.TOKEN, amount: AMOUNTS.STOLEN }],
+                }),
+                headers: new Headers(),
+            });
+
+            await expect(provider.getQuotes(mockQuoteRequest)).rejects.toThrow(
+                ProviderGetQuoteFailure,
+            );
+        });
+
+        it("rejects a user-open quote that smuggles an extra allowance entry", async () => {
+            vi.mocked(httpRequest).mockResolvedValue({
+                status: 200,
+                data: getMockedOifUserOpenQuoteResponse({
+                    extraAllowances: [
+                        {
+                            token: ATTACKER_INTEROP_ADDRESSES.TOKEN,
+                            user: ATTACKER_INTEROP_ADDRESSES.USER,
+                            spender: ATTACKER_INTEROP_ADDRESSES.TOKEN,
+                            required: AMOUNTS.STOLEN,
+                        },
+                    ],
+                }),
+                headers: new Headers(),
+            });
+
+            await expect(provider.getQuotes(mockQuoteRequest)).rejects.toThrow(
+                UnverifiedOrderEntries,
             );
         });
     });

--- a/packages/cross-chain/test/providers/OifProvider.spec.ts
+++ b/packages/cross-chain/test/providers/OifProvider.spec.ts
@@ -14,7 +14,6 @@ import {
 import { OIF_ADDRESSES } from "../mocks/fixtures.js";
 import {
     AMOUNTS,
-    ATTACKER_ADDRESSES,
     ATTACKER_INTEROP_ADDRESSES,
     getMockedOifQuoteResponse,
     getMockedOifResourceLockQuoteResponse,
@@ -179,17 +178,17 @@ describe("OifProvider", () => {
             );
         });
 
-        it("rejects an escrow quote that smuggles an extra permitted entry", async () => {
+        it("rejects an escrow quote that smuggles an extra permitted entry reusing the verified token", async () => {
             vi.mocked(httpRequest).mockResolvedValue({
                 status: 200,
                 data: getMockedOifQuoteResponse({
-                    extraPermitted: [{ token: ATTACKER_ADDRESSES.TOKEN, amount: AMOUNTS.STOLEN }],
+                    extraPermitted: [{ token: OIF_ADDRESSES.TOKEN, amount: "0" }],
                 }),
                 headers: new Headers(),
             });
 
             await expect(provider.getQuotes(mockQuoteRequest)).rejects.toThrow(
-                ProviderGetQuoteFailure,
+                UnverifiedOrderEntries,
             );
         });
 

--- a/packages/cross-chain/test/validators/oifPayloadValidator.spec.ts
+++ b/packages/cross-chain/test/validators/oifPayloadValidator.spec.ts
@@ -84,6 +84,18 @@ describe("validateOifPayload", () => {
 
             await expect(validateOifPayload(intent, corruptedOrder)).resolves.toBe(false);
         });
+
+        it("rejects when solver smuggles an extra permitted entry beyond inputs[0]", async () => {
+            const validResponse = getMockedOifQuoteResponse();
+            const intent = createIntentFromQuote(validResponse, "oif-escrow-v0");
+
+            const attackResponse = getMockedOifQuoteResponse({
+                extraPermitted: [{ token: ATTACKER_ADDRESSES.TOKEN, amount: AMOUNTS.STOLEN }],
+            });
+            const corruptedOrder = getOrder(attackResponse);
+
+            await expect(validateOifPayload(intent, corruptedOrder)).resolves.toBe(false);
+        });
     });
 
     // TODO (EFI-887): re-enable when resource-lock support lands.
@@ -126,6 +138,18 @@ describe("validateOifPayload", () => {
 
             const attackResponse = getMockedOifResourceLockQuoteResponse({
                 sponsor: ATTACKER_ADDRESSES.USER,
+            });
+            const corruptedOrder = getOrder(attackResponse);
+
+            await expect(validateOifPayload(intent, corruptedOrder)).resolves.toBe(false);
+        });
+
+        it("rejects when solver smuggles an extra commitment entry beyond inputs[0]", async () => {
+            const validResponse = getMockedOifResourceLockQuoteResponse();
+            const intent = createIntentFromQuote(validResponse, "oif-resource-lock-v0");
+
+            const attackResponse = getMockedOifResourceLockQuoteResponse({
+                extraCommitments: [{ token: ATTACKER_ADDRESSES.TOKEN, amount: AMOUNTS.STOLEN }],
             });
             const corruptedOrder = getOrder(attackResponse);
 
@@ -231,6 +255,25 @@ describe("validateOifPayload", () => {
 
             const attackResponse = getMockedOifUserOpenQuoteResponse({
                 allowanceRequired: AMOUNTS.STOLEN,
+            });
+            const corruptedOrder = getOrder(attackResponse);
+
+            await expect(validateOifPayload(intent, corruptedOrder)).resolves.toBe(false);
+        });
+
+        it("rejects when solver smuggles an extra allowance entry beyond inputs[0]", async () => {
+            const validResponse = getMockedOifUserOpenQuoteResponse();
+            const intent = createIntentFromQuote(validResponse, "oif-user-open-v0");
+
+            const attackResponse = getMockedOifUserOpenQuoteResponse({
+                extraAllowances: [
+                    {
+                        token: ATTACKER_INTEROP_ADDRESSES.TOKEN,
+                        user: ATTACKER_INTEROP_ADDRESSES.USER,
+                        spender: ATTACKER_INTEROP_ADDRESSES.TOKEN,
+                        required: AMOUNTS.STOLEN,
+                    },
+                ],
             });
             const corruptedOrder = getOrder(attackResponse);
 


### PR DESCRIPTION
## What

OIF order validation only cross-checked the **first** array entry (`inputs[0]`), so a solver could smuggle extra entries beyond `[0]` that were never verified against the user's intent — extra Permit2 permits, user-open allowances, or resource-lock commitments (audit v1.2 #21 / EFI-982).

## Changes

- **OIF payload validators** (escrow / resource-lock / user-open) now reject any order whose solver-controlled array (`permitted[]` / `commitments[]` / `allowances[]`) carries more than the single supported entry.
- **`oif-user-open-v0` order adapter** — the runtime path, also used by the LI.FI Intents provider — rejects multi-allowance orders, throwing the new `UnverifiedOrderEntries` error (surfaces as `ProviderGetQuoteFailure`, so the quote is dropped before the user signs/approves anything).
- Tests for each order type, both at the validator level and end-to-end through `OifProvider.getQuotes()`.

## Follow-up

A follow-up task has been created to enable **multiple tokens (multi-input intents) for OIF**. Until that lands, multi-entry orders are rejected rather than validated per entry.
