### PR TITLE
fix(cross-chain): make OIF adaptQuote params non-optional

### DIFF
--- a/.changeset/oif-adaptquote-required-params.md
+++ b/.changeset/oif-adaptquote-required-params.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Require `QuoteRequest` when adapting OIF quotes
+
+`adaptQuote` now takes `params: QuoteRequest` as a required argument (it was optional). The EIP-712 envelope of escrow/3009 orders is cross-checked against the user's quote request to detect tampering by a compromised solver, so omitting `params` from the public API was a footgun. Callers are now forced at compile time to supply the user's intent, making the tamper-check impossible to skip. `OifProvider.getQuotes` already passes `params`, so runtime behaviour is unchanged.

--- a/packages/cross-chain/src/protocols/oif/adapters/quoteAdapter.ts
+++ b/packages/cross-chain/src/protocols/oif/adapters/quoteAdapter.ts
@@ -28,10 +28,10 @@ const ESCROW_ORDER_TYPE: OifEscrowOrder["type"] = "oif-escrow-v0";
  * - Adds Permit2 `checks.allowances` for `oif-escrow-v0` orders
  * - Preserves all other quote fields
  *
- * When `params` is supplied, the EIP-712 envelope is cross-checked against the
- * user-supplied quote request to detect tampering by a compromised solver.
+ * `params` (the user's quote request) is required: the EIP-712 envelope is
+ * cross-checked against it to detect tampering by a compromised solver.
  */
-export function adaptQuote(providerQuote: ProviderQuote, params?: QuoteRequest): Quote {
+export function adaptQuote(providerQuote: ProviderQuote, params: QuoteRequest): Quote {
     const order = withPermit2Allowances(
         adaptOifOrder(providerQuote.order as OifOrder, params),
         providerQuote,

--- a/packages/cross-chain/test/adapters/quoteAdapter.spec.ts
+++ b/packages/cross-chain/test/adapters/quoteAdapter.spec.ts
@@ -207,7 +207,7 @@ describe("quoteAdapter", () => {
                 },
             };
 
-            const result = adaptQuote(quote);
+            const result = adaptQuote(quote, mockParams());
 
             expect(result.order.checks).toBeUndefined();
         });


### PR DESCRIPTION
# 🤖 Linear

Closes EFI-985

## Description

`adaptQuote` in the OIF adapter took `params?: QuoteRequest` as an optional argument. Since the EIP-712 envelope wiring, adapting an escrow or 3009 order cross-checks the signed envelope against `params` to catch tampering by a compromised solver. With `params` optional, an external SDK caller could call `adaptQuote(quote)` and the type system would not stop them, so the tamper-check rested on a runtime guard alone.

This makes `params` required. The caller has to supply the user's intent at compile time, so the tamper-check can't be skipped from the public API. `OifProvider.getQuotes` already passes `params`, so runtime behaviour does not change.

The lower-level `adaptOifOrder` keeps `params` optional on purpose: the LI.FI intents adapter and the resource-lock / user-open order types call it without a `QuoteRequest`, and its `requireParams` guard still throws for escrow/3009 orders that arrive without one.

## Changes

- `packages/cross-chain/src/protocols/oif/adapters/quoteAdapter.ts`: `adaptQuote` now takes `params: QuoteRequest` (was optional), with the JSDoc updated to match.
- `packages/cross-chain/test/adapters/quoteAdapter.spec.ts`: the non-escrow test passes `mockParams()` so it compiles against the required signature.
- `.changeset/oif-adaptquote-required-params.md`: minor bump for the public API change.

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [ ] If it is a core feature, I have included comprehensive tests.