### PR TITLE
fix(benchmark): replace native title tooltip with hover info icon on table headers

### DIFF
--- a/apps/benchmark/app/components/BenchmarkTable.tsx
+++ b/apps/benchmark/app/components/BenchmarkTable.tsx
@@ -32,11 +32,7 @@ export function BenchmarkTable<T>({
           <tr className='border-b border-border-subtle font-mono text-caption uppercase tracking-widest text-text-muted'>
             {columns.map((column) => (
               <th key={column.key} className={cn('px-3 py-3 font-medium md:px-4', column.className)}>
-                {column.tooltip ? (
-                  <InfoTooltip id={`col-tooltip-${column.key}`} label={column.label} text={column.tooltip} />
-                ) : (
-                  column.label
-                )}
+                {column.tooltip ? <InfoTooltip label={column.label} text={column.tooltip} /> : column.label}
               </th>
             ))}
           </tr>

--- a/apps/benchmark/app/components/BenchmarkTable.tsx
+++ b/apps/benchmark/app/components/BenchmarkTable.tsx
@@ -1,4 +1,5 @@
 import { Fragment, type ReactNode } from 'react';
+import { InfoTooltip } from './InfoTooltip';
 import { cn } from '~/lib/cn';
 
 export interface BenchmarkColumn {
@@ -32,9 +33,7 @@ export function BenchmarkTable<T>({
             {columns.map((column) => (
               <th key={column.key} className={cn('px-3 py-3 font-medium md:px-4', column.className)}>
                 {column.tooltip ? (
-                  <span title={column.tooltip} className='cursor-help underline decoration-dotted underline-offset-4'>
-                    {column.label}
-                  </span>
+                  <InfoTooltip id={`col-tooltip-${column.key}`} label={column.label} text={column.tooltip} />
                 ) : (
                   column.label
                 )}

--- a/apps/benchmark/app/components/InfoTooltip.tsx
+++ b/apps/benchmark/app/components/InfoTooltip.tsx
@@ -23,7 +23,9 @@ export function InfoTooltip({ label, text }: InfoTooltipProps) {
   const id = useId();
 
   // The tooltip lives outside the button so the button's accessible name stays
-  // the label alone; it's still announced as the button's description via the id.
+  // the label alone. It's aria-hidden so screen readers skip it while browsing,
+  // yet aria-describedby still reads its text on focus: a node referenced
+  // directly by describedby contributes to the description even when hidden.
   return (
     <span className='group relative inline-flex'>
       <button type='button' aria-describedby={id} className='inline-flex cursor-default items-center gap-1'>
@@ -43,7 +45,7 @@ export function InfoTooltip({ label, text }: InfoTooltipProps) {
           <path d='M12 8h.01' />
         </svg>
       </button>
-      <span id={id} role='tooltip' className={TOOLTIP_CLASS}>
+      <span id={id} aria-hidden='true' className={TOOLTIP_CLASS}>
         {text}
       </span>
     </span>

--- a/apps/benchmark/app/components/InfoTooltip.tsx
+++ b/apps/benchmark/app/components/InfoTooltip.tsx
@@ -13,33 +13,33 @@ const TOOLTIP_CLASS =
   'pointer-events-none absolute right-0 top-full z-20 mt-2 w-max max-w-[15rem] whitespace-normal border ' +
   'border-border bg-surface-elevated px-2.5 py-1.5 text-left font-sans text-mark normal-case leading-snug ' +
   'tracking-normal text-text-secondary opacity-0 shadow-lg transition-opacity duration-150 ' +
-  'group-hover:opacity-100 group-focus-visible:opacity-100';
+  'group-hover:opacity-100 group-focus-within:opacity-100';
 
 export function InfoTooltip({ label, text, id }: InfoTooltipProps) {
+  // The tooltip lives outside the button so the button's accessible name stays
+  // the label alone; it's still announced as the button's description via the id.
   return (
-    <button
-      type='button'
-      aria-describedby={id}
-      className='group relative inline-flex cursor-default items-center gap-1'
-    >
-      {label}
-      <svg
-        viewBox='0 0 24 24'
-        fill='none'
-        stroke='currentColor'
-        strokeWidth={2}
-        strokeLinecap='round'
-        strokeLinejoin='round'
-        aria-hidden='true'
-        className='size-3 shrink-0 text-text-muted transition-colors group-hover:text-text-secondary'
-      >
-        <circle cx='12' cy='12' r='10' />
-        <path d='M12 16v-4' />
-        <path d='M12 8h.01' />
-      </svg>
+    <span className='group relative inline-flex'>
+      <button type='button' aria-describedby={id} className='inline-flex cursor-default items-center gap-1'>
+        {label}
+        <svg
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth={2}
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          aria-hidden='true'
+          className='size-3 shrink-0 text-text-muted transition-colors group-hover:text-text-secondary'
+        >
+          <circle cx='12' cy='12' r='10' />
+          <path d='M12 16v-4' />
+          <path d='M12 8h.01' />
+        </svg>
+      </button>
       <span id={id} role='tooltip' className={TOOLTIP_CLASS}>
         {text}
       </span>
-    </button>
+    </span>
   );
 }

--- a/apps/benchmark/app/components/InfoTooltip.tsx
+++ b/apps/benchmark/app/components/InfoTooltip.tsx
@@ -1,10 +1,12 @@
+'use client';
+
+import { useId } from 'react';
+
 interface InfoTooltipProps {
   /** Visible column label. */
   label: string;
   /** Plain-language explanation shown on hover or focus. */
   text: string;
-  /** Unique id linking the trigger to its tooltip for screen readers. */
-  id: string;
 }
 
 // Anchored to the right edge and dropped below the header so it stays inside the
@@ -15,7 +17,11 @@ const TOOLTIP_CLASS =
   'tracking-normal text-text-secondary opacity-0 shadow-lg transition-opacity duration-150 ' +
   'group-hover:opacity-100 group-focus-within:opacity-100';
 
-export function InfoTooltip({ label, text, id }: InfoTooltipProps) {
+export function InfoTooltip({ label, text }: InfoTooltipProps) {
+  // useId keeps the trigger/tooltip association unique even when several tables
+  // render the same column keys on one page.
+  const id = useId();
+
   // The tooltip lives outside the button so the button's accessible name stays
   // the label alone; it's still announced as the button's description via the id.
   return (

--- a/apps/benchmark/app/components/InfoTooltip.tsx
+++ b/apps/benchmark/app/components/InfoTooltip.tsx
@@ -1,0 +1,45 @@
+interface InfoTooltipProps {
+  /** Visible column label. */
+  label: string;
+  /** Plain-language explanation shown on hover or focus. */
+  text: string;
+  /** Unique id linking the trigger to its tooltip for screen readers. */
+  id: string;
+}
+
+// Anchored to the right edge and dropped below the header so it stays inside the
+// table's overflow container instead of getting clipped above the first row.
+const TOOLTIP_CLASS =
+  'pointer-events-none absolute right-0 top-full z-20 mt-2 w-max max-w-[15rem] whitespace-normal border ' +
+  'border-border bg-surface-elevated px-2.5 py-1.5 text-left font-sans text-mark normal-case leading-snug ' +
+  'tracking-normal text-text-secondary opacity-0 shadow-lg transition-opacity duration-150 ' +
+  'group-hover:opacity-100 group-focus-visible:opacity-100';
+
+export function InfoTooltip({ label, text, id }: InfoTooltipProps) {
+  return (
+    <button
+      type='button'
+      aria-describedby={id}
+      className='group relative inline-flex cursor-default items-center gap-1'
+    >
+      {label}
+      <svg
+        viewBox='0 0 24 24'
+        fill='none'
+        stroke='currentColor'
+        strokeWidth={2}
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        aria-hidden='true'
+        className='size-3 shrink-0 text-text-muted transition-colors group-hover:text-text-secondary'
+      >
+        <circle cx='12' cy='12' r='10' />
+        <path d='M12 16v-4' />
+        <path d='M12 8h.01' />
+      </svg>
+      <span id={id} role='tooltip' className={TOOLTIP_CLASS}>
+        {text}
+      </span>
+    </button>
+  );
+}


### PR DESCRIPTION
The P50/P99 leaderboard column headers used the native HTML `title` attribute for their explanation, paired with `cursor: help` and a dotted underline. The native tooltip is slow to appear, unstyled, and gives no keyboard or touch affordance.

This swaps it for a styled CSS hover/focus tooltip:
- normal cursor, no dotted underline
- a small info (i) icon next to the label
- hovering or focusing the label or the icon shows the tooltip

The new `InfoTooltip` trigger is a `<button>` so it's keyboard-focusable and linked to the tooltip via `aria-describedby`. The tooltip drops below the header and anchors to the right edge, so it stays inside the table's overflow container instead of getting clipped above the first row.

Closes EFI-988