### PR TITLE
fix(cross-chain): bind Bungee approval checks to user intent (EFI-989)

### DIFF
--- a/.changeset/bungee-bind-approval-checks.md
+++ b/.changeset/bungee-bind-approval-checks.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Bind Bungee approval checks to the quote request and route
+
+Bungee allowance checks were built from the solver's `approvalData`, copying `spenderAddress`, `tokenAddress` and `userAddress` straight into `order.checks.allowances`, which the SDK later turns into `approve()` transactions. A tampered response could set the spender to any address and have the user approve an attacker contract. The allowance spender is now taken from the route (canonical Permit2 for sign routes, the transaction target for tx and manual routes), and the token and owner come from the quote request instead of `approvalData`. Native input assets no longer produce an allowance. `adaptManualRouteQuote` now requires the `QuoteRequest`.

--- a/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/bungee/adapters/quoteResponseAdapter.ts
@@ -1,3 +1,6 @@
+import type { Address } from "viem";
+import { getAddress } from "viem";
+
 import type { OrderChecks } from "../../../core/schemas/order.js";
 import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
 import type { Quote, Step } from "../../../internal.js";
@@ -10,6 +13,8 @@ import type {
     BungeeQuoteResult,
     BungeeTxData,
 } from "../schemas.js";
+import { PERMIT2_ADDRESS } from "../../../core/constants/eip712.js";
+import { isNativeAddress } from "../../../core/utils/token.js";
 import { BungeeTxDataSchema } from "../schemas.js";
 import { validateBungeeSignatureEnvelope } from "../validators/signatureEnvelopeValidator.js";
 import { adaptFees } from "./quoteFeeAdapter.js";
@@ -50,6 +55,7 @@ export function adaptQuotes(
  * @param manualRoute - The manual route entry from `result.manualRoutes`.
  * @param buildTx - The build-tx result for this route's `quoteId`.
  * @param providerId - The provider identifier to stamp on the quote.
+ * @param params - The original SDK quote request, used to bind approvals to user intent.
  * @returns An SDK Quote with a TransactionStep, or `null` if the txData is invalid.
  */
 export function adaptManualRouteQuote(
@@ -57,6 +63,7 @@ export function adaptManualRouteQuote(
     manualRoute: BungeeManualRoute,
     buildTx: BungeeBuildTxResult,
     providerId: string,
+    params: QuoteRequest,
 ): Quote | null {
     const result = response.result;
     const bridgeName = manualRoute.routeDetails?.name ?? "bridge";
@@ -69,6 +76,8 @@ export function adaptManualRouteQuote(
         buildTx.approvalData ?? manualRoute.approvalData,
         buildTx.txData.chainId,
         result.input.amount,
+        params,
+        buildTx.txData.to ? getAddress(buildTx.txData.to) : undefined,
     );
 
     const fees = adaptFees(manualRoute);
@@ -146,6 +155,8 @@ function adaptAutoRouteQuote(
         autoRoute.approvalData,
         params.input.chainId,
         result.input.amount,
+        params,
+        resolveAllowanceSpender(autoRoute),
     );
 
     return {
@@ -257,26 +268,35 @@ function buildTransactionStep(txData: BungeeTxData, description: string): Step |
 
 // ── Allowance helpers ──────────────────────────────────
 
+// Verified approve spender: canonical Permit2 for sign routes, the tx target for tx routes.
+function resolveAllowanceSpender(autoRoute: BungeeAutoRoute): Address | undefined {
+    if (autoRoute.userOp === "sign") return PERMIT2_ADDRESS;
+    if (autoRoute.userOp === "tx" && autoRoute.txData?.to) return getAddress(autoRoute.txData.to);
+    return undefined;
+}
+
 /**
- * Extract allowance checks from Bungee approval data.
- *
- * Uses `inputAmount` instead of `approvalData.amount` — Bungee returns a post-fee
- * approval amount that causes TRANSFER_FROM_FAILED errors on-chain.
+ * Build the allowance from verified intent and the route's spender, never from the
+ * solver-supplied `approvalData` fields (which only signal that an approval is needed).
+ * Uses `inputAmount` because Bungee's post-fee `approvalData.amount` reverts with
+ * TRANSFER_FROM_FAILED on-chain.
  */
 function extractAllowances(
     approvalData: BungeeApprovalData | null | undefined,
     chainId: number,
     inputAmount: string,
+    params: QuoteRequest,
+    spender: Address | undefined,
 ): NonNullable<OrderChecks["allowances"]> {
-    if (!approvalData) return [];
+    if (!approvalData || spender === undefined) return [];
+    if (isNativeAddress(params.input.assetAddress, "eip155")) return [];
 
-    const { spenderAddress, tokenAddress, userAddress } = approvalData;
     return [
         {
             chainId,
-            tokenAddress,
-            owner: userAddress,
-            spender: spenderAddress,
+            tokenAddress: getAddress(params.input.assetAddress),
+            owner: getAddress(params.user),
+            spender,
             required: inputAmount,
         },
     ];

--- a/packages/cross-chain/src/protocols/bungee/provider.ts
+++ b/packages/cross-chain/src/protocols/bungee/provider.ts
@@ -243,7 +243,7 @@ export class BungeeProvider extends CrossChainProvider {
                 return autoQuotes;
             }
 
-            const manualQuotes = await this.buildManualRouteQuotes(response);
+            const manualQuotes = await this.buildManualRouteQuotes(response, params);
             return [...autoQuotes, ...manualQuotes];
         } catch (error) {
             if (error instanceof ProviderGetQuoteFailure) {
@@ -264,7 +264,10 @@ export class BungeeProvider extends CrossChainProvider {
      * and individual failures (one bridge failing to build) do not abort the others —
      * the caller still gets the auto routes and any manual routes that succeeded.
      */
-    private async buildManualRouteQuotes(response: BungeeQuoteResponse): Promise<Quote[]> {
+    private async buildManualRouteQuotes(
+        response: BungeeQuoteResponse,
+        params: QuoteRequest,
+    ): Promise<Quote[]> {
         const manualRoutes = response.result.manualRoutes ?? [];
         if (manualRoutes.length === 0) return [];
 
@@ -297,6 +300,7 @@ export class BungeeProvider extends CrossChainProvider {
                     result.value.route,
                     result.value.buildTx,
                     this.providerId,
+                    params,
                 ),
             )
             .filter((quote): quote is Quote => quote !== null);

--- a/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
@@ -1,3 +1,4 @@
+import { getAddress } from "viem";
 import { describe, expect, it } from "vitest";
 
 import type { QuoteRequest } from "../../../../src/core/schemas/quoteRequest.js";
@@ -17,6 +18,7 @@ const VALID_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
 const RECIPIENT_ADDRESS = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
 const SPENDER_ADDRESS = "0x3a23F943181408EAC424116Af7b7790c94Cb97a5";
 const BUNGEE_GATEWAY = "0xCDeA28EE7bd5bf7710b294d9391E1B6A318D809a";
+const ATTACKER_ADDRESS = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 const PROVIDER_ID = "bungee";
 const ORIGIN_CHAIN_ID = 1;
 const DESTINATION_CHAIN_ID = 10;
@@ -419,7 +421,7 @@ describe("adaptQuotes", () => {
         const allowances = quote!.order.checks?.allowances;
         expect(allowances).toHaveLength(1);
         expect(allowances![0]!.required).toBe("1000000");
-        expect(allowances![0]!.spender).toBe("0x2222222222222222222222222222222222222222");
+        expect(allowances![0]!.spender).toBe(PERMIT2_ADDRESS);
     });
 
     it("sets tracking orderId from requestHash", () => {
@@ -483,6 +485,68 @@ describe("adaptQuotes", () => {
 
         expect(quotes).toHaveLength(0);
     });
+
+    it("pins the sign-route allowance spender to Permit2, ignoring solver spenderAddress", () => {
+        const response = buildBungeeQuoteResponse();
+        response.result.autoRoute = buildAutoRoute({
+            approvalData: {
+                spenderAddress: ATTACKER_ADDRESS,
+                amount: "950000",
+                tokenAddress: ATTACKER_ADDRESS,
+                userAddress: VALID_ADDRESS,
+            },
+        });
+
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
+        const allowance = quote!.order.checks!.allowances![0]!;
+
+        expect(allowance.spender).toBe(PERMIT2_ADDRESS);
+        expect(allowance.tokenAddress).toBe(getAddress(VALID_ADDRESS));
+        expect(allowance.owner).toBe(getAddress(VALID_ADDRESS));
+    });
+
+    it("binds the tx-route allowance spender to txData.to, ignoring solver spenderAddress", () => {
+        const response = buildBungeeQuoteResponse();
+        response.result.autoRoute = buildAutoRoute({
+            userOp: "tx",
+            signTypedData: null,
+            txData: { to: VALID_ADDRESS, data: "0xdeadbeef", value: "0", chainId: 1 },
+            approvalData: {
+                spenderAddress: ATTACKER_ADDRESS,
+                amount: "950000",
+                tokenAddress: ATTACKER_ADDRESS,
+                userAddress: ATTACKER_ADDRESS,
+            },
+        });
+
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, makeQuoteRequest());
+        const allowance = quote!.order.checks!.allowances![0]!;
+
+        expect(allowance.spender).toBe(getAddress(VALID_ADDRESS));
+        expect(allowance.tokenAddress).toBe(getAddress(VALID_ADDRESS));
+        expect(allowance.owner).toBe(getAddress(VALID_ADDRESS));
+    });
+
+    it("omits the allowance when the input asset is native", () => {
+        const response = buildBungeeQuoteResponse();
+        response.result.autoRoute = buildAutoRoute({
+            userOp: "tx",
+            signTypedData: null,
+            txData: { to: VALID_ADDRESS, data: "0xdeadbeef", value: "0", chainId: 1 },
+        });
+        const params = makeQuoteRequest({
+            input: {
+                chainId: ORIGIN_CHAIN_ID,
+                assetAddress: "0x0000000000000000000000000000000000000000",
+                amount: INPUT_AMOUNT,
+            },
+        });
+
+        const [quote] = adaptQuotes(response as never, PROVIDER_ID, params);
+
+        expect(quote!.order.steps[0]!.kind).toBe("transaction");
+        expect(quote!.order.checks).toBeUndefined();
+    });
 });
 
 describe("adaptManualRouteQuote", () => {
@@ -492,6 +556,7 @@ describe("adaptManualRouteQuote", () => {
             buildManualRoute(),
             buildBuildTxResult(),
             PROVIDER_ID,
+            makeQuoteRequest(),
         );
 
         expect(quote).not.toBeNull();
@@ -507,6 +572,7 @@ describe("adaptManualRouteQuote", () => {
                 txData: { data: "0xdeadbeef", value: "0", chainId: 1 }, // missing `to`
             }),
             PROVIDER_ID,
+            makeQuoteRequest(),
         );
 
         expect(quote).toBeNull();
@@ -518,6 +584,7 @@ describe("adaptManualRouteQuote", () => {
             buildManualRoute({ routeDetails: { name: "Stargate", logoURI: "" } }),
             buildBuildTxResult(),
             PROVIDER_ID,
+            makeQuoteRequest(),
         );
 
         const step = quote!.order.steps[0]!;
@@ -530,6 +597,7 @@ describe("adaptManualRouteQuote", () => {
             buildManualRoute(),
             buildBuildTxResult(),
             PROVIDER_ID,
+            makeQuoteRequest(),
         );
 
         const allowances = quote!.order.checks?.allowances;
@@ -549,6 +617,7 @@ describe("adaptManualRouteQuote", () => {
             buildManualRoute(),
             buildTx,
             PROVIDER_ID,
+            makeQuoteRequest(),
         );
 
         const allowances = quote!.order.checks?.allowances;
@@ -567,7 +636,13 @@ describe("adaptManualRouteQuote", () => {
         });
         const buildTx = buildBuildTxResult({ approvalData: undefined });
 
-        const quote = adaptManualRouteQuote(buildManualResponse(), route, buildTx, PROVIDER_ID);
+        const quote = adaptManualRouteQuote(
+            buildManualResponse(),
+            route,
+            buildTx,
+            PROVIDER_ID,
+            makeQuoteRequest(),
+        );
 
         expect(quote!.order.checks?.allowances).toHaveLength(1);
     });
@@ -576,7 +651,13 @@ describe("adaptManualRouteQuote", () => {
         const route = buildManualRoute({ approvalData: undefined });
         const buildTx = buildBuildTxResult({ approvalData: undefined });
 
-        const quote = adaptManualRouteQuote(buildManualResponse(), route, buildTx, PROVIDER_ID);
+        const quote = adaptManualRouteQuote(
+            buildManualResponse(),
+            route,
+            buildTx,
+            PROVIDER_ID,
+            makeQuoteRequest(),
+        );
 
         expect(quote!.order.checks).toBeUndefined();
     });
@@ -587,6 +668,7 @@ describe("adaptManualRouteQuote", () => {
             buildManualRoute(),
             buildBuildTxResult(),
             PROVIDER_ID,
+            makeQuoteRequest(),
         );
 
         expect(quote!.tracking).toBeUndefined();
@@ -598,6 +680,7 @@ describe("adaptManualRouteQuote", () => {
             buildManualRoute(),
             buildBuildTxResult(),
             PROVIDER_ID,
+            makeQuoteRequest(),
         );
 
         expect(quote!.quoteId).toBe("manual-1");
@@ -613,10 +696,36 @@ describe("adaptManualRouteQuote", () => {
             buildManualRoute(),
             buildBuildTxResult(),
             PROVIDER_ID,
+            makeQuoteRequest(),
         );
 
         expect(quote!.metadata?.bungeeManualRoute).toBeDefined();
         expect(quote!.metadata?.bungeeBuildTx).toBeDefined();
         expect(quote!.metadata?.bungeeResponse).toBeDefined();
+    });
+
+    it("binds the allowance spender to txData.to, ignoring solver spenderAddress", () => {
+        const buildTx = buildBuildTxResult({
+            txData: { to: VALID_ADDRESS, data: "0xdeadbeef", value: "0", chainId: 1 },
+            approvalData: {
+                spenderAddress: ATTACKER_ADDRESS,
+                amount: "1000000",
+                tokenAddress: ATTACKER_ADDRESS,
+                userAddress: ATTACKER_ADDRESS,
+            },
+        });
+
+        const quote = adaptManualRouteQuote(
+            buildManualResponse(),
+            buildManualRoute(),
+            buildTx,
+            PROVIDER_ID,
+            makeQuoteRequest(),
+        );
+        const allowance = quote!.order.checks!.allowances![0]!;
+
+        expect(allowance.spender).toBe(getAddress(VALID_ADDRESS));
+        expect(allowance.tokenAddress).toBe(getAddress(VALID_ADDRESS));
+        expect(allowance.owner).toBe(getAddress(VALID_ADDRESS));
     });
 });

--- a/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/bungee/adapters/quoteResponseAdapter.spec.ts
@@ -628,10 +628,10 @@ describe("adaptManualRouteQuote", () => {
     it("falls back to manualRoute.approvalData when buildTx.approvalData is absent", () => {
         const route = buildManualRoute({
             approvalData: {
-                spenderAddress: SPENDER_ADDRESS,
+                spenderAddress: ATTACKER_ADDRESS,
                 amount: "1000000",
-                tokenAddress: VALID_ADDRESS,
-                userAddress: VALID_ADDRESS,
+                tokenAddress: ATTACKER_ADDRESS,
+                userAddress: ATTACKER_ADDRESS,
             },
         });
         const buildTx = buildBuildTxResult({ approvalData: undefined });
@@ -643,8 +643,12 @@ describe("adaptManualRouteQuote", () => {
             PROVIDER_ID,
             makeQuoteRequest(),
         );
+        const allowance = quote!.order.checks!.allowances![0]!;
 
         expect(quote!.order.checks?.allowances).toHaveLength(1);
+        expect(allowance.spender).toBe(getAddress(SPENDER_ADDRESS));
+        expect(allowance.tokenAddress).toBe(getAddress(VALID_ADDRESS));
+        expect(allowance.owner).toBe(getAddress(VALID_ADDRESS));
     });
 
     it("omits allowances when no approval is needed", () => {


### PR DESCRIPTION
# 🤖 Linear

Closes EFI-989

## Description

The Bungee quote adapter built its `approve()` checks straight from the solver's `approvalData`. It copied `spenderAddress`, `tokenAddress` and `userAddress` into `order.checks.allowances`, and `DefaultApprovalService` turns those into real `approve()` transactions. A tampered or compromised response could set the spender to any address and have the user approve an attacker contract.

This binds the allowance to the quote request and the route instead of trusting the solver:

- The spender comes from the route: canonical Permit2 for sign routes, the transaction target (`txData.to`) for tx and manual routes.
- `tokenAddress` and `owner` come from the quote request (`input.assetAddress` and `user`), not from `approvalData`.
- A native input asset no longer produces an allowance.
- `approvalData` is now only a signal that an approval is needed.

Changes:

- `quoteResponseAdapter.ts`: rewrite `extractAllowances` to take the request and a verified spender, and add `resolveAllowanceSpender`. `adaptManualRouteQuote` now takes the request.
- `provider.ts`: thread the request through `buildManualRouteQuotes` into the manual-route path.
- Tests: cover spender pinning for sign and tx routes, token and owner binding, native input, and the manual route.

## Checklist before requesting a review

- [ ] I have conducted a self-review of my code.
- [ ] I have conducted a QA.
- [ ] If it is a core feature, I have included comprehensive tests.