### PR TITLE
fix(cross-chain): validate allowance checks before approving (EFI-990)

### DIFF
--- a/.changeset/bind-allowance-checks-to-quote-intent.md
+++ b/.changeset/bind-allowance-checks-to-quote-intent.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Validate quote-supplied allowance checks against the quote's own intent before approving
+
+The approval service built `approve(spender, amount)` from the `owner`, `spender`, and `tokenAddress` carried in a quote, so a forged quote could make the connected wallet approve an arbitrary spender on an arbitrary token — and `preferInfinite` raised the granted amount to `maxUint256`. A new `ApprovalValidator` now keeps only the checks that match the quote: the token and owner must match a previewed input, the spender must be canonical Permit2 or the `to` of one of the quote's own transaction steps, and the required amount cannot exceed the input (`preferInfinite` is honoured only for Permit2). Dropped checks are reported through the validation failure handler and never produce an approval step.

--- a/apps/docs/src/pages/cross-chain/advanced-usage.mdx
+++ b/apps/docs/src/pages/cross-chain/advanced-usage.mdx
@@ -165,6 +165,8 @@ The service is best-effort. Allowance reads run through `MulticallAllowanceReade
 
 Pass a `failureHandler` to observe batch failures. Defaults to `console.warn`; pass `{ handle: () => {} }` to silence, or your own implementation to route failures into telemetry.
 
+Before any read, each quote-supplied allowance check is validated against the quote's own intent: the token and owner must match a previewed input, the spender must be canonical Permit2 or the `to` of one of the quote's own steps, and the required amount cannot exceed the input. Checks that fail are dropped (never producing an `approve`) and reported through `validationFailureHandler` — same shape and default as `failureHandler`. A handler that throws is isolated and never aborts enrichment.
+
 ### Provider coverage
 
 The approval service can only enrich a quote whose provider declares its allowance requirements in `order.checks.allowances`. Coverage across shipped providers:

--- a/apps/docs/src/pages/cross-chain/api.mdx
+++ b/apps/docs/src/pages/cross-chain/api.mdx
@@ -306,13 +306,14 @@ Best-effort: on any read failure the affected quotes pass through unmodified. Qu
 
 ### CreateApprovalServiceConfig
 
-| Field              | Type                          | Required | Description                                                                                                            |
-| ------------------ | ----------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `rpcUrls`          | `Record<number, string>`      | No       | RPC URLs per chain ID. Used to build public clients for `allowance()` multicalls when `publicClient` is not supplied.  |
-| `publicClient`     | `PublicClient` (viem)         | No       | Pre-configured viem public client. Takes precedence over `rpcUrls`.                                                    |
-| `amountStrategy`   | `ApprovalAmountStrategy`      | No       | Strategy that decides the `amount` encoded in each `approve` call. Defaults to `ExactAmountStrategy`.                  |
-| `approvalGasLimit` | `bigint`                      | No       | Custom gas limit forwarded to every generated approval transaction. When omitted, the wallet or relayer estimates gas. |
-| `failureHandler`   | `AllowanceReadFailureHandler` | No       | Handler for full-batch allowance read failures. Defaults to `console.warn`; pass `{ handle: () => {} }` to silence.    |
+| Field                      | Type                               | Required | Description                                                                                                                                                                                                              |
+| -------------------------- | ---------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `rpcUrls`                  | `Record<number, string>`           | No       | RPC URLs per chain ID. Used to build public clients for `allowance()` multicalls when `publicClient` is not supplied.                                                                                                    |
+| `publicClient`             | `PublicClient` (viem)              | No       | Pre-configured viem public client. Takes precedence over `rpcUrls`.                                                                                                                                                      |
+| `amountStrategy`           | `ApprovalAmountStrategy`           | No       | Strategy that decides the `amount` encoded in each `approve` call. Defaults to `ExactAmountStrategy`.                                                                                                                    |
+| `approvalGasLimit`         | `bigint`                           | No       | Custom gas limit forwarded to every generated approval transaction. When omitted, the wallet or relayer estimates gas.                                                                                                   |
+| `failureHandler`           | `AllowanceReadFailureHandler`      | No       | Handler for full-batch allowance read failures. Defaults to `console.warn`; pass `{ handle: () => {} }` to silence.                                                                                                      |
+| `validationFailureHandler` | `ApprovalValidationFailureHandler` | No       | Handler for allowance checks dropped because they don't match the quote's own intent (forged spender, foreign token, amount above the quoted input). Defaults to `console.warn`; pass `{ handle: () => {} }` to silence. |
 
 ### Amount Strategies
 

--- a/packages/cross-chain/src/core/interfaces/approval.interface.ts
+++ b/packages/cross-chain/src/core/interfaces/approval.interface.ts
@@ -67,6 +67,38 @@ export interface ApprovalService {
     enrichQuotes(quotes: ExecutableQuote[]): Promise<ExecutableQuote[]>;
 }
 
+// ── Allowance validation ─────────────────────────────────
+
+/** Why a quote-supplied allowance check was rejected before becoming an `approve`. */
+export enum ApprovalValidationFailureReason {
+    NativeAsset = "native-asset",
+    ChainMismatch = "chain-mismatch",
+    TokenMismatch = "token-mismatch",
+    OwnerMismatch = "owner-mismatch",
+    UntrustedSpender = "untrusted-spender",
+    AmountExceedsInput = "amount-exceeds-input",
+}
+
+/** A rejected allowance check together with the reason it failed validation. */
+export interface ApprovalValidationViolation {
+    check: AllowanceCheck;
+    reason: ApprovalValidationFailureReason;
+}
+
+/** Receives allowance checks dropped because they don't match the quote's own intent. */
+export interface ApprovalValidationFailureHandler {
+    handle(violation: ApprovalValidationViolation): void;
+}
+
+/**
+ * Returns only the allowance checks that match a quote's own intent, so an
+ * `approve` can never target a spender or token the quote's own steps and inputs
+ * don't already use.
+ */
+export interface ApprovalValidator {
+    validate(quote: ExecutableQuote): AllowanceCheck[];
+}
+
 // ── Utilities ────────────────────────────────────────────
 
 /** Builds a composite key that uniquely identifies an allowance slot. */

--- a/packages/cross-chain/src/core/services/approval/DefaultApprovalService.ts
+++ b/packages/cross-chain/src/core/services/approval/DefaultApprovalService.ts
@@ -8,15 +8,21 @@ import type {
     AllowanceReader,
     ApprovalAmountStrategy,
     ApprovalService,
+    ApprovalValidator,
 } from "../../interfaces/approval.interface.js";
 import type { TransactionStep } from "../../schemas/order.js";
 import type { ExecutableQuote } from "../../schemas/quote.js";
 import { allowanceKey, toAllowanceEntry } from "../../interfaces/approval.interface.js";
+import { defaultApprovalValidator } from "./DefaultApprovalValidator.js";
 
 /**
  * Reads on-chain ERC-20 allowances for every quote and prepends approval
  * `TransactionStep`s into `order.steps` when the current allowance is
  * insufficient.
+ *
+ * Only allowance checks that bind to the quote's own intent reach the wallet:
+ * an `approve` can never target a spender or token the quote's own steps and
+ * inputs don't already use.
  *
  * Never throws -- on any failure the affected quotes pass through unmodified.
  */
@@ -24,13 +30,14 @@ export class DefaultApprovalService implements ApprovalService {
     constructor(
         private readonly reader: AllowanceReader,
         private readonly amountStrategy: ApprovalAmountStrategy,
+        private readonly validator: ApprovalValidator = defaultApprovalValidator,
         private readonly gasLimit?: bigint,
     ) {}
 
     async enrichQuotes(quotes: ExecutableQuote[]): Promise<ExecutableQuote[]> {
         const pairs = quotes.map((quote) => ({
             quote,
-            checks: quote.order.checks?.allowances ?? [],
+            checks: this.validator.validate(quote),
         }));
         const allChecks = pairs.flatMap((p) => p.checks);
         if (allChecks.length === 0) return quotes;

--- a/packages/cross-chain/src/core/services/approval/DefaultApprovalValidator.ts
+++ b/packages/cross-chain/src/core/services/approval/DefaultApprovalValidator.ts
@@ -1,0 +1,137 @@
+import type { Address } from "viem";
+import { isAddress, isAddressEqual } from "viem";
+
+import type {
+    AllowanceCheck,
+    ApprovalValidationFailureHandler,
+    ApprovalValidator,
+} from "../../interfaces/approval.interface.js";
+import type { Step } from "../../schemas/order.js";
+import type { ExecutableQuote, QuotePreviewEntry } from "../../schemas/quote.js";
+import { PERMIT2_ADDRESS } from "../../constants/eip712.js";
+import { ApprovalValidationFailureReason } from "../../interfaces/approval.interface.js";
+import { isNativeAddress } from "../../utils/token.js";
+import { defaultApprovalValidationFailureHandler } from "./validationFailureHandler.js";
+
+/** Trusted spender addresses keyed by chain id, derived from a quote's own steps. */
+type TrustedSpenders = ReadonlyMap<number, ReadonlySet<Address>>;
+
+/**
+ * Default {@link ApprovalValidator}: returns an allowance check only when it
+ * matches the quote's own intent, so an `approve` can never target a spender or
+ * token the quote's own steps and inputs don't already use.
+ *
+ * A check survives when its `(chainId, tokenAddress, owner)` matches a previewed
+ * input, its `spender` is canonical Permit2 or the `to` of one of the quote's own
+ * transaction steps, and its `required` amount does not exceed that input.
+ * `preferInfinite` is honoured only for Permit2. Rejected checks are reported via
+ * the failure handler and never produce an approval step. Never throws.
+ */
+export class DefaultApprovalValidator implements ApprovalValidator {
+    constructor(
+        private readonly onViolation: ApprovalValidationFailureHandler = defaultApprovalValidationFailureHandler,
+    ) {}
+
+    validate(quote: ExecutableQuote): AllowanceCheck[] {
+        const checks = quote.order.checks?.allowances ?? [];
+        if (checks.length === 0) return [];
+
+        const inputs = quote.preview.inputs;
+        const trustedSpenders = collectTrustedSpenders(quote.order.steps);
+
+        const valid: AllowanceCheck[] = [];
+        for (const check of checks) {
+            const reason = validationFailure(check, inputs, trustedSpenders);
+            if (reason !== undefined) {
+                try {
+                    this.onViolation.handle({ check, reason });
+                } catch {}
+                continue;
+            }
+            valid.push(normalizePreferInfinite(check));
+        }
+        return valid;
+    }
+}
+
+/** Default validator wired with the `console.warn` failure handler. */
+export const defaultApprovalValidator: ApprovalValidator = new DefaultApprovalValidator();
+
+function validationFailure(
+    check: AllowanceCheck,
+    inputs: readonly QuotePreviewEntry[],
+    trustedSpenders: TrustedSpenders,
+): ApprovalValidationFailureReason | undefined {
+    if (isNativeAddress(check.tokenAddress, "eip155")) {
+        return ApprovalValidationFailureReason.NativeAsset;
+    }
+
+    const input = inputs.find(
+        (entry) =>
+            entry.chainId === check.chainId && sameAddress(entry.assetAddress, check.tokenAddress),
+    );
+    if (input === undefined) {
+        return inputs.some((entry) => entry.chainId === check.chainId)
+            ? ApprovalValidationFailureReason.TokenMismatch
+            : ApprovalValidationFailureReason.ChainMismatch;
+    }
+
+    if (!sameAddress(input.accountAddress, check.owner)) {
+        return ApprovalValidationFailureReason.OwnerMismatch;
+    }
+
+    if (!isTrustedSpender(check, trustedSpenders)) {
+        return ApprovalValidationFailureReason.UntrustedSpender;
+    }
+
+    const required = parseAmount(check.required);
+    const available = parseAmount(input.amount);
+    if (required === null || available === null || required > available) {
+        return ApprovalValidationFailureReason.AmountExceedsInput;
+    }
+
+    return undefined;
+}
+
+function collectTrustedSpenders(steps: readonly Step[]): TrustedSpenders {
+    const byChain = new Map<number, Set<Address>>();
+    for (const step of steps) {
+        if (step.kind !== "transaction" || step.category === "approval") continue;
+        const { to } = step.transaction;
+        if (!isAddress(to, { strict: false })) continue;
+        const spenders = byChain.get(step.chainId) ?? new Set<Address>();
+        spenders.add(to);
+        byChain.set(step.chainId, spenders);
+    }
+    return byChain;
+}
+
+function isTrustedSpender(check: AllowanceCheck, trustedSpenders: TrustedSpenders): boolean {
+    if (sameAddress(check.spender, PERMIT2_ADDRESS)) return true;
+    const spenders = trustedSpenders.get(check.chainId);
+    if (spenders === undefined) return false;
+    for (const spender of spenders) {
+        if (sameAddress(spender, check.spender)) return true;
+    }
+    return false;
+}
+
+function normalizePreferInfinite(check: AllowanceCheck): AllowanceCheck {
+    if (!check.preferInfinite || sameAddress(check.spender, PERMIT2_ADDRESS)) return check;
+    return { ...check, preferInfinite: false };
+}
+
+function parseAmount(value: string): bigint | null {
+    try {
+        return BigInt(value);
+    } catch {
+        return null;
+    }
+}
+
+/** Checksum-safe equality that treats anything that isn't a valid address as unequal. */
+function sameAddress(a: string, b: string): boolean {
+    return (
+        isAddress(a, { strict: false }) && isAddress(b, { strict: false }) && isAddressEqual(a, b)
+    );
+}

--- a/packages/cross-chain/src/core/services/approval/index.ts
+++ b/packages/cross-chain/src/core/services/approval/index.ts
@@ -1,3 +1,5 @@
+export * from "./validationFailureHandler.js";
+export * from "./DefaultApprovalValidator.js";
 export * from "./DefaultApprovalService.js";
 export * from "./ExactAmountStrategy.js";
 export * from "./InfiniteAmountStrategy.js";

--- a/packages/cross-chain/src/core/services/approval/validationFailureHandler.ts
+++ b/packages/cross-chain/src/core/services/approval/validationFailureHandler.ts
@@ -1,0 +1,12 @@
+import type { ApprovalValidationFailureHandler } from "../../interfaces/approval.interface.js";
+
+/** Default handler: logs dropped allowance checks through `console.warn`. */
+export const defaultApprovalValidationFailureHandler: ApprovalValidationFailureHandler = {
+    handle({ check, reason }) {
+        console.warn(
+            `[ApprovalValidation] Dropped untrusted allowance check (${reason}): ` +
+                `chain=${check.chainId} token=${check.tokenAddress} ` +
+                `owner=${check.owner} spender=${check.spender}`,
+        );
+    },
+};

--- a/packages/cross-chain/src/external.ts
+++ b/packages/cross-chain/src/external.ts
@@ -31,6 +31,12 @@ export {
     createApprovalService,
     ExactAmountStrategy,
     InfiniteAmountStrategy,
+    DefaultApprovalValidator,
+    ApprovalValidationFailureReason,
+    defaultApprovalValidationFailureHandler,
+    type ApprovalValidator,
+    type ApprovalValidationFailureHandler,
+    type ApprovalValidationViolation,
     // Tracking
     createOrderTracker,
     OrderTracker,

--- a/packages/cross-chain/src/factories/approvalServiceFactory.ts
+++ b/packages/cross-chain/src/factories/approvalServiceFactory.ts
@@ -4,9 +4,11 @@ import type {
     AllowanceReadFailureHandler,
     ApprovalAmountStrategy,
     ApprovalService,
+    ApprovalValidationFailureHandler,
 } from "../internal.js";
 import {
     DefaultApprovalService,
+    DefaultApprovalValidator,
     ExactAmountStrategy,
     MulticallAllowanceReader,
     PublicClientManager,
@@ -35,11 +37,19 @@ export interface CreateApprovalServiceConfig {
      * custom telemetry, or a no-op handler to silence them.
      */
     failureHandler?: AllowanceReadFailureHandler;
+    /**
+     * Handler invoked when a quote-supplied allowance check is dropped because
+     * it doesn't match the quote's own intent (forged spender, foreign token,
+     * etc.). Defaults to {@link defaultApprovalValidationFailureHandler} (logs
+     * through `console.warn`). Provide your own to route these into telemetry.
+     */
+    validationFailureHandler?: ApprovalValidationFailureHandler;
 }
 
 export function createApprovalService(config?: CreateApprovalServiceConfig): ApprovalService {
     const clientManager = new PublicClientManager(config?.publicClient, config?.rpcUrls);
     const reader = new MulticallAllowanceReader(clientManager, config?.failureHandler);
     const strategy = config?.amountStrategy ?? new ExactAmountStrategy();
-    return new DefaultApprovalService(reader, strategy, config?.approvalGasLimit);
+    const validator = new DefaultApprovalValidator(config?.validationFailureHandler);
+    return new DefaultApprovalService(reader, strategy, validator, config?.approvalGasLimit);
 }

--- a/packages/cross-chain/test/services/approval/DefaultApprovalService.spec.ts
+++ b/packages/cross-chain/test/services/approval/DefaultApprovalService.spec.ts
@@ -9,8 +9,13 @@ import type {
 } from "../../../src/core/interfaces/approval.interface.js";
 import type { ExecutableQuote } from "../../../src/core/schemas/quote.js";
 import type { PublicClientManager } from "../../../src/core/utils/publicClientManager.js";
+import { PERMIT2_ADDRESS } from "../../../src/core/constants/eip712.js";
 import { allowanceKey } from "../../../src/core/interfaces/approval.interface.js";
 import { DefaultApprovalService } from "../../../src/core/services/approval/DefaultApprovalService.js";
+import {
+    DefaultApprovalValidator,
+    defaultApprovalValidator,
+} from "../../../src/core/services/approval/DefaultApprovalValidator.js";
 import { ExactAmountStrategy } from "../../../src/core/services/approval/ExactAmountStrategy.js";
 import { InfiniteAmountStrategy } from "../../../src/core/services/approval/InfiniteAmountStrategy.js";
 import { MulticallAllowanceReader } from "../../../src/core/services/approval/MulticallAllowanceReader.js";
@@ -18,6 +23,7 @@ import { MulticallAllowanceReader } from "../../../src/core/services/approval/Mu
 const TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as Address;
 const OWNER = "0x0000000000000000000000000000000000000001" as Address;
 const SPENDER = "0x0000000000000000000000000000000000000002" as Address;
+const ATTACKER = "0x000000000000000000000000000000000000dEaD" as Address;
 const CHAIN_ID = 1;
 
 function makeQuote(
@@ -153,7 +159,12 @@ describe("DefaultApprovalService", () => {
 
     it("forwards gas limit to the approval step when configured", async () => {
         const reader = mockReader(new Map([[testKey, 0n]]));
-        const service = new DefaultApprovalService(reader, new ExactAmountStrategy(), 100_000n);
+        const service = new DefaultApprovalService(
+            reader,
+            new ExactAmountStrategy(),
+            defaultApprovalValidator,
+            100_000n,
+        );
         const quote = makeQuote({
             allowances: [
                 {
@@ -238,7 +249,42 @@ describe("DefaultApprovalService", () => {
         expect(result).toEqual([quote]);
     });
 
-    it("approves maxUint256 for preferInfinite entries regardless of strategy", async () => {
+    it("approves maxUint256 for preferInfinite entries when the spender is canonical Permit2", async () => {
+        const permit2Key = allowanceKey({
+            chainId: CHAIN_ID,
+            tokenAddress: TOKEN,
+            owner: OWNER,
+            spender: PERMIT2_ADDRESS,
+        });
+        const reader = mockReader(new Map([[permit2Key, 0n]]));
+        const service = new DefaultApprovalService(reader, new ExactAmountStrategy());
+        const quote = makeQuote({
+            allowances: [
+                {
+                    chainId: CHAIN_ID,
+                    tokenAddress: TOKEN,
+                    owner: OWNER,
+                    spender: PERMIT2_ADDRESS,
+                    required: "1000",
+                    preferInfinite: true,
+                },
+            ],
+        });
+
+        const [enriched] = await service.enrichQuotes([quote]);
+
+        const step = enriched!.order.steps[0]!;
+        if (step.kind !== "transaction") throw new Error("expected transaction step");
+        expect(step.transaction.data).toBe(
+            encodeFunctionData({
+                abi: erc20Abi,
+                functionName: "approve",
+                args: [PERMIT2_ADDRESS, maxUint256],
+            }),
+        );
+    });
+
+    it("caps preferInfinite to the strategy amount when the spender is not Permit2", async () => {
         const reader = mockReader(new Map([[testKey, 0n]]));
         const service = new DefaultApprovalService(reader, new ExactAmountStrategy());
         const quote = makeQuote({
@@ -262,9 +308,56 @@ describe("DefaultApprovalService", () => {
             encodeFunctionData({
                 abi: erc20Abi,
                 functionName: "approve",
-                args: [SPENDER, maxUint256],
+                args: [SPENDER, 1000n],
             }),
         );
+    });
+
+    it("drops a forged allowance whose spender is neither Permit2 nor a step target", async () => {
+        const reader = mockReader(new Map());
+        const service = new DefaultApprovalService(reader, new ExactAmountStrategy());
+        const quote = makeQuote({
+            allowances: [
+                {
+                    chainId: CHAIN_ID,
+                    tokenAddress: TOKEN,
+                    owner: OWNER,
+                    spender: ATTACKER,
+                    required: "1000",
+                    preferInfinite: true,
+                },
+            ],
+        });
+
+        const [enriched] = await service.enrichQuotes([quote]);
+
+        expect(enriched!.order.steps).toHaveLength(1);
+        expect(reader.readAllowances).not.toHaveBeenCalled();
+    });
+
+    it("reports a dropped forged check to the binding failure handler", async () => {
+        const handler = { handle: vi.fn() };
+        const reader = mockReader(new Map());
+        const service = new DefaultApprovalService(
+            reader,
+            new ExactAmountStrategy(),
+            new DefaultApprovalValidator(handler),
+        );
+        const quote = makeQuote({
+            allowances: [
+                {
+                    chainId: CHAIN_ID,
+                    tokenAddress: TOKEN,
+                    owner: OWNER,
+                    spender: ATTACKER,
+                    required: "1000",
+                },
+            ],
+        });
+
+        await service.enrichQuotes([quote]);
+
+        expect(handler.handle).toHaveBeenCalledTimes(1);
     });
 
     // Guards against a chain allowlist regression: the real reader and
@@ -370,7 +463,7 @@ describe("DefaultApprovalService", () => {
                     tokenAddress: TOKEN,
                     owner: OWNER,
                     spender: SPENDER,
-                    required: "2000",
+                    required: "1000",
                 },
             ],
         });

--- a/packages/cross-chain/test/services/approval/DefaultApprovalValidator.spec.ts
+++ b/packages/cross-chain/test/services/approval/DefaultApprovalValidator.spec.ts
@@ -1,0 +1,247 @@
+import type { Address } from "viem";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+    AllowanceCheck,
+    ApprovalValidationFailureHandler,
+    ApprovalValidationViolation,
+} from "../../../src/core/interfaces/approval.interface.js";
+import type { ExecutableQuote } from "../../../src/core/schemas/quote.js";
+import { PERMIT2_ADDRESS } from "../../../src/core/constants/eip712.js";
+import { ApprovalValidationFailureReason } from "../../../src/core/interfaces/approval.interface.js";
+import { DefaultApprovalValidator } from "../../../src/core/services/approval/DefaultApprovalValidator.js";
+
+function spyHandler(): {
+    handle: ReturnType<typeof vi.fn<(violation: ApprovalValidationViolation) => void>>;
+} {
+    return { handle: vi.fn<(violation: ApprovalValidationViolation) => void>() };
+}
+
+function validate(
+    quote: ExecutableQuote,
+    handler?: ApprovalValidationFailureHandler,
+): AllowanceCheck[] {
+    return new DefaultApprovalValidator(handler).validate(quote);
+}
+
+const USER = "0x1111111111111111111111111111111111111111" as Address;
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as Address;
+const USDT = "0xdAC17F958D2ee523a2206206994597C13D831ec7" as Address;
+const ROUTER = "0x2222222222222222222222222222222222222222" as Address;
+const ATTACKER = "0x000000000000000000000000000000000000dEaD" as Address;
+const NATIVE = "0x0000000000000000000000000000000000000000" as Address;
+const CHAIN_ID = 1;
+
+function makeQuote(opts: {
+    allowances: AllowanceCheck[];
+    steps?: ExecutableQuote["order"]["steps"];
+    input?: { chainId: number; assetAddress: string; amount: string };
+}): ExecutableQuote {
+    const input = opts.input ?? { chainId: CHAIN_ID, assetAddress: USDC, amount: "1000" };
+    return {
+        order: {
+            steps: opts.steps ?? [
+                { kind: "transaction", chainId: CHAIN_ID, transaction: { to: ROUTER, data: "0x" } },
+            ],
+            checks: { allowances: opts.allowances },
+        },
+        preview: {
+            inputs: [{ ...input, accountAddress: USER }],
+            outputs: [{ chainId: 42161, accountAddress: USER, assetAddress: USDT, amount: "990" }],
+        },
+        provider: "test",
+        _providerId: "test",
+    };
+}
+
+function check(overrides: Partial<AllowanceCheck> = {}): AllowanceCheck {
+    return {
+        chainId: CHAIN_ID,
+        tokenAddress: USDC,
+        owner: USER,
+        spender: ROUTER,
+        required: "1000",
+        ...overrides,
+    };
+}
+
+describe("DefaultApprovalValidator", () => {
+    it("returns an empty array when the quote has no allowance checks", () => {
+        const quote = makeQuote({ allowances: [] });
+
+        expect(validate(quote)).toEqual([]);
+    });
+
+    it("keeps a check whose spender is a transaction step target", () => {
+        const quote = makeQuote({ allowances: [check({ spender: ROUTER })] });
+
+        const valid = validate(quote);
+
+        expect(valid).toHaveLength(1);
+        expect(valid[0]!.spender).toBe(ROUTER);
+    });
+
+    it("keeps a check whose spender is canonical Permit2 even without a matching step", () => {
+        const quote = makeQuote({
+            allowances: [check({ spender: PERMIT2_ADDRESS })],
+            steps: [
+                {
+                    kind: "signature",
+                    chainId: CHAIN_ID,
+                    signaturePayload: {
+                        signatureType: "eip712",
+                        domain: {},
+                        primaryType: "PermitWitnessTransferFrom",
+                        types: { EIP712Domain: [] },
+                        message: {},
+                    },
+                },
+            ],
+        });
+
+        const valid = validate(quote);
+
+        expect(valid).toHaveLength(1);
+        expect(valid[0]!.spender).toBe(PERMIT2_ADDRESS);
+    });
+
+    it("matches the step target case-insensitively", () => {
+        const quote = makeQuote({
+            allowances: [check({ spender: ROUTER.toUpperCase().replace("0X", "0x") })],
+            steps: [
+                {
+                    kind: "transaction",
+                    chainId: CHAIN_ID,
+                    transaction: { to: ROUTER.toLowerCase(), data: "0x" },
+                },
+            ],
+        });
+
+        expect(validate(quote)).toHaveLength(1);
+    });
+
+    it("drops a check with an untrusted spender", () => {
+        const handler = spyHandler();
+        const quote = makeQuote({ allowances: [check({ spender: ATTACKER })] });
+
+        const valid = validate(quote, handler);
+
+        expect(valid).toEqual([]);
+        expect(handler.handle).toHaveBeenCalledTimes(1);
+        expect(handler.handle.mock.calls[0]![0].reason).toBe(
+            ApprovalValidationFailureReason.UntrustedSpender,
+        );
+    });
+
+    it("drops a check whose owner doesn't match the previewed input", () => {
+        const handler = spyHandler();
+        const quote = makeQuote({ allowances: [check({ owner: ATTACKER })] });
+
+        expect(validate(quote, handler)).toEqual([]);
+        expect(handler.handle.mock.calls[0]![0].reason).toBe(
+            ApprovalValidationFailureReason.OwnerMismatch,
+        );
+    });
+
+    it("drops a check whose token isn't the previewed input asset", () => {
+        const handler = spyHandler();
+        const quote = makeQuote({ allowances: [check({ tokenAddress: USDT })] });
+
+        expect(validate(quote, handler)).toEqual([]);
+        expect(handler.handle.mock.calls[0]![0].reason).toBe(
+            ApprovalValidationFailureReason.TokenMismatch,
+        );
+    });
+
+    it("drops a check on a chain with no previewed input", () => {
+        const handler = spyHandler();
+        const quote = makeQuote({ allowances: [check({ chainId: 10 })] });
+
+        expect(validate(quote, handler)).toEqual([]);
+        expect(handler.handle.mock.calls[0]![0].reason).toBe(
+            ApprovalValidationFailureReason.ChainMismatch,
+        );
+    });
+
+    it("drops a check for a native token", () => {
+        const handler = spyHandler();
+        const quote = makeQuote({
+            input: { chainId: CHAIN_ID, assetAddress: NATIVE, amount: "1000" },
+            allowances: [check({ tokenAddress: NATIVE })],
+        });
+
+        expect(validate(quote, handler)).toEqual([]);
+        expect(handler.handle.mock.calls[0]![0].reason).toBe(
+            ApprovalValidationFailureReason.NativeAsset,
+        );
+    });
+
+    it("drops a check whose required exceeds the input amount", () => {
+        const handler = spyHandler();
+        const quote = makeQuote({ allowances: [check({ required: "5000" })] });
+
+        expect(validate(quote, handler)).toEqual([]);
+        expect(handler.handle.mock.calls[0]![0].reason).toBe(
+            ApprovalValidationFailureReason.AmountExceedsInput,
+        );
+    });
+
+    it("drops a check whose required amount is not a parseable number", () => {
+        const handler = spyHandler();
+        const quote = makeQuote({ allowances: [check({ required: "not-a-number" })] });
+
+        expect(validate(quote, handler)).toEqual([]);
+        expect(handler.handle.mock.calls[0]![0].reason).toBe(
+            ApprovalValidationFailureReason.AmountExceedsInput,
+        );
+    });
+
+    it("keeps preferInfinite when the spender is canonical Permit2", () => {
+        const quote = makeQuote({
+            allowances: [check({ spender: PERMIT2_ADDRESS, preferInfinite: true })],
+        });
+
+        const [valid] = validate(quote);
+
+        expect(valid!.preferInfinite).toBe(true);
+    });
+
+    it("strips preferInfinite when the spender is not Permit2", () => {
+        const quote = makeQuote({
+            allowances: [check({ spender: ROUTER, preferInfinite: true })],
+        });
+
+        const [valid] = validate(quote);
+
+        expect(valid!.preferInfinite).toBe(false);
+    });
+
+    it("keeps only the valid checks when a quote mixes valid and forged entries", () => {
+        const handler = spyHandler();
+        const quote = makeQuote({
+            allowances: [check({ spender: ROUTER }), check({ spender: ATTACKER })],
+        });
+
+        const valid = validate(quote, handler);
+
+        expect(valid).toHaveLength(1);
+        expect(valid[0]!.spender).toBe(ROUTER);
+        expect(handler.handle).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps validating when the failure handler throws", () => {
+        const throwingHandler: ApprovalValidationFailureHandler = {
+            handle() {
+                throw new Error("telemetry down");
+            },
+        };
+        const quote = makeQuote({
+            allowances: [check({ spender: ATTACKER }), check({ spender: ROUTER })],
+        });
+
+        const valid = validate(quote, throwingHandler);
+
+        expect(valid).toHaveLength(1);
+        expect(valid[0]!.spender).toBe(ROUTER);
+    });
+});


### PR DESCRIPTION
# 🤖 Linear

Closes EFI-990

## Description

`DefaultApprovalService` turned every allowance check carried by a quote into an `approve(spender, amount)` from the connected wallet. The `owner`, `spender`, and `tokenAddress` came straight from the quote, so a forged quote could make the wallet approve any spender on any token, and `preferInfinite` pushed the amount to `maxUint256`. This is finding #30.

The service now runs each check through an `ApprovalValidator` before reading allowances. A check survives only when it matches the quote's own intent:

- the token and owner match a previewed input,
- the spender is canonical Permit2 or the `to` of one of the quote's own transaction steps,
- the required amount does not exceed that input,
- native assets are skipped, and `preferInfinite` is honoured only for Permit2.

Checks that fail are dropped, never produce an `approve`, and are reported through a failure handler. An amount that doesn't parse is treated as a failure instead of throwing.

### Changes

- New `ApprovalValidator` interface plus `ApprovalValidationFailureReason`, `ApprovalValidationViolation`, and `ApprovalValidationFailureHandler` in `approval.interface.ts`.
- `DefaultApprovalValidator` holds the rules as module-level functions and exposes the `defaultApprovalValidator` singleton. Address comparisons use viem `isAddressEqual` guarded by `isAddress`; trusted spenders are a `ReadonlyMap<number, ReadonlySet<Address>>`.
- `defaultApprovalValidationFailureHandler` (the `console.warn` default) lives in its own file.
- `DefaultApprovalService` receives the validator by constructor injection and calls `validate(quote)` instead of trusting the raw checks.
- `createApprovalService` builds the validator and exposes a `validationFailureHandler` option.
- Docs for the validation step and the new option in `advanced-usage.mdx` and `api.mdx`.
- Changeset (minor).

### Test plan

- [ ] `pnpm --filter @wonderland/interop-cross-chain test` (validator and service specs).
- [ ] `pnpm --filter @wonderland/interop-cross-chain check-types` and `lint`.
- [ ] A forged allowance (attacker spender, foreign token, `preferInfinite`) produces no `approve`.
- [ ] Real quotes from Across, Relay, Bungee, and LI.FI Intents keep their legitimate approvals.

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [x] If it is a core feature, I have included comprehensive tests.