### PR TITLE
fix(cross-chain): drop tokens with conflicting metadata from discovery

### DIFF
--- a/.changeset/drop-conflicting-discovery-metadata.md
+++ b/.changeset/drop-conflicting-discovery-metadata.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Drop tokens with conflicting metadata from discovery results
+
+Discovery results used first-write-wins for `symbol`/`decimals`, so a malicious discovery source could relabel a token and have downstream checks trust it. When sources disagree on a token's `symbol` or `decimals`, the token is now dropped from the discovery result and a warning is logged. This applies both to the aggregator's merged view and to standalone discovery services.

--- a/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
+++ b/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
@@ -201,10 +201,13 @@ function dropConflictedTokens(
     for (const [chainId, addresses] of conflicted) {
         for (const canonical of addresses) {
             delete tokenMetadata[chainId]?.[canonical];
-            console.warn(
-                `[AssetDiscovery] Providers disagree on symbol/decimals for token ${canonical} on chain ${chainId}; dropping it from discovery results`,
-            );
         }
+        // One warning per chain, not per token, so a poisoned provider reporting
+        // many conflicts can't flood the logs.
+        console.warn(
+            `[AssetDiscovery] Providers disagree on symbol/decimals for ${addresses.size} token(s) on chain ${chainId}; dropping them from discovery results: ${[...addresses].join(", ")}`,
+        );
+
         const tokens = tokensByChain[chainId];
         if (tokens) {
             tokensByChain[chainId] = tokens.filter((addr) => !addresses.has(addr));

--- a/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
+++ b/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
@@ -155,25 +155,18 @@ export function mergeDiscoveredAssets(sources: DiscoveredAssets[]): DiscoveredAs
     } as DiscoveredAssets;
 }
 
-/** Sources disagree on `symbol` or `decimals`: at least one is mislabeling the token. */
+/**
+ * Sources disagree on `symbol` or `decimals`: at least one is mislabeling the token.
+ *
+ * Symbols are compared with strict equality, matching the downstream same-asset check
+ * in `validateBuildQuoteParams`. Normalizing here (e.g. case-folding) would only desync
+ * the two comparisons, and providers report symbols from standard token lists anyway.
+ */
 function isIdentityConflict(
     existing: DiscoveredAssetInfo,
     incoming: { symbol: string; decimals: number },
 ): boolean {
-    // Compare symbols case- and whitespace-insensitively so honest providers that
-    // report the same token with cosmetic differences aren't flagged as conflicting.
-    return (
-        normalizeSymbol(existing.symbol) !== normalizeSymbol(incoming.symbol) ||
-        existing.decimals !== incoming.decimals
-    );
-}
-
-function normalizeSymbol(symbol: string): string {
-    // Coerce defensively: a malicious discovery source may send a non-string
-    // symbol, and a crash here would take down discovery instead of dropping the token.
-    return String(symbol ?? "")
-        .trim()
-        .toUpperCase();
+    return existing.symbol !== incoming.symbol || existing.decimals !== incoming.decimals;
 }
 
 /** Record a (chainId, canonical address) pair as conflicted. */

--- a/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
+++ b/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
@@ -17,6 +17,10 @@ import { isNativeAddress, toCanonicalNativeAddress } from "./token.js";
  * Each metadata entry includes a `providers` array listing which provider IDs
  * reported the asset.
  *
+ * Tokens with conflicting `symbol`/`decimals` are dropped (see
+ * {@link dropConflictedTokens}); this also covers standalone consumers of
+ * `getSupportedAssets()` that never go through {@link mergeDiscoveredAssets}.
+ *
  * @internal Used by BaseAssetDiscoveryService - not exported publicly
  * @param results - Discovery results from one or more providers
  * @param filterChainIds - Optional numeric chain IDs to include (others are skipped)
@@ -27,6 +31,7 @@ export function toDiscoveredAssets(
 ): DiscoveredAssets {
     const tokensByChain: Record<number, string[]> = {};
     const tokenMetadata: Record<number, Record<string, DiscoveredAssetInfo>> = {};
+    const conflicted = new Map<number, Set<string>>();
 
     for (const result of results) {
         for (const network of result.networks) {
@@ -48,6 +53,10 @@ export function toDiscoveredAssets(
 
                 const existing = tokenMetadata[chainId][canonicalAddr];
                 if (existing) {
+                    if (isIdentityConflict(existing, asset)) {
+                        markConflicted(conflicted, chainId, canonicalAddr);
+                        continue;
+                    }
                     if (!existing.providers.includes(result.providerId)) {
                         existing.providers.push(result.providerId);
                     }
@@ -67,6 +76,8 @@ export function toDiscoveredAssets(
         }
     }
 
+    dropConflictedTokens(tokensByChain, tokenMetadata, conflicted);
+
     return {
         tokensByChain,
         tokenMetadata,
@@ -78,8 +89,11 @@ export function toDiscoveredAssets(
  *
  * Used by Aggregator to combine results from multiple providers.
  * Deduplicates tokens by canonical address (native placeholders collapse
- * to the canonical EIP-7528 form); merges `providers` arrays (first-write-wins
- * for symbol/decimals, first non-empty wins for name/logoURI, union for providers).
+ * to the canonical EIP-7528 form); merges `providers` arrays (first non-empty
+ * wins for name/logoURI, union for providers).
+ *
+ * Tokens with conflicting `symbol`/`decimals` across sources are dropped
+ * (see {@link dropConflictedTokens}).
  *
  * @internal Used by Aggregator - not exported publicly
  * @param sources - Array of DiscoveredAssets to merge
@@ -87,6 +101,7 @@ export function toDiscoveredAssets(
 export function mergeDiscoveredAssets(sources: DiscoveredAssets[]): DiscoveredAssets {
     const tokensByChain: Record<number, string[]> = {};
     const tokenMetadata: Record<number, Record<string, DiscoveredAssetInfo>> = {};
+    const conflicted = new Map<number, Set<string>>();
 
     for (const source of sources) {
         for (const [chainKeyStr, tokens] of Object.entries(source.tokensByChain)) {
@@ -107,6 +122,10 @@ export function mergeDiscoveredAssets(sources: DiscoveredAssets[]): DiscoveredAs
                 const canonical = toCanonicalNativeAddress(addr, "eip155");
                 const existing = tokenMetadata[chainId][canonical];
                 if (existing) {
+                    if (isIdentityConflict(existing, meta)) {
+                        markConflicted(conflicted, chainId, canonical);
+                        continue;
+                    }
                     for (const pid of meta.providers) {
                         if (!existing.providers.includes(pid)) {
                             existing.providers.push(pid);
@@ -128,8 +147,67 @@ export function mergeDiscoveredAssets(sources: DiscoveredAssets[]): DiscoveredAs
         }
     }
 
+    dropConflictedTokens(tokensByChain, tokenMetadata, conflicted);
+
     return {
         tokensByChain,
         tokenMetadata,
     } as DiscoveredAssets;
+}
+
+/** Sources disagree on `symbol` or `decimals`: at least one is mislabeling the token. */
+function isIdentityConflict(
+    existing: DiscoveredAssetInfo,
+    incoming: { symbol: string; decimals: number },
+): boolean {
+    return existing.symbol !== incoming.symbol || existing.decimals !== incoming.decimals;
+}
+
+/** Record a (chainId, canonical address) pair as conflicted. */
+function markConflicted(
+    conflicted: Map<number, Set<string>>,
+    chainId: number,
+    canonical: string,
+): void {
+    let addresses = conflicted.get(chainId);
+    if (!addresses) {
+        addresses = new Set();
+        conflicted.set(chainId, addresses);
+    }
+    addresses.add(canonical);
+}
+
+/**
+ * Remove conflicted tokens from both lookup structures.
+ *
+ * There is no way to tell which source is lying, so conflicted entries are
+ * dropped entirely (fail-closed): downstream treats missing metadata as
+ * unknown and rejects, instead of trusting a poisoned symbol.
+ */
+function dropConflictedTokens(
+    tokensByChain: Record<number, string[]>,
+    tokenMetadata: Record<number, Record<string, DiscoveredAssetInfo>>,
+    conflicted: Map<number, Set<string>>,
+): void {
+    for (const [chainId, addresses] of conflicted) {
+        for (const canonical of addresses) {
+            delete tokenMetadata[chainId]?.[canonical];
+            console.warn(
+                `[AssetDiscovery] Providers disagree on symbol/decimals for token ${canonical} on chain ${chainId}; dropping it from discovery results`,
+            );
+        }
+        const tokens = tokensByChain[chainId];
+        if (tokens) {
+            tokensByChain[chainId] = tokens.filter((addr) => !addresses.has(addr));
+        }
+
+        // Don't leave empty chain entries behind.
+        if (tokensByChain[chainId]?.length === 0) {
+            delete tokensByChain[chainId];
+        }
+        const chainMeta = tokenMetadata[chainId];
+        if (chainMeta && Object.keys(chainMeta).length === 0) {
+            delete tokenMetadata[chainId];
+        }
+    }
 }

--- a/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
+++ b/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
@@ -169,7 +169,11 @@ function isIdentityConflict(
 }
 
 function normalizeSymbol(symbol: string): string {
-    return symbol.trim().toUpperCase();
+    // Coerce defensively: a malicious discovery source may send a non-string
+    // symbol, and a crash here would take down discovery instead of dropping the token.
+    return String(symbol ?? "")
+        .trim()
+        .toUpperCase();
 }
 
 /** Record a (chainId, canonical address) pair as conflicted. */

--- a/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
+++ b/packages/cross-chain/src/core/utils/toDiscoveredAssets.ts
@@ -160,7 +160,16 @@ function isIdentityConflict(
     existing: DiscoveredAssetInfo,
     incoming: { symbol: string; decimals: number },
 ): boolean {
-    return existing.symbol !== incoming.symbol || existing.decimals !== incoming.decimals;
+    // Compare symbols case- and whitespace-insensitively so honest providers that
+    // report the same token with cosmetic differences aren't flagged as conflicting.
+    return (
+        normalizeSymbol(existing.symbol) !== normalizeSymbol(incoming.symbol) ||
+        existing.decimals !== incoming.decimals
+    );
+}
+
+function normalizeSymbol(symbol: string): string {
+    return symbol.trim().toUpperCase();
 }
 
 /** Record a (chainId, canonical address) pair as conflicted. */

--- a/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
+++ b/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
@@ -428,37 +428,6 @@ describe("mergeDiscoveredAssets", () => {
             expect(merged.tokenMetadata[1]?.[USDC_ETH.toLowerCase()]).toBeUndefined();
         });
 
-        it("does not treat casing or whitespace differences in symbol as a conflict", () => {
-            const sourceA = toDiscoveredAssets([
-                result("provider-a", { chainId: 1, assets: [{ ...usdcEth, symbol: "USDC" }] }),
-            ]);
-            const sourceB = toDiscoveredAssets([
-                result("provider-b", { chainId: 1, assets: [{ ...usdcEth, symbol: " usdc " }] }),
-            ]);
-
-            const merged = mergeDiscoveredAssets([sourceA, sourceB]);
-
-            const meta = merged.tokenMetadata[1]?.[USDC_ETH.toLowerCase()];
-            expect(meta?.symbol).toBe("USDC");
-            expect(meta?.providers).toEqual(["provider-a", "provider-b"]);
-        });
-
-        it("does not crash on a non-string symbol and drops the token", () => {
-            const honest = toDiscoveredAssets([
-                result("honest", { chainId: 1, assets: [usdcEth] }),
-            ]);
-            const malicious = toDiscoveredAssets([
-                result("malicious", {
-                    chainId: 1,
-                    assets: [{ ...usdcEth, symbol: null as unknown as string }],
-                }),
-            ]);
-
-            expect(() => mergeDiscoveredAssets([honest, malicious])).not.toThrow();
-            const merged = mergeDiscoveredAssets([honest, malicious]);
-            expect(merged.tokenMetadata[1]?.[USDC_ETH.toLowerCase()]).toBeUndefined();
-        });
-
         it("does not drop tokens over name/logoURI differences", () => {
             const sourceA = toDiscoveredAssets([
                 result("provider-a", {

--- a/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
+++ b/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
@@ -390,6 +390,31 @@ describe("mergeDiscoveredAssets", () => {
             );
         });
 
+        it("logs a single warning per chain regardless of how many tokens conflict", () => {
+            const honest = toDiscoveredAssets([
+                result("honest", { chainId: 1, assets: [usdcEth, wethEth] }),
+            ]);
+            const malicious = toDiscoveredAssets([
+                result("malicious", {
+                    chainId: 1,
+                    assets: [
+                        { ...usdcEth, symbol: "DAI" },
+                        { ...wethEth, symbol: "DAI" },
+                    ],
+                }),
+            ]);
+
+            mergeDiscoveredAssets([honest, malicious]);
+
+            expect(console.warn).toHaveBeenCalledTimes(1);
+            expect(console.warn).toHaveBeenCalledWith(
+                expect.stringContaining(USDC_ETH.toLowerCase()),
+            );
+            expect(console.warn).toHaveBeenCalledWith(
+                expect.stringContaining(WETH_ETH.toLowerCase()),
+            );
+        });
+
         it("drops a token when sources disagree on decimals", () => {
             const honest = toDiscoveredAssets([
                 result("honest", { chainId: 1, assets: [usdcEth] }),

--- a/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
+++ b/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
@@ -443,6 +443,22 @@ describe("mergeDiscoveredAssets", () => {
             expect(meta?.providers).toEqual(["provider-a", "provider-b"]);
         });
 
+        it("does not crash on a non-string symbol and drops the token", () => {
+            const honest = toDiscoveredAssets([
+                result("honest", { chainId: 1, assets: [usdcEth] }),
+            ]);
+            const malicious = toDiscoveredAssets([
+                result("malicious", {
+                    chainId: 1,
+                    assets: [{ ...usdcEth, symbol: null as unknown as string }],
+                }),
+            ]);
+
+            expect(() => mergeDiscoveredAssets([honest, malicious])).not.toThrow();
+            const merged = mergeDiscoveredAssets([honest, malicious]);
+            expect(merged.tokenMetadata[1]?.[USDC_ETH.toLowerCase()]).toBeUndefined();
+        });
+
         it("does not drop tokens over name/logoURI differences", () => {
             const sourceA = toDiscoveredAssets([
                 result("provider-a", {

--- a/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
+++ b/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
@@ -403,6 +403,21 @@ describe("mergeDiscoveredAssets", () => {
             expect(merged.tokenMetadata[1]?.[USDC_ETH.toLowerCase()]).toBeUndefined();
         });
 
+        it("does not treat casing or whitespace differences in symbol as a conflict", () => {
+            const sourceA = toDiscoveredAssets([
+                result("provider-a", { chainId: 1, assets: [{ ...usdcEth, symbol: "USDC" }] }),
+            ]);
+            const sourceB = toDiscoveredAssets([
+                result("provider-b", { chainId: 1, assets: [{ ...usdcEth, symbol: " usdc " }] }),
+            ]);
+
+            const merged = mergeDiscoveredAssets([sourceA, sourceB]);
+
+            const meta = merged.tokenMetadata[1]?.[USDC_ETH.toLowerCase()];
+            expect(meta?.symbol).toBe("USDC");
+            expect(meta?.providers).toEqual(["provider-a", "provider-b"]);
+        });
+
         it("does not drop tokens over name/logoURI differences", () => {
             const sourceA = toDiscoveredAssets([
                 result("provider-a", {

--- a/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
+++ b/packages/cross-chain/test/utils/toDiscoveredAssets.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
     AssetDiscoveryResult,
@@ -73,17 +73,6 @@ describe("toDiscoveredAssets", () => {
             expect(Object.keys(out.tokenMetadata[1]!)).toHaveLength(2);
         });
 
-        it("use first-write-wins for metadata and merge providers", () => {
-            const out = toDiscoveredAssets([
-                result("provider-1", { chainId: 1, assets: [{ ...usdcEth, symbol: "USDC-OLD" }] }),
-                result("provider-2", { chainId: 1, assets: [{ ...usdcEth, symbol: "USDC-NEW" }] }),
-            ]);
-
-            const meta = out.tokenMetadata[1]![USDC_ETH.toLowerCase()]!;
-            expect(meta.symbol).toBe("USDC-OLD");
-            expect(meta.providers).toEqual(["provider-1", "provider-2"]);
-        });
-
         it("fills missing name/logoURI from later providers", () => {
             const out = toDiscoveredAssets([
                 result("provider-1", { chainId: 1, assets: [usdcEth] }),
@@ -144,6 +133,29 @@ describe("toDiscoveredAssets", () => {
             expect(out.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.providers).toEqual([
                 "provider-1",
             ]);
+        });
+    });
+
+    describe("conflicting identity metadata", () => {
+        beforeEach(() => {
+            vi.spyOn(console, "warn").mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        // Conflict handling is shared with mergeDiscoveredAssets and tested in
+        // depth there; this only covers that this entry point applies it too.
+        it("drops a token when providers disagree on symbol/decimals", () => {
+            const out = toDiscoveredAssets([
+                result("honest", { chainId: 1, assets: [usdcEth, wethEth] }),
+                result("malicious", { chainId: 1, assets: [{ ...usdcEth, symbol: "DAI" }] }),
+            ]);
+
+            expect(out.tokenMetadata[1]?.[USDC_ETH.toLowerCase()]).toBeUndefined();
+            expect(out.tokensByChain[1]).not.toContain(USDC_ETH.toLowerCase());
+            expect(out.tokenMetadata[1]?.[WETH_ETH.toLowerCase()]).toBeDefined();
         });
     });
 
@@ -282,23 +294,6 @@ describe("mergeDiscoveredAssets", () => {
         ]);
     });
 
-    it("use first-write-wins for metadata fields", () => {
-        const sourceA = toDiscoveredAssets([
-            result("provider-a", { chainId: 1, assets: [{ ...usdcEth, symbol: "USDC-FIRST" }] }),
-        ]);
-        const sourceB = toDiscoveredAssets([
-            result("provider-b", {
-                chainId: 1,
-                assets: [{ ...usdcEth, symbol: "USDC-SECOND", decimals: 18 }],
-            }),
-        ]);
-
-        const merged = mergeDiscoveredAssets([sourceA, sourceB]);
-
-        expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.symbol).toBe("USDC-FIRST");
-        expect(merged.tokenMetadata[1]![USDC_ETH.toLowerCase()]!.decimals).toBe(6);
-    });
-
     it("treats empty strings as missing in cross-source merges", () => {
         const sourceA = toDiscoveredAssets([
             result("provider-a", { chainId: 1, assets: [{ ...usdcEth, name: "", logoURI: "" }] }),
@@ -366,6 +361,102 @@ describe("mergeDiscoveredAssets", () => {
         expect(merged.tokensByChain[1]).toEqual([NATIVE_EEE_LOWER]);
         expect(Object.keys(merged.tokenMetadata[1]!)).toEqual([NATIVE_EEE_LOWER]);
         expect(merged.tokenMetadata[1]![NATIVE_EEE_LOWER]!.providers).toEqual(["bungee", "across"]);
+    });
+
+    describe("conflicting identity metadata", () => {
+        beforeEach(() => {
+            vi.spyOn(console, "warn").mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it("drops a token when sources disagree on symbol, and warns", () => {
+            const honest = toDiscoveredAssets([
+                result("honest", { chainId: 1, assets: [usdcEth, wethEth] }),
+            ]);
+            const malicious = toDiscoveredAssets([
+                result("malicious", { chainId: 1, assets: [{ ...usdcEth, symbol: "DAI" }] }),
+            ]);
+
+            const merged = mergeDiscoveredAssets([honest, malicious]);
+
+            expect(merged.tokenMetadata[1]?.[USDC_ETH.toLowerCase()]).toBeUndefined();
+            expect(merged.tokensByChain[1]).not.toContain(USDC_ETH.toLowerCase());
+            expect(merged.tokenMetadata[1]?.[WETH_ETH.toLowerCase()]).toBeDefined();
+            expect(console.warn).toHaveBeenCalledWith(
+                expect.stringContaining(USDC_ETH.toLowerCase()),
+            );
+        });
+
+        it("drops a token when sources disagree on decimals", () => {
+            const honest = toDiscoveredAssets([
+                result("honest", { chainId: 1, assets: [usdcEth] }),
+            ]);
+            const malicious = toDiscoveredAssets([
+                result("malicious", { chainId: 1, assets: [{ ...usdcEth, decimals: 18 }] }),
+            ]);
+
+            const merged = mergeDiscoveredAssets([honest, malicious]);
+
+            expect(merged.tokenMetadata[1]?.[USDC_ETH.toLowerCase()]).toBeUndefined();
+        });
+
+        it("does not drop tokens over name/logoURI differences", () => {
+            const sourceA = toDiscoveredAssets([
+                result("provider-a", {
+                    chainId: 1,
+                    assets: [{ ...usdcEth, name: "USD Coin", logoURI: "https://logo/a.png" }],
+                }),
+            ]);
+            const sourceB = toDiscoveredAssets([
+                result("provider-b", {
+                    chainId: 1,
+                    assets: [{ ...usdcEth, name: "USDC Token", logoURI: "https://logo/b.png" }],
+                }),
+            ]);
+
+            const merged = mergeDiscoveredAssets([sourceA, sourceB]);
+
+            const meta = merged.tokenMetadata[1]?.[USDC_ETH.toLowerCase()];
+            expect(meta?.symbol).toBe("USDC");
+            expect(meta?.providers).toEqual(["provider-a", "provider-b"]);
+        });
+
+        it("drops native entries when collapsed placeholders disagree on symbol", () => {
+            const sourceA = toDiscoveredAssets([
+                result("bungee", { chainId: 1, assets: [ethEee] }),
+            ]);
+            const sourceB = toDiscoveredAssets([
+                result("across", { chainId: 1, assets: [{ ...ethZero, symbol: "WETH" }] }),
+            ]);
+
+            const merged = mergeDiscoveredAssets([sourceA, sourceB]);
+
+            expect(merged.tokenMetadata[1]?.[NATIVE_EEE_LOWER]).toBeUndefined();
+            expect(merged.tokensByChain[1] ?? []).not.toContain(NATIVE_EEE_LOWER);
+        });
+
+        it("drops only the affected chain entry and removes it when left empty", () => {
+            const honest = toDiscoveredAssets([
+                result(
+                    "honest",
+                    { chainId: 1, assets: [usdcEth] },
+                    { chainId: 42161, assets: [usdcArb] },
+                ),
+            ]);
+            const malicious = toDiscoveredAssets([
+                result("malicious", { chainId: 1, assets: [{ ...usdcEth, symbol: "DAI" }] }),
+            ]);
+
+            const merged = mergeDiscoveredAssets([honest, malicious]);
+
+            expect(merged.tokensByChain[1]).toBeUndefined();
+            expect(merged.tokenMetadata[1]).toBeUndefined();
+            expect(merged.tokensByChain[42161]).toContain(USDC_ARB.toLowerCase());
+            expect(merged.tokenMetadata[42161]?.[USDC_ARB.toLowerCase()]).toBeDefined();
+        });
     });
 
     it("canonicalizes native placeholders from raw input keys", () => {


### PR DESCRIPTION
## What

Discovery merged `tokenMetadata` from multiple providers with a first-write-wins policy on `symbol` and `decimals`. Whichever provider was indexed first defined a token's identity, so a malicious discovery source could relabel a canonical `(chainId, address)` with a forged symbol. The symbol-based same-asset check in `buildQuote` would then treat two different assets as the same and accept a mismatched pair (audit finding #31).

## Change

`toDiscoveredAssets` and `mergeDiscoveredAssets` now detect when sources disagree on `symbol` or `decimals` for the same canonical `(chainId, address)` and drop that token from the result entirely (from both `tokenMetadata` and `tokensByChain`), logging a warning. Empty chain entries left behind are removed. There is no trusted token registry to tell which source is lying, so conflicted entries fail closed: downstream treats the missing metadata as unknown and rejects, instead of trusting a poisoned symbol.

The check lives in both entry points because `getSupportedAssets()` on a single provider is public and does not go through the merge.

Scope is the discovery layer only. The same-asset comparison in `buildQuoteValidator` (finding #14, EFI-1001) is handled separately in #380; this PR does not touch it. The two findings share a root cause and only close together: #380 hardens the decision, this PR keeps poisoned metadata from reaching it.

Closes EFI-1002
