### PR TITLE
chore(benchmark): remove internal ticket and PR references from comments

### DIFF
--- a/apps/benchmark/app/page.tsx
+++ b/apps/benchmark/app/page.tsx
@@ -105,7 +105,7 @@ async function loadInitialChains(): Promise<NetworkAssets[]> {
 async function loadLeaderboardMetrics(): Promise<ProviderMetrics[]> {
   // Leaderboard reads "ambient" activity on the canonical route. We use the
   // initial route with no token filter so the sample reflects every asset on
-  // that pair. EFI-975 tracks aggregating across multiple top routes.
+  // that pair. A future change could aggregate across multiple top routes.
   try {
     return await withTimeout(
       fetchProviderMetrics({


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Remove internal ticket reference from benchmark leaderboard comment
<code>📝 Documentation</code> <code>🕐 Less than 5 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

Strips internal Linear ticket IDs from source comments in the benchmark app so the code is production-ready. One comment in `app/page.tsx` referenced a ticket for future multi-route leaderboard aggregation; rewritten as a self-contained note without the internal pointer. No behavior change.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Remove internal Linear ticket ID from benchmark app source comment.
• Reword note about future multi-route leaderboard aggregation without internal references.
</pre>
</details>

<details>
<summary>High-Level Assessment</summary>

<br/>

Current approach (rewrite the comment to be self-contained) is the simplest and most appropriate way to remove internal references without changing behavior.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>page.tsx</strong> <code>Rewrite leaderboard note to remove internal ticket reference</code> <code>+1/-1</code></summary>

<br/>

>Rewrite leaderboard note to remove internal ticket reference
>
><pre>
>• Replaces an internal Linear ticket ID reference in a leaderboard metrics comment with a generic, self-contained note about potential future multi-route aggregation. No runtime logic is changed.
></pre>
>
><a href='https://github.com/defi-wonderland/interop-sdk/pull/385/files#diff-095fb26eb392a9d9a0398dac6ddd98d805f48dd527257f3fbe93f8d53a8622f3'>apps/benchmark/app/page.tsx</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>