### PR TITLE
docs: drop unsupported trust claim from cross-chain overview

### DIFF
--- a/apps/docs/src/pages/cross-chain/index.mdx
+++ b/apps/docs/src/pages/cross-chain/index.mdx
@@ -9,7 +9,7 @@ description: An open source toolkit for cross-chain value movement — aggregate
 
 Easy to use, open source and maximally configurable, the `cross-chain` package connects your application to multiple providers via a single integration.
 
-Simplify cross-chain payments and DeFi actions while comparing providers on price or speed to route each transfer the best way for your users.
+Simplify cross-chain payments and DeFi actions while comparing providers on price and speed to pick the best route for your users.
 
 Developed by Wonderland in collaboration with the [Ethereum Foundation](https://ethereum.foundation/), the `cross-chain` package builds on open standards like the [Open Intents Framework](https://openintents.xyz/) and [ERC-7683](https://eips.ethereum.org/EIPS/eip-7683), while also integrating other intent protocols in an open source client-side library.
 

--- a/apps/docs/src/pages/cross-chain/index.mdx
+++ b/apps/docs/src/pages/cross-chain/index.mdx
@@ -9,7 +9,7 @@ description: An open source toolkit for cross-chain value movement — aggregate
 
 Easy to use, open source and maximally configurable, the `cross-chain` package connects your application to multiple providers via a single integration.
 
-Simplify cross-chain payments and DeFi actions while comparing providers on price and speed to route each transfer the best way for your users.
+Simplify cross-chain payments and DeFi actions while comparing providers on price or speed to route each transfer the best way for your users.
 
 Developed by Wonderland in collaboration with the [Ethereum Foundation](https://ethereum.foundation/), the `cross-chain` package builds on open standards like the [Open Intents Framework](https://openintents.xyz/) and [ERC-7683](https://eips.ethereum.org/EIPS/eip-7683), while also integrating other intent protocols in an open source client-side library.
 

--- a/apps/docs/src/pages/cross-chain/index.mdx
+++ b/apps/docs/src/pages/cross-chain/index.mdx
@@ -9,7 +9,7 @@ description: An open source toolkit for cross-chain value movement — aggregate
 
 Easy to use, open source and maximally configurable, the `cross-chain` package connects your application to multiple providers via a single integration.
 
-Simplify cross-chain payments and DeFi actions while comparing providers to find the best balance of price, latency and trust for your users.
+Simplify cross-chain payments and DeFi actions while comparing providers on price and speed to route each transfer the best way for your users.
 
 Developed by Wonderland in collaboration with the [Ethereum Foundation](https://ethereum.foundation/), the `cross-chain` package builds on open standards like the [Open Intents Framework](https://openintents.xyz/) and [ERC-7683](https://eips.ethereum.org/EIPS/eip-7683), while also integrating other intent protocols in an open source client-side library.
 


### PR DESCRIPTION
The cross-chain overview subhead claimed providers are compared on "the best balance of price, latency and trust." The SDK sorts quotes on a single axis (`bestOutput` or `lowerEta`) and has no trust dimension, so that oversold what the code does. Reworded to price and speed.

Closes EFI-987