### PR TITLE
feat(benchmark): add head-to-head route store and interactive selector

### DIFF
--- a/apps/benchmark/app/components/Arrow.tsx
+++ b/apps/benchmark/app/components/Arrow.tsx
@@ -1,9 +1,10 @@
 interface ArrowProps {
   onSwap?: () => void;
   spinKey?: number;
+  ariaLabel?: string;
 }
 
-export function Arrow({ onSwap, spinKey = 0 }: ArrowProps) {
+export function Arrow({ onSwap, spinKey = 0, ariaLabel = 'swap from and to chains' }: ArrowProps) {
   if (!onSwap) {
     return (
       <span aria-hidden='true' className='cursor-default select-none font-sans text-xl leading-none text-text-muted'>
@@ -16,7 +17,7 @@ export function Arrow({ onSwap, spinKey = 0 }: ArrowProps) {
     <button
       type='button'
       onClick={onSwap}
-      aria-label='swap from and to chains'
+      aria-label={ariaLabel}
       className='cursor-pointer select-none font-sans text-xl leading-none text-text-muted transition-colors hover:text-text-primary active:scale-90'
     >
       <span key={spinKey} className='animate-spin-once inline-block'>

--- a/apps/benchmark/app/components/Dot.tsx
+++ b/apps/benchmark/app/components/Dot.tsx
@@ -2,10 +2,11 @@ import { cn } from '~/lib/cn';
 
 interface DotProps {
   className: string;
-  size?: 'sm' | 'md';
+  size?: 'xs' | 'sm' | 'md';
 }
 
 const SIZE_CLASS: Record<NonNullable<DotProps['size']>, string> = {
+  xs: 'size-1.5',
   sm: 'size-2',
   md: 'size-2.5',
 };

--- a/apps/benchmark/app/components/headtohead/Dot.tsx
+++ b/apps/benchmark/app/components/headtohead/Dot.tsx
@@ -1,0 +1,5 @@
+import { cn } from '~/lib/cn';
+
+export function Dot({ className }: { className: string }) {
+  return <span className={cn('inline-block size-1.5 rounded-full', className)} aria-hidden='true' />;
+}

--- a/apps/benchmark/app/components/headtohead/Dot.tsx
+++ b/apps/benchmark/app/components/headtohead/Dot.tsx
@@ -1,5 +1,0 @@
-import { cn } from '~/lib/cn';
-
-export function Dot({ className }: { className: string }) {
-  return <span className={cn('inline-block size-1.5 rounded-full', className)} aria-hidden='true' />;
-}

--- a/apps/benchmark/app/components/headtohead/InlinePicker.tsx
+++ b/apps/benchmark/app/components/headtohead/InlinePicker.tsx
@@ -74,6 +74,12 @@ export function InlinePicker<T extends string | number>({
       event.preventDefault();
       const previous = current <= 0 ? options.length - 1 : current - 1;
       optionRefs.current[previous]?.focus();
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      optionRefs.current[0]?.focus();
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      optionRefs.current[options.length - 1]?.focus();
     } else if (event.key === 'Escape') {
       event.preventDefault();
       closeAndReturnFocus();

--- a/apps/benchmark/app/components/headtohead/InlinePicker.tsx
+++ b/apps/benchmark/app/components/headtohead/InlinePicker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { Chevron } from '../Chevron';
 import { Dot } from '../Dot';
 import { cn } from '~/lib/cn';
 
@@ -17,6 +18,8 @@ interface InlinePickerProps<T extends string | number> {
   onChange: (value: T) => void;
   triggerDotClass: string;
   triggerLabel: string;
+  /** Extra classes for the trigger label, e.g. a fixed width to stop siblings shifting. */
+  triggerLabelClassName?: string;
 }
 
 /**
@@ -32,6 +35,7 @@ export function InlinePicker<T extends string | number>({
   onChange,
   triggerDotClass,
   triggerLabel,
+  triggerLabelClassName,
 }: InlinePickerProps<T>) {
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -108,10 +112,16 @@ export function InlinePicker<T extends string | number>({
         aria-haspopup='listbox'
         aria-expanded={open}
         aria-label={`${ariaLabel}: ${triggerLabel}`}
-        className='inline-flex cursor-pointer items-center gap-2 transition active:scale-95'
+        className={cn(
+          'inline-flex cursor-pointer items-center gap-2 border bg-surface px-2.5 py-1 transition active:scale-95',
+          open
+            ? 'border-accent text-text-primary'
+            : 'border-border text-text-secondary hover:border-accent hover:text-text-primary',
+        )}
       >
         <Dot size='xs' className={triggerDotClass} />
-        <span>{triggerLabel}</span>
+        <span className={triggerLabelClassName}>{triggerLabel}</span>
+        <Chevron />
       </button>
       {open ? (
         <ul

--- a/apps/benchmark/app/components/headtohead/InlinePicker.tsx
+++ b/apps/benchmark/app/components/headtohead/InlinePicker.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
-import { Dot } from './Dot';
+import { Dot } from '../Dot';
 import { cn } from '~/lib/cn';
 
 export interface InlinePickerOption<T> {
@@ -104,7 +104,7 @@ export function InlinePicker<T extends string | number>({
         aria-label={`${ariaLabel}: ${triggerLabel}`}
         className='inline-flex cursor-pointer items-center gap-2 transition active:scale-95'
       >
-        <Dot className={triggerDotClass} />
+        <Dot size='xs' className={triggerDotClass} />
         <span>{triggerLabel}</span>
       </button>
       {open ? (
@@ -131,7 +131,7 @@ export function InlinePicker<T extends string | number>({
                     : 'text-text-secondary hover:bg-surface hover:text-text-primary',
                 )}
               >
-                <Dot className={option.dotClass} />
+                <Dot size='xs' className={option.dotClass} />
                 <span>{option.label}</span>
               </button>
             </li>

--- a/apps/benchmark/app/components/headtohead/InlinePicker.tsx
+++ b/apps/benchmark/app/components/headtohead/InlinePicker.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { Dot } from './Dot';
+import { cn } from '~/lib/cn';
+
+export interface InlinePickerOption<T> {
+  value: T;
+  label: string;
+  dotClass: string;
+}
+
+interface InlinePickerProps<T extends string | number> {
+  ariaLabel: string;
+  value: T;
+  options: readonly InlinePickerOption<T>[];
+  onChange: (value: T) => void;
+  triggerDotClass: string;
+  triggerLabel: string;
+}
+
+/**
+ * Compact popover picker designed for the head-to-head route pill. Renders an
+ * inline trigger (dot + label) and a positioned listbox of options. Keyboard,
+ * focus, and click-outside handling mirror the larger `Dropdown` component
+ * used by the request bar.
+ */
+export function InlinePicker<T extends string | number>({
+  ariaLabel,
+  value,
+  options,
+  onChange,
+  triggerDotClass,
+  triggerLabel,
+}: InlinePickerProps<T>) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const selectedIndex = options.findIndex((option) => option.value === value);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleMouseDown = (event: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const target = selectedIndex >= 0 ? selectedIndex : 0;
+    optionRefs.current[target]?.focus();
+  }, [open, selectedIndex]);
+
+  const closeAndReturnFocus = () => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const handleSelect = (next: T) => {
+    onChange(next);
+    closeAndReturnFocus();
+  };
+
+  const handleListKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
+    const current = optionRefs.current.findIndex((node) => node === document.activeElement);
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const next = current < 0 ? 0 : Math.min(current + 1, options.length - 1);
+      optionRefs.current[next]?.focus();
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const previous = current <= 0 ? options.length - 1 : current - 1;
+      optionRefs.current[previous]?.focus();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      closeAndReturnFocus();
+    } else if (event.key === 'Tab') {
+      setOpen(false);
+    }
+  };
+
+  const handleTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      setOpen(true);
+    } else if (event.key === 'Escape' && open) {
+      event.preventDefault();
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div ref={wrapperRef} className='relative inline-flex'>
+      <button
+        ref={triggerRef}
+        type='button'
+        onClick={() => setOpen((current) => !current)}
+        onKeyDown={handleTriggerKeyDown}
+        aria-haspopup='listbox'
+        aria-expanded={open}
+        aria-label={`${ariaLabel}: ${triggerLabel}`}
+        className='inline-flex cursor-pointer items-center gap-2 transition active:scale-95'
+      >
+        <Dot className={triggerDotClass} />
+        <span>{triggerLabel}</span>
+      </button>
+      {open ? (
+        <ul
+          role='listbox'
+          aria-label={ariaLabel}
+          onKeyDown={handleListKeyDown}
+          className='animate-popover-enter absolute top-full left-0 z-20 mt-2 min-w-full origin-top border border-border bg-surface-elevated shadow-lg'
+        >
+          {options.map((option, index) => (
+            <li key={String(option.value)}>
+              <button
+                ref={(node) => {
+                  optionRefs.current[index] = node;
+                }}
+                type='button'
+                role='option'
+                aria-selected={option.value === value}
+                onClick={() => handleSelect(option.value)}
+                className={cn(
+                  'flex w-full cursor-pointer items-center gap-2 px-3 py-2 font-mono text-label transition active:bg-accent-soft/60',
+                  option.value === value
+                    ? 'bg-accent-soft text-accent'
+                    : 'text-text-secondary hover:bg-surface hover:text-text-primary',
+                )}
+              >
+                <Dot className={option.dotClass} />
+                <span>{option.label}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/benchmark/app/components/headtohead/RouteSelector.tsx
+++ b/apps/benchmark/app/components/headtohead/RouteSelector.tsx
@@ -41,7 +41,7 @@ export function RouteSelector() {
       <span className='font-mono text-label uppercase tracking-wider text-text-muted'>ROUTE</span>
       <div className='flex items-center gap-2 font-mono text-mark text-text-primary'>
         <InlinePicker
-          ariaLabel='asset'
+          ariaLabel='route asset'
           value={route.assetSymbol}
           options={assetOptions}
           onChange={setAssetSymbol}
@@ -50,7 +50,7 @@ export function RouteSelector() {
         />
         <span className='text-text-muted'>·</span>
         <InlinePicker
-          ariaLabel='from chain'
+          ariaLabel='route from chain'
           value={route.fromChainId}
           options={fromChainOptions}
           onChange={setFromChainId}
@@ -66,7 +66,7 @@ export function RouteSelector() {
           →
         </button>
         <InlinePicker
-          ariaLabel='to chain'
+          ariaLabel='route to chain'
           value={route.toChainId}
           options={toChainOptions}
           onChange={setToChainId}

--- a/apps/benchmark/app/components/headtohead/RouteSelector.tsx
+++ b/apps/benchmark/app/components/headtohead/RouteSelector.tsx
@@ -1,35 +1,208 @@
-import { CHAINS, type ChainId } from '~/lib/chains';
+'use client';
+
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { ASSET_SYMBOLS, ASSETS } from '~/lib/assets';
+import { CHAIN_IDS, CHAINS } from '~/lib/chains';
 import { cn } from '~/lib/cn';
+import { useHeadToHeadRouteStore } from '~/lib/headToHeadRouteStore';
 
-interface RouteSelectorProps {
-  fromChainId: ChainId;
-  toChainId: ChainId;
-  assetSymbol: string;
-  assetColorClass: string;
-}
+export function RouteSelector() {
+  const route = useHeadToHeadRouteStore((state) => state.route);
+  const setFromChainId = useHeadToHeadRouteStore((state) => state.setFromChainId);
+  const setToChainId = useHeadToHeadRouteStore((state) => state.setToChainId);
+  const setAssetSymbol = useHeadToHeadRouteStore((state) => state.setAssetSymbol);
+  const swapChains = useHeadToHeadRouteStore((state) => state.swapChains);
 
-/**
- * Static route summary pill rendered next to the section header. Matches the
- * shape of the Pencil design's `routeSel`; the caret is decorative — the
- * actual route still lives in the global request bar at the top of the page.
- */
-export function RouteSelector({ fromChainId, toChainId, assetSymbol, assetColorClass }: RouteSelectorProps) {
-  const from = CHAINS[fromChainId];
-  const to = CHAINS[toChainId];
+  const from = CHAINS[route.fromChainId];
+  const to = CHAINS[route.toChainId];
+  const asset = ASSETS[route.assetSymbol];
+
+  const assetOptions = ASSET_SYMBOLS.map((symbol) => ({
+    value: symbol,
+    label: ASSETS[symbol].displayName,
+    dotClass: ASSETS[symbol].colorClass,
+  }));
+  const fromChainOptions = CHAIN_IDS.filter((id) => id !== route.toChainId).map((id) => ({
+    value: id,
+    label: CHAINS[id].displayName,
+    dotClass: CHAINS[id].colorClass,
+  }));
+  const toChainOptions = CHAIN_IDS.filter((id) => id !== route.fromChainId).map((id) => ({
+    value: id,
+    label: CHAINS[id].displayName,
+    dotClass: CHAINS[id].colorClass,
+  }));
 
   return (
     <div className='flex items-center gap-3.5 border border-border bg-surface-elevated px-4 py-2.5'>
       <span className='font-mono text-label uppercase tracking-wider text-text-muted'>ROUTE</span>
       <div className='flex items-center gap-2 font-mono text-mark text-text-primary'>
-        <Dot className={assetColorClass} />
-        <span>{assetSymbol}</span>
+        <InlinePicker
+          ariaLabel='asset'
+          value={route.assetSymbol}
+          options={assetOptions}
+          onChange={setAssetSymbol}
+          triggerDotClass={asset.colorClass}
+          triggerLabel={asset.displayName}
+        />
         <span className='text-text-muted'>·</span>
-        <Dot className={from.colorClass} />
-        <span>{from.displayName}</span>
-        <span className='text-text-muted'>→</span>
-        <Dot className={to.colorClass} />
-        <span>{to.displayName}</span>
+        <InlinePicker
+          ariaLabel='from chain'
+          value={route.fromChainId}
+          options={fromChainOptions}
+          onChange={setFromChainId}
+          triggerDotClass={from.colorClass}
+          triggerLabel={from.displayName}
+        />
+        <button
+          type='button'
+          onClick={swapChains}
+          aria-label='swap chains'
+          className='cursor-pointer text-text-muted transition hover:text-text-primary active:scale-95'
+        >
+          →
+        </button>
+        <InlinePicker
+          ariaLabel='to chain'
+          value={route.toChainId}
+          options={toChainOptions}
+          onChange={setToChainId}
+          triggerDotClass={to.colorClass}
+          triggerLabel={to.displayName}
+        />
       </div>
+    </div>
+  );
+}
+
+interface InlinePickerOption<T> {
+  value: T;
+  label: string;
+  dotClass: string;
+}
+
+interface InlinePickerProps<T extends string | number> {
+  ariaLabel: string;
+  value: T;
+  options: readonly InlinePickerOption<T>[];
+  onChange: (value: T) => void;
+  triggerDotClass: string;
+  triggerLabel: string;
+}
+
+function InlinePicker<T extends string | number>({
+  ariaLabel,
+  value,
+  options,
+  onChange,
+  triggerDotClass,
+  triggerLabel,
+}: InlinePickerProps<T>) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const selectedIndex = options.findIndex((option) => option.value === value);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleMouseDown = (event: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const target = selectedIndex >= 0 ? selectedIndex : 0;
+    optionRefs.current[target]?.focus();
+  }, [open, selectedIndex]);
+
+  const closeAndReturnFocus = () => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const handleSelect = (next: T) => {
+    onChange(next);
+    closeAndReturnFocus();
+  };
+
+  const handleListKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
+    const current = optionRefs.current.findIndex((node) => node === document.activeElement);
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const next = current < 0 ? 0 : Math.min(current + 1, options.length - 1);
+      optionRefs.current[next]?.focus();
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const previous = current <= 0 ? options.length - 1 : current - 1;
+      optionRefs.current[previous]?.focus();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      closeAndReturnFocus();
+    } else if (event.key === 'Tab') {
+      setOpen(false);
+    }
+  };
+
+  const handleTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      setOpen(true);
+    } else if (event.key === 'Escape' && open) {
+      event.preventDefault();
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div ref={wrapperRef} className='relative inline-flex'>
+      <button
+        ref={triggerRef}
+        type='button'
+        onClick={() => setOpen((current) => !current)}
+        onKeyDown={handleTriggerKeyDown}
+        aria-haspopup='listbox'
+        aria-expanded={open}
+        aria-label={`${ariaLabel}: ${triggerLabel}`}
+        className='inline-flex cursor-pointer items-center gap-2 transition active:scale-95'
+      >
+        <Dot className={triggerDotClass} />
+        <span>{triggerLabel}</span>
+      </button>
+      {open ? (
+        <ul
+          role='listbox'
+          aria-label={ariaLabel}
+          onKeyDown={handleListKeyDown}
+          className='animate-popover-enter absolute top-full left-0 z-20 mt-2 min-w-full origin-top border border-border bg-surface-elevated shadow-lg'
+        >
+          {options.map((option, index) => (
+            <li key={String(option.value)}>
+              <button
+                ref={(node) => {
+                  optionRefs.current[index] = node;
+                }}
+                type='button'
+                role='option'
+                aria-selected={option.value === value}
+                onClick={() => handleSelect(option.value)}
+                className={cn(
+                  'flex w-full cursor-pointer items-center gap-2 px-3 py-2 font-mono text-label transition active:bg-accent-soft/60',
+                  option.value === value
+                    ? 'bg-accent-soft text-accent'
+                    : 'text-text-secondary hover:bg-surface hover:text-text-primary',
+                )}
+              >
+                <Dot className={option.dotClass} />
+                <span>{option.label}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
     </div>
   );
 }

--- a/apps/benchmark/app/components/headtohead/RouteSelector.tsx
+++ b/apps/benchmark/app/components/headtohead/RouteSelector.tsx
@@ -1,9 +1,16 @@
 'use client';
 
+import { useState } from 'react';
+import { Arrow } from '../Arrow';
 import { InlinePicker, type InlinePickerOption } from './InlinePicker';
 import { ASSET_SYMBOLS, ASSETS, type AssetSymbol } from '~/lib/assets';
 import { CHAIN_IDS, CHAINS, type ChainId } from '~/lib/chains';
 import { useHeadToHeadRouteStore } from '~/lib/headToHeadRouteStore';
+
+// Widest chain displayName is 8 characters (arbitrum/ethereum/optimism). A
+// fixed label width keeps both chain chips the same size, so the swap arrow
+// between them doesn't shift when e.g. `base` moves to the front.
+const CHAIN_LABEL_CLASS = 'min-w-[8ch] text-center';
 
 export function RouteSelector() {
   const route = useHeadToHeadRouteStore((state) => state.route);
@@ -11,6 +18,12 @@ export function RouteSelector() {
   const setToChainId = useHeadToHeadRouteStore((state) => state.setToChainId);
   const setAssetSymbol = useHeadToHeadRouteStore((state) => state.setAssetSymbol);
   const swapChains = useHeadToHeadRouteStore((state) => state.swapChains);
+  const [swapSpins, setSwapSpins] = useState(0);
+
+  const handleSwap = () => {
+    swapChains();
+    setSwapSpins((count) => count + 1);
+  };
 
   const from = CHAINS[route.fromChainId];
   const to = CHAINS[route.toChainId];
@@ -56,15 +69,9 @@ export function RouteSelector() {
           onChange={setFromChainId}
           triggerDotClass={from.colorClass}
           triggerLabel={from.displayName}
+          triggerLabelClassName={CHAIN_LABEL_CLASS}
         />
-        <button
-          type='button'
-          onClick={swapChains}
-          aria-label='swap chains'
-          className='cursor-pointer text-text-muted transition hover:text-text-primary active:scale-95'
-        >
-          →
-        </button>
+        <Arrow onSwap={handleSwap} spinKey={swapSpins} ariaLabel='swap chains' />
         <InlinePicker
           ariaLabel='route to chain'
           value={route.toChainId}
@@ -72,6 +79,7 @@ export function RouteSelector() {
           onChange={setToChainId}
           triggerDotClass={to.colorClass}
           triggerLabel={to.displayName}
+          triggerLabelClassName={CHAIN_LABEL_CLASS}
         />
       </div>
     </div>

--- a/apps/benchmark/app/components/headtohead/RouteSelector.tsx
+++ b/apps/benchmark/app/components/headtohead/RouteSelector.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
-import { ASSET_SYMBOLS, ASSETS } from '~/lib/assets';
-import { CHAIN_IDS, CHAINS } from '~/lib/chains';
-import { cn } from '~/lib/cn';
+import { InlinePicker, type InlinePickerOption } from './InlinePicker';
+import { ASSET_SYMBOLS, ASSETS, type AssetSymbol } from '~/lib/assets';
+import { CHAIN_IDS, CHAINS, type ChainId } from '~/lib/chains';
 import { useHeadToHeadRouteStore } from '~/lib/headToHeadRouteStore';
 
 export function RouteSelector() {
@@ -17,21 +16,25 @@ export function RouteSelector() {
   const to = CHAINS[route.toChainId];
   const asset = ASSETS[route.assetSymbol];
 
-  const assetOptions = ASSET_SYMBOLS.map((symbol) => ({
+  const assetOptions: InlinePickerOption<AssetSymbol>[] = ASSET_SYMBOLS.map((symbol) => ({
     value: symbol,
     label: ASSETS[symbol].displayName,
     dotClass: ASSETS[symbol].colorClass,
   }));
-  const fromChainOptions = CHAIN_IDS.filter((id) => id !== route.toChainId).map((id) => ({
-    value: id,
-    label: CHAINS[id].displayName,
-    dotClass: CHAINS[id].colorClass,
-  }));
-  const toChainOptions = CHAIN_IDS.filter((id) => id !== route.fromChainId).map((id) => ({
-    value: id,
-    label: CHAINS[id].displayName,
-    dotClass: CHAINS[id].colorClass,
-  }));
+  const fromChainOptions: InlinePickerOption<ChainId>[] = CHAIN_IDS.filter((id) => id !== route.toChainId).map(
+    (id) => ({
+      value: id,
+      label: CHAINS[id].displayName,
+      dotClass: CHAINS[id].colorClass,
+    }),
+  );
+  const toChainOptions: InlinePickerOption<ChainId>[] = CHAIN_IDS.filter((id) => id !== route.fromChainId).map(
+    (id) => ({
+      value: id,
+      label: CHAINS[id].displayName,
+      dotClass: CHAINS[id].colorClass,
+    }),
+  );
 
   return (
     <div className='flex items-center gap-3.5 border border-border bg-surface-elevated px-4 py-2.5'>
@@ -73,140 +76,4 @@ export function RouteSelector() {
       </div>
     </div>
   );
-}
-
-interface InlinePickerOption<T> {
-  value: T;
-  label: string;
-  dotClass: string;
-}
-
-interface InlinePickerProps<T extends string | number> {
-  ariaLabel: string;
-  value: T;
-  options: readonly InlinePickerOption<T>[];
-  onChange: (value: T) => void;
-  triggerDotClass: string;
-  triggerLabel: string;
-}
-
-function InlinePicker<T extends string | number>({
-  ariaLabel,
-  value,
-  options,
-  onChange,
-  triggerDotClass,
-  triggerLabel,
-}: InlinePickerProps<T>) {
-  const [open, setOpen] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const selectedIndex = options.findIndex((option) => option.value === value);
-
-  useEffect(() => {
-    if (!open) return;
-    const handleMouseDown = (event: MouseEvent) => {
-      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', handleMouseDown);
-    return () => document.removeEventListener('mousedown', handleMouseDown);
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const target = selectedIndex >= 0 ? selectedIndex : 0;
-    optionRefs.current[target]?.focus();
-  }, [open, selectedIndex]);
-
-  const closeAndReturnFocus = () => {
-    setOpen(false);
-    triggerRef.current?.focus();
-  };
-
-  const handleSelect = (next: T) => {
-    onChange(next);
-    closeAndReturnFocus();
-  };
-
-  const handleListKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
-    const current = optionRefs.current.findIndex((node) => node === document.activeElement);
-    if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      const next = current < 0 ? 0 : Math.min(current + 1, options.length - 1);
-      optionRefs.current[next]?.focus();
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      const previous = current <= 0 ? options.length - 1 : current - 1;
-      optionRefs.current[previous]?.focus();
-    } else if (event.key === 'Escape') {
-      event.preventDefault();
-      closeAndReturnFocus();
-    } else if (event.key === 'Tab') {
-      setOpen(false);
-    }
-  };
-
-  const handleTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      event.preventDefault();
-      setOpen(true);
-    } else if (event.key === 'Escape' && open) {
-      event.preventDefault();
-      setOpen(false);
-    }
-  };
-
-  return (
-    <div ref={wrapperRef} className='relative inline-flex'>
-      <button
-        ref={triggerRef}
-        type='button'
-        onClick={() => setOpen((current) => !current)}
-        onKeyDown={handleTriggerKeyDown}
-        aria-haspopup='listbox'
-        aria-expanded={open}
-        aria-label={`${ariaLabel}: ${triggerLabel}`}
-        className='inline-flex cursor-pointer items-center gap-2 transition active:scale-95'
-      >
-        <Dot className={triggerDotClass} />
-        <span>{triggerLabel}</span>
-      </button>
-      {open ? (
-        <ul
-          role='listbox'
-          aria-label={ariaLabel}
-          onKeyDown={handleListKeyDown}
-          className='animate-popover-enter absolute top-full left-0 z-20 mt-2 min-w-full origin-top border border-border bg-surface-elevated shadow-lg'
-        >
-          {options.map((option, index) => (
-            <li key={String(option.value)}>
-              <button
-                ref={(node) => {
-                  optionRefs.current[index] = node;
-                }}
-                type='button'
-                role='option'
-                aria-selected={option.value === value}
-                onClick={() => handleSelect(option.value)}
-                className={cn(
-                  'flex w-full cursor-pointer items-center gap-2 px-3 py-2 font-mono text-label transition active:bg-accent-soft/60',
-                  option.value === value
-                    ? 'bg-accent-soft text-accent'
-                    : 'text-text-secondary hover:bg-surface hover:text-text-primary',
-                )}
-              >
-                <Dot className={option.dotClass} />
-                <span>{option.label}</span>
-              </button>
-            </li>
-          ))}
-        </ul>
-      ) : null}
-    </div>
-  );
-}
-
-function Dot({ className }: { className: string }) {
-  return <span className={cn('inline-block size-1.5 rounded-full', className)} aria-hidden='true' />;
 }

--- a/apps/benchmark/app/lib/headToHeadRouteStore.ts
+++ b/apps/benchmark/app/lib/headToHeadRouteStore.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { create } from 'zustand';
+import { AssetSymbol } from './assets';
+import { ChainId } from './chains';
+import { INITIAL_ASSET_SYMBOL, INITIAL_FROM_CHAIN_ID, INITIAL_TO_CHAIN_ID } from './requestBarDefaults';
+
+export interface HeadToHeadRoute {
+  fromChainId: ChainId;
+  toChainId: ChainId;
+  assetSymbol: AssetSymbol;
+}
+
+interface HeadToHeadRouteState {
+  route: HeadToHeadRoute;
+  setFromChainId: (fromChainId: ChainId) => void;
+  setToChainId: (toChainId: ChainId) => void;
+  setAssetSymbol: (assetSymbol: AssetSymbol) => void;
+  swapChains: () => void;
+}
+
+const INITIAL_ROUTE: HeadToHeadRoute = {
+  fromChainId: INITIAL_FROM_CHAIN_ID,
+  toChainId: INITIAL_TO_CHAIN_ID,
+  assetSymbol: INITIAL_ASSET_SYMBOL,
+};
+
+export const useHeadToHeadRouteStore = create<HeadToHeadRouteState>((set) => ({
+  route: INITIAL_ROUTE,
+  setFromChainId: (fromChainId) => set((state) => ({ route: { ...state.route, fromChainId } })),
+  setToChainId: (toChainId) => set((state) => ({ route: { ...state.route, toChainId } })),
+  setAssetSymbol: (assetSymbol) => set((state) => ({ route: { ...state.route, assetSymbol } })),
+  swapChains: () =>
+    set((state) => ({
+      route: {
+        ...state.route,
+        fromChainId: state.route.toChainId,
+        toChainId: state.route.fromChainId,
+      },
+    })),
+}));

--- a/apps/benchmark/app/page.tsx
+++ b/apps/benchmark/app/page.tsx
@@ -81,14 +81,7 @@ export default async function Home() {
             index='03'
             label='head-to-head · by route'
             title='compare providers on a specific chain pair'
-            rightSlot={
-              <RouteSelector
-                fromChainId={INITIAL_FROM_CHAIN_ID}
-                toChainId={INITIAL_TO_CHAIN_ID}
-                assetSymbol={INITIAL_ASSET_SYMBOL}
-                assetColorClass='bg-asset-usdc'
-              />
-            }
+            rightSlot={<RouteSelector />}
           />
           <HeadToHead metrics={MOCK_HEAD_TO_HEAD_METRICS} />
         </SectionFrame>

--- a/apps/benchmark/tests/headtohead-selector.spec.ts
+++ b/apps/benchmark/tests/headtohead-selector.spec.ts
@@ -5,34 +5,34 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('asset picker opens a listbox and updates the trigger', async ({ page }) => {
-  const trigger = page.getByRole('button', { name: /^asset:/i });
+  const trigger = page.getByRole('button', { name: /^route asset:/i });
   await trigger.click();
-  const listbox = page.getByRole('listbox', { name: 'asset' });
+  const listbox = page.getByRole('listbox', { name: 'route asset' });
   await expect(listbox).toBeVisible();
   await listbox.getByRole('option', { name: 'WETH' }).click();
-  await expect(trigger).toHaveAccessibleName(/asset: WETH/i);
+  await expect(trigger).toHaveAccessibleName(/route asset: WETH/i);
 });
 
 test('swap chains arrow flips from and to', async ({ page }) => {
-  const fromTrigger = page.getByRole('button', { name: /^from chain:/i });
-  const toTrigger = page.getByRole('button', { name: /^to chain:/i });
+  const fromTrigger = page.getByRole('button', { name: /^route from chain:/i });
+  const toTrigger = page.getByRole('button', { name: /^route to chain:/i });
 
   const initialFromName = await fromTrigger.getAttribute('aria-label');
   const initialToName = await toTrigger.getAttribute('aria-label');
 
   await page.getByRole('button', { name: 'swap chains' }).click();
 
-  await expect(fromTrigger).toHaveAttribute('aria-label', initialToName!.replace('to chain:', 'from chain:'));
-  await expect(toTrigger).toHaveAttribute('aria-label', initialFromName!.replace('from chain:', 'to chain:'));
+  await expect(fromTrigger).toHaveAttribute('aria-label', initialToName!.replace('route to chain:', 'route from chain:'));
+  await expect(toTrigger).toHaveAttribute('aria-label', initialFromName!.replace('route from chain:', 'route to chain:'));
 });
 
 test('from chain options exclude the current to chain', async ({ page }) => {
-  const toTrigger = page.getByRole('button', { name: /^to chain:/i });
+  const toTrigger = page.getByRole('button', { name: /^route to chain:/i });
   const toLabel = await toTrigger.getAttribute('aria-label');
-  const toChainName = toLabel!.replace('to chain: ', '');
+  const toChainName = toLabel!.replace('route to chain: ', '');
 
-  await page.getByRole('button', { name: /^from chain:/i }).click();
-  const listbox = page.getByRole('listbox', { name: 'from chain' });
+  await page.getByRole('button', { name: /^route from chain:/i }).click();
+  const listbox = page.getByRole('listbox', { name: 'route from chain' });
   await expect(listbox).toBeVisible();
   await expect(listbox.getByRole('option', { name: toChainName })).toHaveCount(0);
 });

--- a/apps/benchmark/tests/headtohead-selector.spec.ts
+++ b/apps/benchmark/tests/headtohead-selector.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test('asset picker opens a listbox and updates the trigger', async ({ page }) => {
+  const trigger = page.getByRole('button', { name: /^asset:/i });
+  await trigger.click();
+  const listbox = page.getByRole('listbox', { name: 'asset' });
+  await expect(listbox).toBeVisible();
+  await listbox.getByRole('option', { name: 'WETH' }).click();
+  await expect(trigger).toHaveAccessibleName(/asset: WETH/i);
+});
+
+test('swap chains arrow flips from and to', async ({ page }) => {
+  const fromTrigger = page.getByRole('button', { name: /^from chain:/i });
+  const toTrigger = page.getByRole('button', { name: /^to chain:/i });
+
+  const initialFromName = await fromTrigger.getAttribute('aria-label');
+  const initialToName = await toTrigger.getAttribute('aria-label');
+
+  await page.getByRole('button', { name: 'swap chains' }).click();
+
+  await expect(fromTrigger).toHaveAttribute('aria-label', initialToName!.replace('to chain:', 'from chain:'));
+  await expect(toTrigger).toHaveAttribute('aria-label', initialFromName!.replace('from chain:', 'to chain:'));
+});
+
+test('from chain options exclude the current to chain', async ({ page }) => {
+  const toTrigger = page.getByRole('button', { name: /^to chain:/i });
+  const toLabel = await toTrigger.getAttribute('aria-label');
+  const toChainName = toLabel!.replace('to chain: ', '');
+
+  await page.getByRole('button', { name: /^from chain:/i }).click();
+  const listbox = page.getByRole('listbox', { name: 'from chain' });
+  await expect(listbox).toBeVisible();
+  await expect(listbox.getByRole('option', { name: toChainName })).toHaveCount(0);
+});


### PR DESCRIPTION
Foundation for the head-to-head interactive route. Section 03's `RouteSelector` becomes a real input + state store; consumption (refetch on change, debounce, loading states) lands in a follow-up.

## What's in

- `useHeadToHeadRouteStore` Zustand store with `fromChainId`, `toChainId`, `assetSymbol`. Separate from `useRequestBarStore` so changing the head-to-head route doesn't disturb the live race at the top.
- `RouteSelector` rewritten as a `'use client'` component with inline pickers for asset and from/to chain, plus a swap-chains arrow. Reads and writes the store.
- `page.tsx` no longer passes the initial route as props; the store's default values cover SSR.

## What's NOT in

- Refetching on store change. The table still consumes the SSR-loaded metrics for the initial route. EFI-993 wires the consumption layer (API route with `revalidate`, client hook with debounce, loading/error states).

Closes EFI-994