### PR TITLE
fix(cross-chain): fail closed on relay exact-output without quoted input amount

### DIFF
--- a/.changeset/relay-exact-output-cap.md
+++ b/.changeset/relay-exact-output-cap.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Relay exact-output quotes now fail closed when the response omits the quoted input amount (`details.currencyIn.amount`). Previously the EIP-712 max-spend cap could be left undefined and skipped during signature envelope validation.

--- a/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/relay/adapters/quoteResponseAdapter.ts
@@ -79,15 +79,23 @@ export function adaptQuote(
     // On exact-output the user input amount is empty, so bind the envelope cap to the
     // quoted input. On exact-input keep the user's signed amount; overriding it with
     // solver data would weaken the max-spend check.
+    const validationInputAmount =
+        params.swapType === "exact-output"
+            ? (currencyIn?.amount ?? params.input.amount)
+            : params.input.amount;
+
+    // Fail closed: without an input amount the signature validators compute an
+    // undefined max-spend cap and skip the check, so an exact-output quote that omits
+    // the quoted input would bypass envelope tamper protection.
+    if (params.swapType === "exact-output" && validationInputAmount === undefined) {
+        throw new ProviderGetQuoteFailure(
+            "Relay exact-output response omits details.currencyIn.amount required to bound the signature envelope",
+        );
+    }
+
     const paramsForValidation: QuoteRequest = {
         ...params,
-        input: {
-            ...params.input,
-            amount:
-                params.swapType === "exact-output"
-                    ? (currencyIn?.amount ?? params.input.amount)
-                    : params.input.amount,
-        },
+        input: { ...params.input, amount: validationInputAmount },
     };
 
     return {

--- a/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/relay/adapters/quoteResponseAdapter.spec.ts
@@ -514,6 +514,25 @@ describe("adaptQuote — envelope max-spend binding", () => {
         });
         expect(() => adaptQuote(params, response, PROVIDER_ID)).not.toThrow();
     });
+
+    it("throws on exact-output when the quote omits the input amount", () => {
+        const base = makeRelayQuoteResponse();
+        const response = {
+            ...base,
+            details: { ...base.details!, currencyIn: undefined },
+        } as RelayQuoteResponse;
+        const params = makeQuoteRequest({
+            swapType: "exact-output",
+            input: { chainId: ORIGIN_CHAIN_ID, assetAddress: VALID_ADDRESS },
+            output: {
+                chainId: DESTINATION_CHAIN_ID,
+                assetAddress: VALID_ADDRESS,
+                amount: OUTPUT_AMOUNT,
+            },
+        });
+        // Without a quoted input amount the max-spend cap would be skipped, so fail closed.
+        expect(() => adaptQuote(params, response, PROVIDER_ID)).toThrow(ProviderGetQuoteFailure);
+    });
 });
 
 describe("adaptRelaySteps — signature steps", () => {


### PR DESCRIPTION
## Summary

Relay exact-output quotes now fail closed when the response omits the quoted input amount.

In `adaptQuote()`, exact-output requests carry no user input amount, so the envelope max-spend cap is taken from `details.currencyIn.amount`. When the solver omits `currencyIn`, that amount stayed `undefined`, `validateRelaySignatureEnvelope()` computed `maxAmount` as `undefined`, and the Permit2 / EIP-3009 validators skipped the cap check, weakening envelope tamper protection. Now it throws `ProviderGetQuoteFailure` instead of continuing without a cap.

Sibling of the exact-input fix in #361. Found by Qodo on the release PR #355.

Closes EFI-984
