### PR TITLE
fix(benchmark): denominate amount presets in the selected asset

### DIFF
--- a/apps/benchmark/app/components/RequestBar.tsx
+++ b/apps/benchmark/app/components/RequestBar.tsx
@@ -12,12 +12,6 @@ import { CHAIN_IDS, CHAINS, ChainId } from '~/lib/chains';
 import { cn } from '~/lib/cn';
 import { useRequestBarStore, type RequestPreset } from '~/lib/requestBarStore';
 
-const PRESETS: RequestPreset[] = [
-  { label: '$100', amount: '100.00' },
-  { label: '$1k', amount: '1,000.00' },
-  { label: '$10k', amount: '10,000.00' },
-];
-
 interface RequestBarProps {
   chains: NetworkAssets[];
 }
@@ -53,6 +47,7 @@ export function RequestBar({ chains }: RequestBarProps) {
   const fromOptions = useMemo(() => toChainOptions(request.toChainId), [request.toChainId]);
   const toOptions = useMemo(() => toChainOptions(request.fromChainId), [request.fromChainId]);
   const assetOptions = useMemo(() => toAssetOptions(), []);
+  const presets = ASSETS[request.assetSymbol].presets;
 
   const clearPendingAmountRun = () => {
     if (debounceTimer.current === null) return;
@@ -132,7 +127,7 @@ export function RequestBar({ chains }: RequestBarProps) {
           <div className='flex flex-1 flex-col gap-3 md:flex-row md:items-center md:gap-4'>
             <AmountField amount={request.amount} onChange={handleAmountChange} />
             <div className='flex gap-1'>
-              {PRESETS.map((preset) => (
+              {presets.map((preset) => (
                 <PresetPill
                   key={preset.label}
                   label={preset.label}

--- a/apps/benchmark/app/components/RequestBar.tsx
+++ b/apps/benchmark/app/components/RequestBar.tsx
@@ -10,7 +10,7 @@ import type { NetworkAssets } from '@wonderland/interop-cross-chain';
 import { ASSET_SYMBOLS, ASSETS, AssetSymbol } from '~/lib/assets';
 import { CHAIN_IDS, CHAINS, ChainId } from '~/lib/chains';
 import { cn } from '~/lib/cn';
-import { useRequestBarStore, type RequestPreset } from '~/lib/requestBarStore';
+import { useRequestBarStore } from '~/lib/requestBarStore';
 
 interface RequestBarProps {
   chains: NetworkAssets[];
@@ -92,9 +92,9 @@ export function RequestBar({ chains }: RequestBarProps) {
     }, 200);
   };
 
-  const handlePresetClick = (preset: RequestPreset) => {
+  const handlePresetClick = (presetIndex: number) => {
     clearPendingAmountRun();
-    setPreset(preset);
+    setPreset(presetIndex);
     void runRace();
   };
 
@@ -127,12 +127,12 @@ export function RequestBar({ chains }: RequestBarProps) {
           <div className='flex flex-1 flex-col gap-3 md:flex-row md:items-center md:gap-4'>
             <AmountField amount={request.amount} onChange={handleAmountChange} />
             <div className='flex gap-1'>
-              {presets.map((preset) => (
+              {presets.map((preset, index) => (
                 <PresetPill
                   key={preset.label}
                   label={preset.label}
-                  selected={preset.label === request.selectedPreset}
-                  onClick={() => handlePresetClick(preset)}
+                  selected={index === request.selectedPreset}
+                  onClick={() => handlePresetClick(index)}
                   fillContainer
                 />
               ))}

--- a/apps/benchmark/app/lib/assets.ts
+++ b/apps/benchmark/app/lib/assets.ts
@@ -3,11 +3,23 @@ export enum AssetSymbol {
   WETH = 'WETH',
 }
 
+export interface AssetPreset {
+  label: string;
+  amount: string;
+}
+
 export interface AssetMeta {
   symbol: AssetSymbol;
   displayName: string;
   colorClass: string;
   iconUrl: string;
+  /**
+   * Quick-amount presets denominated in this asset. A raw USD figure only
+   * makes sense for USD-pegged assets, so each asset carries its own amounts.
+   * Index-aligned across assets (small / medium / large) so switching assets
+   * can re-apply the equivalent magnitude.
+   */
+  presets: readonly AssetPreset[];
 }
 
 export const ASSETS: Record<AssetSymbol, AssetMeta> = {
@@ -16,12 +28,22 @@ export const ASSETS: Record<AssetSymbol, AssetMeta> = {
     displayName: 'USDC',
     colorClass: 'bg-asset-usdc',
     iconUrl: '/icons/assets/usdc.svg',
+    presets: [
+      { label: '$100', amount: '100.00' },
+      { label: '$1k', amount: '1,000.00' },
+      { label: '$10k', amount: '10,000.00' },
+    ],
   },
   [AssetSymbol.WETH]: {
     symbol: AssetSymbol.WETH,
     displayName: 'WETH',
     colorClass: 'bg-asset-eth',
     iconUrl: '/icons/assets/weth.svg',
+    presets: [
+      { label: '0.05', amount: '0.05' },
+      { label: '0.5', amount: '0.5' },
+      { label: '5', amount: '5' },
+    ],
   },
 };
 

--- a/apps/benchmark/app/lib/requestBarDefaults.ts
+++ b/apps/benchmark/app/lib/requestBarDefaults.ts
@@ -1,4 +1,4 @@
-import { ASSETS, AssetSymbol } from './assets';
+import { ASSETS, AssetSymbol, type AssetPreset } from './assets';
 import { ChainId } from './chains';
 
 export const INITIAL_FROM_CHAIN_ID = ChainId.Arbitrum;
@@ -9,6 +9,6 @@ export const INITIAL_ASSET_SYMBOL = AssetSymbol.USDC;
 // matches a real preset of the selected asset. Fail loud at module load if
 // the asset is ever misconfigured without presets.
 export const INITIAL_PRESET_INDEX = 0;
-const initialPreset = ASSETS[INITIAL_ASSET_SYMBOL].presets.at(INITIAL_PRESET_INDEX);
+const initialPreset: AssetPreset | undefined = ASSETS[INITIAL_ASSET_SYMBOL].presets[INITIAL_PRESET_INDEX];
 if (!initialPreset) throw new Error(`${INITIAL_ASSET_SYMBOL} must define at least one amount preset`);
 export const INITIAL_AMOUNT = initialPreset.amount;

--- a/apps/benchmark/app/lib/requestBarDefaults.ts
+++ b/apps/benchmark/app/lib/requestBarDefaults.ts
@@ -1,8 +1,12 @@
-import { AssetSymbol } from './assets';
+import { ASSETS, AssetSymbol } from './assets';
 import { ChainId } from './chains';
 
 export const INITIAL_FROM_CHAIN_ID = ChainId.Arbitrum;
 export const INITIAL_TO_CHAIN_ID = ChainId.Base;
 export const INITIAL_ASSET_SYMBOL = AssetSymbol.USDC;
-export const INITIAL_AMOUNT = '100.00';
-export const INITIAL_PRESET = '$100';
+
+// Derived from the initial asset's first preset so the boot state always
+// matches a real preset of the selected asset.
+const initialPreset = ASSETS[INITIAL_ASSET_SYMBOL].presets[0];
+export const INITIAL_AMOUNT = initialPreset.amount;
+export const INITIAL_PRESET = initialPreset.label;

--- a/apps/benchmark/app/lib/requestBarDefaults.ts
+++ b/apps/benchmark/app/lib/requestBarDefaults.ts
@@ -6,7 +6,9 @@ export const INITIAL_TO_CHAIN_ID = ChainId.Base;
 export const INITIAL_ASSET_SYMBOL = AssetSymbol.USDC;
 
 // Derived from the initial asset's first preset so the boot state always
-// matches a real preset of the selected asset.
-const initialPreset = ASSETS[INITIAL_ASSET_SYMBOL].presets[0];
+// matches a real preset of the selected asset. Fail loud at module load if
+// the asset is ever misconfigured without presets.
+export const INITIAL_PRESET_INDEX = 0;
+const initialPreset = ASSETS[INITIAL_ASSET_SYMBOL].presets.at(INITIAL_PRESET_INDEX);
+if (!initialPreset) throw new Error(`${INITIAL_ASSET_SYMBOL} must define at least one amount preset`);
 export const INITIAL_AMOUNT = initialPreset.amount;
-export const INITIAL_PRESET = initialPreset.label;

--- a/apps/benchmark/app/lib/requestBarStore.ts
+++ b/apps/benchmark/app/lib/requestBarStore.ts
@@ -1,13 +1,13 @@
 'use client';
 
 import { create } from 'zustand';
-import { ASSETS, AssetSymbol, type AssetPreset } from './assets';
+import { ASSETS, AssetSymbol } from './assets';
 import { ChainId } from './chains';
 import {
   INITIAL_AMOUNT,
   INITIAL_ASSET_SYMBOL,
   INITIAL_FROM_CHAIN_ID,
-  INITIAL_PRESET,
+  INITIAL_PRESET_INDEX,
   INITIAL_TO_CHAIN_ID,
 } from './requestBarDefaults';
 import type { RaceRow } from '~/components/race-table/types';
@@ -17,15 +17,18 @@ export interface RequestBarRequest {
   toChainId: ChainId;
   assetSymbol: AssetSymbol;
   amount: string;
-  selectedPreset: string | null;
+  /**
+   * Index into the selected asset's `presets`, or null for a manually typed
+   * amount. An index (not the label) so display text stays free to change,
+   * and so switching assets maps to the equivalent preset positionally.
+   */
+  selectedPreset: number | null;
 }
 
 export interface AmountUpdate {
   amount: string;
-  selectedPreset?: string | null;
+  selectedPreset?: number | null;
 }
-
-export type RequestPreset = AssetPreset;
 
 interface RequestBarState {
   request: RequestBarRequest;
@@ -34,7 +37,7 @@ interface RequestBarState {
   setToChainId: (toChainId: ChainId) => void;
   setAssetSymbol: (assetSymbol: AssetSymbol) => void;
   setAmount: (update: AmountUpdate) => void;
-  setPreset: (preset: RequestPreset) => void;
+  setPreset: (presetIndex: number) => void;
   swapChains: () => void;
   setRows: (rows: RaceRow[]) => void;
 }
@@ -44,7 +47,7 @@ const INITIAL_REQUEST: RequestBarRequest = {
   toChainId: INITIAL_TO_CHAIN_ID,
   assetSymbol: INITIAL_ASSET_SYMBOL,
   amount: INITIAL_AMOUNT,
-  selectedPreset: INITIAL_PRESET,
+  selectedPreset: INITIAL_PRESET_INDEX,
 };
 
 export const useRequestBarStore = create<RequestBarState>((set) => ({
@@ -59,13 +62,13 @@ export const useRequestBarStore = create<RequestBarState>((set) => ({
       // re-applied in the new denomination. Presets are index-aligned across
       // assets; a manually typed amount is left untouched.
       if (state.request.selectedPreset !== null) {
-        const previousIndex = ASSETS[state.request.assetSymbol].presets.findIndex(
-          (preset) => preset.label === state.request.selectedPreset,
-        );
         const nextPresets = ASSETS[assetSymbol].presets;
-        const next = nextPresets[previousIndex] ?? nextPresets[0];
-        request.amount = next.amount;
-        request.selectedPreset = next.label;
+        const nextIndex = state.request.selectedPreset < nextPresets.length ? state.request.selectedPreset : 0;
+        const next = nextPresets[nextIndex];
+        if (next) {
+          request.amount = next.amount;
+          request.selectedPreset = nextIndex;
+        }
       }
       return { request };
     }),
@@ -77,7 +80,12 @@ export const useRequestBarStore = create<RequestBarState>((set) => ({
         selectedPreset: selectedPreset === undefined ? state.request.selectedPreset : selectedPreset,
       },
     })),
-  setPreset: ({ amount, label }) => set((state) => ({ request: { ...state.request, amount, selectedPreset: label } })),
+  setPreset: (presetIndex) =>
+    set((state) => {
+      const preset = ASSETS[state.request.assetSymbol].presets[presetIndex];
+      if (!preset) return state;
+      return { request: { ...state.request, amount: preset.amount, selectedPreset: presetIndex } };
+    }),
   swapChains: () =>
     set((state) => ({
       request: {

--- a/apps/benchmark/app/lib/requestBarStore.ts
+++ b/apps/benchmark/app/lib/requestBarStore.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { create } from 'zustand';
-import { AssetSymbol } from './assets';
+import { ASSETS, AssetSymbol, type AssetPreset } from './assets';
 import { ChainId } from './chains';
 import {
   INITIAL_AMOUNT,
@@ -25,10 +25,7 @@ export interface AmountUpdate {
   selectedPreset?: string | null;
 }
 
-export interface RequestPreset {
-  label: string;
-  amount: string;
-}
+export type RequestPreset = AssetPreset;
 
 interface RequestBarState {
   request: RequestBarRequest;
@@ -55,7 +52,23 @@ export const useRequestBarStore = create<RequestBarState>((set) => ({
   rows: [],
   setFromChainId: (fromChainId) => set((state) => ({ request: { ...state.request, fromChainId } })),
   setToChainId: (toChainId) => set((state) => ({ request: { ...state.request, toChainId } })),
-  setAssetSymbol: (assetSymbol) => set((state) => ({ request: { ...state.request, assetSymbol } })),
+  setAssetSymbol: (assetSymbol) =>
+    set((state) => {
+      const request = { ...state.request, assetSymbol };
+      // Presets are denominated in the asset, so a selected preset must be
+      // re-applied in the new denomination. Presets are index-aligned across
+      // assets; a manually typed amount is left untouched.
+      if (state.request.selectedPreset !== null) {
+        const previousIndex = ASSETS[state.request.assetSymbol].presets.findIndex(
+          (preset) => preset.label === state.request.selectedPreset,
+        );
+        const nextPresets = ASSETS[assetSymbol].presets;
+        const next = nextPresets[previousIndex] ?? nextPresets[0];
+        request.amount = next.amount;
+        request.selectedPreset = next.label;
+      }
+      return { request };
+    }),
   setAmount: ({ amount, selectedPreset }) =>
     set((state) => ({
       request: {


### PR DESCRIPTION
The amount presets were raw USD figures ($100/$1k/$10k) applied as the input amount no matter the asset. With WETH selected, "$100" submitted 100 WETH (~$250k), and switching assets kept the stale amount.

Presets now live on `AssetMeta`, denominated per asset: USDC keeps $100/$1k/$10k, WETH gets 0.05/0.5/5. They're index-aligned, so switching assets with a preset selected re-applies the equivalent magnitude in the new denomination; manually typed amounts are left untouched. Boot defaults derive from the initial asset's first preset instead of duplicating the figures.

Verified in the browser: switching USDC→WETH with $100 selected re-labels the pills and applies 0.05. E2e suite green.

Closes EFI-1003