### PR TITLE
feat(cross-chain): add Superbridge schemas and API service

### DIFF
--- a/.changeset/superbridge-schemas-and-api-service.md
+++ b/.changeset/superbridge-schemas-and-api-service.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Add Superbridge schemas and API service
+
+Add `schemas.ts` mirroring the Superbridge HTTP API (routes, activity, gasless submission, tokens) and `SuperbridgeApiService`, a thin typed wrapper over `HttpClient` exposing `getRoutes`, `getActivity` and `submitGasless`. The `SuperbridgeProvider` now builds and holds the service. `getQuotes` and `getTrackingConfig` still throw `ProviderExecuteNotImplemented` until the adapters land.

--- a/packages/cross-chain/src/protocols/superbridge/index.ts
+++ b/packages/cross-chain/src/protocols/superbridge/index.ts
@@ -1,3 +1,5 @@
 export * from "./constants.js";
 export * from "./provider.js";
+export * from "./schemas.js";
+export * from "./services/index.js";
 export * from "./types.js";

--- a/packages/cross-chain/src/protocols/superbridge/provider.ts
+++ b/packages/cross-chain/src/protocols/superbridge/provider.ts
@@ -22,6 +22,7 @@ import {
     SUPERBRIDGE_PROTOCOL_NAME,
     SUPERBRIDGE_REQUEST_TIMEOUT_MS,
 } from "./constants.js";
+import { SuperbridgeApiService } from "./services/index.js";
 import { SuperbridgeConfigSchema } from "./types.js";
 
 /**
@@ -33,6 +34,7 @@ export class SuperbridgeProvider extends CrossChainProvider {
     readonly protocolName = SUPERBRIDGE_PROTOCOL_NAME;
     readonly providerId: string;
     private readonly http: HttpClient;
+    private readonly apiService: SuperbridgeApiService;
     private readonly baseUrl: string;
     private readonly apiHeaders: Record<string, string>;
     private readonly submissionModes: ReadonlySet<SubmissionMode>;
@@ -57,6 +59,7 @@ export class SuperbridgeProvider extends CrossChainProvider {
                 headers: this.apiHeaders,
                 timeout: SUPERBRIDGE_REQUEST_TIMEOUT_MS,
             });
+            this.apiService = new SuperbridgeApiService(this.http);
         } catch (error) {
             if (error instanceof ZodError) {
                 throw new ProviderConfigFailure(

--- a/packages/cross-chain/src/protocols/superbridge/schemas.ts
+++ b/packages/cross-chain/src/protocols/superbridge/schemas.ts
@@ -1,0 +1,284 @@
+import { z } from "zod";
+
+// ── Common ──────────────────────────────────────────────
+
+/** Token metadata returned across Superbridge responses. */
+export const SuperbridgeTokenSchema = z.object({
+    address: z.string(),
+    chainUid: z.string().optional(),
+    chainId: z.string(),
+    chainKeys: z.array(z.string()).optional(),
+    name: z.string().optional(),
+    decimals: z.number().int().nonnegative(),
+    symbol: z.string(),
+    logoUri: z.string().nullable().optional(),
+    usd: z.number().nullable().optional(),
+    isSpl2022: z.boolean().optional(),
+    verified: z.boolean().optional(),
+});
+
+/** EVM initiating/step transaction ready to be sent on-chain. */
+export const SuperbridgeEvmTransactionSchema = z.object({
+    type: z.literal("evm"),
+    chainUid: z.string().optional(),
+    chainId: z.string(),
+    chainKeys: z.array(z.string()).optional(),
+    from: z.string().optional(),
+    to: z.string(),
+    data: z.string(),
+    value: z.string().optional(),
+});
+
+/** EVM gasless initiating transaction carrying EIP-712 typed data to sign. */
+export const SuperbridgeEvmGaslessTransactionSchema = z.object({
+    type: z.literal("evm-gasless"),
+    chainUid: z.string().optional(),
+    chainId: z.string(),
+    chainKeys: z.array(z.string()).optional(),
+    typedData: z.string(),
+});
+
+/** Initiating transaction variants supported by the SDK (EVM only). */
+export const SuperbridgeInitiatingTransactionSchema = z.discriminatedUnion("type", [
+    SuperbridgeEvmTransactionSchema,
+    SuperbridgeEvmGaslessTransactionSchema,
+]);
+
+/** ERC-20 approval (or revoke / gas-token approval) required before bridging. */
+export const SuperbridgeTokenApprovalSchema = z.object({
+    contractAddress: z.string(),
+    tokenAddress: z.string(),
+    amount: z.string().optional(),
+    tx: SuperbridgeEvmTransactionSchema,
+});
+
+/** Display info for the underlying bridge provider of a route. */
+export const SuperbridgeProviderInfoSchema = z
+    .object({
+        name: z.string(),
+    })
+    .passthrough();
+
+/** A single fee line item. */
+export const SuperbridgeFeeItemSchema = z.object({
+    name: z.string().optional(),
+    amount: z.string(),
+    token: SuperbridgeTokenSchema.optional(),
+    exclusive: z.boolean().optional(),
+    bps: z.number().optional(),
+});
+
+/** A group of fee line items belonging to a provider. */
+export const SuperbridgeFeeGroupSchema = z.object({
+    items: z.array(SuperbridgeFeeItemSchema),
+    provider: SuperbridgeProviderInfoSchema.optional(),
+});
+
+// ── Routes ──────────────────────────────────────────────
+
+/** Body for the Superbridge POST `/v1/routes` request. */
+export const SuperbridgeRoutesRequestSchema = z.object({
+    fromChainId: z.string().optional(),
+    toChainId: z.string().optional(),
+    fromChainKey: z.string().optional(),
+    toChainKey: z.string().optional(),
+    fromTokenAddress: z.string(),
+    toTokenAddress: z.string(),
+    sender: z.string().optional(),
+    recipient: z.string().optional(),
+    amount: z.string(),
+    slippage: z.number(),
+    routeIds: z.array(z.string()).optional(),
+});
+
+/** A step inside a route quote (transaction or wait). Wait steps carry the ETA contribution. */
+export const SuperbridgeRouteStepSchema = z
+    .object({
+        type: z.string().optional(),
+        expectedDuration: z.number().optional(),
+    })
+    .passthrough();
+
+/** A successful quote from a single provider. */
+export const SuperbridgeRouteQuoteSchema = z
+    .object({
+        initiatingTransaction: SuperbridgeInitiatingTransactionSchema,
+        tokenApproval: SuperbridgeTokenApprovalSchema.optional(),
+        revokeTokenApproval: SuperbridgeTokenApprovalSchema.optional(),
+        gasTokenApproval: SuperbridgeTokenApprovalSchema.optional(),
+        fees: z.array(SuperbridgeFeeGroupSchema).optional(),
+        token: SuperbridgeTokenSchema.optional(),
+        receiveToken: SuperbridgeTokenSchema.optional(),
+        receive: z.string().optional(),
+        steps: z.array(SuperbridgeRouteStepSchema).optional(),
+        duration: z.number().optional(),
+    })
+    .passthrough();
+
+/** Per-route metadata carrying the route id and underlying bridge provider. */
+export const SuperbridgeRouteMetaSchema = z
+    .object({
+        id: z.string().optional(),
+        provider: SuperbridgeProviderInfoSchema.optional(),
+        secondaryProvider: z.unknown().optional(),
+        requiresManualSteps: z.boolean().optional(),
+    })
+    .passthrough();
+
+/** One route result: either a quote (with `initiatingTransaction`) or an error variant. */
+export const SuperbridgeRouteResultSchema = z.object({
+    result: z.unknown(),
+    meta: SuperbridgeRouteMetaSchema.optional(),
+});
+
+/** Response from the Superbridge POST `/v1/routes` endpoint. */
+export const SuperbridgeRoutesResponseSchema = z.object({
+    request: z.unknown().optional(),
+    results: z.array(SuperbridgeRouteResultSchema),
+});
+
+// ── Activity ────────────────────────────────────────────
+
+/** On-chain confirmation details for a completed transaction step. */
+export const SuperbridgeConfirmationSchema = z
+    .object({
+        timestamp: z.number().optional(),
+        transactionHash: z.string(),
+        status: z.enum(["confirmed", "reverted", "dropped"]).optional(),
+    })
+    .passthrough();
+
+/** A transaction step within an activity item. */
+export const SuperbridgeActivityTransactionStepSchema = z
+    .object({
+        type: z.literal("transaction"),
+        chainUid: z.string().optional(),
+        chainId: z.string().optional(),
+        chainKeys: z.array(z.string()).optional(),
+        action: z.unknown().optional(),
+        transactionStatus: z.enum(["done", "ready", "not-ready", "auto", "invalidated"]),
+        confirmation: SuperbridgeConfirmationSchema.optional(),
+    })
+    .passthrough();
+
+/** A wait step within an activity item. */
+export const SuperbridgeActivityWaitStepSchema = z
+    .object({
+        type: z.literal("wait"),
+        waitStatus: z.enum(["done", "in-progress", "not-started", "invalidated"]),
+        waitType: z.string().optional(),
+        startedAt: z.number().optional(),
+        expectedDuration: z.number().optional(),
+    })
+    .passthrough();
+
+/** A protocol upgrade event that can invalidate earlier steps. */
+export const SuperbridgeActivityUpgradeEventSchema = z
+    .object({
+        type: z.literal("upgrade-event"),
+    })
+    .passthrough();
+
+/** A single step inside an activity item. */
+export const SuperbridgeActivityStepSchema = z.discriminatedUnion("type", [
+    SuperbridgeActivityTransactionStepSchema,
+    SuperbridgeActivityWaitStepSchema,
+    SuperbridgeActivityUpgradeEventSchema,
+]);
+
+/** A single activity item returned by GET `/v1/activity`. */
+export const SuperbridgeActivitySchema = z
+    .object({
+        id: z.string(),
+        type: z.enum(["bridge", "crosschainswap", "swap"]).optional(),
+        provider: SuperbridgeProviderInfoSchema.optional(),
+        fromChainId: z.string().optional(),
+        toChainId: z.string().optional(),
+        from: z.string().optional(),
+        to: z.string().optional(),
+        amount: z.string().optional(),
+        receiveAmount: z.string().optional(),
+        fromToken: SuperbridgeTokenSchema.optional(),
+        toToken: SuperbridgeTokenSchema.optional(),
+        steps: z.array(SuperbridgeActivityStepSchema),
+        fees: z.array(SuperbridgeFeeGroupSchema).optional(),
+        nextCheckTimestamp: z.number().nullable().optional(),
+        escapeHatch: z.boolean().optional(),
+    })
+    .passthrough();
+
+/** Response from the Superbridge GET `/v1/activity` endpoint. */
+export const SuperbridgeActivityResponseSchema = z.array(SuperbridgeActivitySchema);
+
+// ── Submit gasless ──────────────────────────────────────
+
+/** Body for the Superbridge POST `/v1/submit_gasless` request. */
+export const SuperbridgeSubmitGaslessRequestSchema = z.object({
+    typedData: z.string(),
+    signature: z.string(),
+    id: z.string().optional(),
+    chainId: z.string().optional(),
+});
+
+/** Response from the Superbridge POST `/v1/submit_gasless` endpoint. */
+export const SuperbridgeSubmitGaslessResponseSchema = z
+    .object({
+        id: z.string().optional(),
+        txHash: z.string().optional(),
+        status: z.string().optional(),
+        message: z.string().optional(),
+    })
+    .passthrough();
+
+/** EIP-712 typed data parsed from a gasless initiating transaction. */
+export const SuperbridgeTypedDataSchema = z.object({
+    domain: z.record(z.string(), z.unknown()),
+    types: z.record(z.string(), z.array(z.object({ name: z.string(), type: z.string() }))),
+    primaryType: z.string(),
+    message: z.record(z.string(), z.unknown()),
+});
+
+/** Metadata stored on SDK signature steps created from gasless Superbridge routes. */
+export const SuperbridgeGaslessStepMetadataSchema = z.object({
+    superbridgeTypedData: z.string(),
+    superbridgeChainId: z.string().optional(),
+    superbridgeRouteId: z.string().optional(),
+});
+
+// ── Tokens (discovery) ──────────────────────────────────
+
+/** Response from the Superbridge GET `/v1/tokens` endpoint. Paginated. */
+export const SuperbridgeTokensResponseSchema = z.object({
+    tokens: z.array(SuperbridgeTokenSchema),
+    nextCursor: z.string().nullable().optional(),
+});
+
+// ── Types ───────────────────────────────────────────────
+
+export type SuperbridgeToken = z.infer<typeof SuperbridgeTokenSchema>;
+export type SuperbridgeEvmTransaction = z.infer<typeof SuperbridgeEvmTransactionSchema>;
+export type SuperbridgeEvmGaslessTransaction = z.infer<
+    typeof SuperbridgeEvmGaslessTransactionSchema
+>;
+export type SuperbridgeInitiatingTransaction = z.infer<
+    typeof SuperbridgeInitiatingTransactionSchema
+>;
+export type SuperbridgeTokenApproval = z.infer<typeof SuperbridgeTokenApprovalSchema>;
+export type SuperbridgeFeeItem = z.infer<typeof SuperbridgeFeeItemSchema>;
+export type SuperbridgeFeeGroup = z.infer<typeof SuperbridgeFeeGroupSchema>;
+export type SuperbridgeRoutesRequest = z.infer<typeof SuperbridgeRoutesRequestSchema>;
+export type SuperbridgeRouteStep = z.infer<typeof SuperbridgeRouteStepSchema>;
+export type SuperbridgeRouteQuote = z.infer<typeof SuperbridgeRouteQuoteSchema>;
+export type SuperbridgeRouteMeta = z.infer<typeof SuperbridgeRouteMetaSchema>;
+export type SuperbridgeRouteResult = z.infer<typeof SuperbridgeRouteResultSchema>;
+export type SuperbridgeRoutesResponse = z.infer<typeof SuperbridgeRoutesResponseSchema>;
+export type SuperbridgeActivityStep = z.infer<typeof SuperbridgeActivityStepSchema>;
+export type SuperbridgeActivity = z.infer<typeof SuperbridgeActivitySchema>;
+export type SuperbridgeActivityResponse = z.infer<typeof SuperbridgeActivityResponseSchema>;
+export type SuperbridgeSubmitGaslessRequest = z.infer<typeof SuperbridgeSubmitGaslessRequestSchema>;
+export type SuperbridgeSubmitGaslessResponse = z.infer<
+    typeof SuperbridgeSubmitGaslessResponseSchema
+>;
+export type SuperbridgeTokensResponse = z.infer<typeof SuperbridgeTokensResponseSchema>;
+export type SuperbridgeTypedData = z.infer<typeof SuperbridgeTypedDataSchema>;
+export type SuperbridgeGaslessStepMetadata = z.infer<typeof SuperbridgeGaslessStepMetadataSchema>;

--- a/packages/cross-chain/src/protocols/superbridge/schemas.ts
+++ b/packages/cross-chain/src/protocols/superbridge/schemas.ts
@@ -125,9 +125,19 @@ export const SuperbridgeRouteMetaSchema = z
     })
     .passthrough();
 
+/** A non-quote route result variant (`Disabled`, `AmountTooLarge`, `GenericError`, …) carrying a `type` discriminator. */
+export const SuperbridgeRouteErrorSchema = z
+    .object({
+        type: z.string(),
+        error: z.string().optional(),
+        maximum: z.string().optional(),
+        minimum: z.string().optional(),
+    })
+    .passthrough();
+
 /** One route result: either a quote (with `initiatingTransaction`) or an error variant. */
 export const SuperbridgeRouteResultSchema = z.object({
-    result: z.unknown(),
+    result: z.union([SuperbridgeRouteQuoteSchema, SuperbridgeRouteErrorSchema]),
     meta: SuperbridgeRouteMetaSchema.optional(),
 });
 
@@ -270,6 +280,7 @@ export type SuperbridgeRoutesRequest = z.infer<typeof SuperbridgeRoutesRequestSc
 export type SuperbridgeRouteStep = z.infer<typeof SuperbridgeRouteStepSchema>;
 export type SuperbridgeRouteQuote = z.infer<typeof SuperbridgeRouteQuoteSchema>;
 export type SuperbridgeRouteMeta = z.infer<typeof SuperbridgeRouteMetaSchema>;
+export type SuperbridgeRouteError = z.infer<typeof SuperbridgeRouteErrorSchema>;
 export type SuperbridgeRouteResult = z.infer<typeof SuperbridgeRouteResultSchema>;
 export type SuperbridgeRoutesResponse = z.infer<typeof SuperbridgeRoutesResponseSchema>;
 export type SuperbridgeActivityStep = z.infer<typeof SuperbridgeActivityStepSchema>;

--- a/packages/cross-chain/src/protocols/superbridge/services/SuperbridgeApiService.ts
+++ b/packages/cross-chain/src/protocols/superbridge/services/SuperbridgeApiService.ts
@@ -6,7 +6,12 @@ import type {
     SuperbridgeSubmitGaslessRequest,
     SuperbridgeSubmitGaslessResponse,
 } from "../schemas.js";
-import { HttpError, ProviderExecuteFailure, ProviderGetQuoteFailure } from "../../../internal.js";
+import {
+    HttpError,
+    ProviderExecuteFailure,
+    ProviderGetQuoteFailure,
+    ProviderGetStatusFailure,
+} from "../../../internal.js";
 import {
     SuperbridgeActivityResponseSchema,
     SuperbridgeRoutesRequestSchema,
@@ -36,10 +41,10 @@ export class SuperbridgeApiService {
     /** GET /v1/activity — fetch the activity (status, steps) for a transaction. */
     async getActivity(txHash: string): Promise<SuperbridgeActivityResponse> {
         try {
-            const response = await this.http.get(`/v1/activity?txHash=${txHash}`);
+            const response = await this.http.get("/v1/activity", { params: { txHash } });
             return SuperbridgeActivityResponseSchema.parse(response.data);
         } catch (error) {
-            this.throwProviderError(error, ProviderExecuteFailure, "Superbridge activity");
+            this.throwProviderError(error, ProviderGetStatusFailure, "Superbridge status");
         }
     }
 

--- a/packages/cross-chain/src/protocols/superbridge/services/SuperbridgeApiService.ts
+++ b/packages/cross-chain/src/protocols/superbridge/services/SuperbridgeApiService.ts
@@ -1,0 +1,104 @@
+import type { HttpClient } from "../../../internal.js";
+import type {
+    SuperbridgeActivityResponse,
+    SuperbridgeRoutesRequest,
+    SuperbridgeRoutesResponse,
+    SuperbridgeSubmitGaslessRequest,
+    SuperbridgeSubmitGaslessResponse,
+} from "../schemas.js";
+import { HttpError, ProviderExecuteFailure, ProviderGetQuoteFailure } from "../../../internal.js";
+import {
+    SuperbridgeActivityResponseSchema,
+    SuperbridgeRoutesRequestSchema,
+    SuperbridgeRoutesResponseSchema,
+    SuperbridgeSubmitGaslessRequestSchema,
+    SuperbridgeSubmitGaslessResponseSchema,
+} from "../schemas.js";
+
+/**
+ * HTTP client for the Superbridge API.
+ * Encapsulates all HTTP calls and response parsing.
+ */
+export class SuperbridgeApiService {
+    constructor(private readonly http: HttpClient) {}
+
+    /** POST /v1/routes — fetch bridging routes from Superbridge. */
+    async getRoutes(params: SuperbridgeRoutesRequest): Promise<SuperbridgeRoutesResponse> {
+        try {
+            const parsed = SuperbridgeRoutesRequestSchema.parse(params);
+            const response = await this.http.post("/v1/routes", parsed);
+            return SuperbridgeRoutesResponseSchema.parse(response.data);
+        } catch (error) {
+            this.throwProviderError(error, ProviderGetQuoteFailure, "Superbridge routes");
+        }
+    }
+
+    /** GET /v1/activity — fetch the activity (status, steps) for a transaction. */
+    async getActivity(txHash: string): Promise<SuperbridgeActivityResponse> {
+        try {
+            const response = await this.http.get(`/v1/activity?txHash=${txHash}`);
+            return SuperbridgeActivityResponseSchema.parse(response.data);
+        } catch (error) {
+            this.throwProviderError(error, ProviderExecuteFailure, "Superbridge activity");
+        }
+    }
+
+    /** POST /v1/submit_gasless — submit a signed gasless transaction. */
+    async submitGasless(
+        params: SuperbridgeSubmitGaslessRequest,
+    ): Promise<SuperbridgeSubmitGaslessResponse> {
+        try {
+            const parsed = SuperbridgeSubmitGaslessRequestSchema.parse(params);
+            const response = await this.http.post("/v1/submit_gasless", parsed);
+            return SuperbridgeSubmitGaslessResponseSchema.parse(response.data);
+        } catch (error) {
+            this.throwProviderError(
+                error,
+                ProviderExecuteFailure,
+                "Superbridge gasless submission",
+            );
+        }
+    }
+
+    /** Wrap any caught error into the appropriate provider failure and re-throw. */
+    private throwProviderError(
+        error: unknown,
+        ErrorClass: new (message: string, cause?: string, stack?: string) => Error,
+        operation: string,
+    ): never {
+        if (error instanceof HttpError && error.status === 429) {
+            throw new ErrorClass(
+                `${operation} rate limit exceeded`,
+                `Too many requests (429) for ${operation}`,
+                error.stack,
+            );
+        }
+
+        const cause =
+            error instanceof HttpError
+                ? (this.extractApiMessage(error) ?? error.message)
+                : error instanceof Error
+                  ? error.message
+                  : String(error);
+
+        throw new ErrorClass(
+            `Failed to get ${operation}`,
+            cause,
+            error instanceof Error ? error.stack : undefined,
+        );
+    }
+
+    /** Try to read the `message` field from a Superbridge API error response body. */
+    private extractApiMessage(error: HttpError): string | undefined {
+        const data: unknown = error.data;
+        if (
+            data !== null &&
+            typeof data === "object" &&
+            "message" in data &&
+            typeof data.message === "string"
+        ) {
+            return data.message;
+        }
+        return undefined;
+    }
+}

--- a/packages/cross-chain/src/protocols/superbridge/services/index.ts
+++ b/packages/cross-chain/src/protocols/superbridge/services/index.ts
@@ -1,0 +1,1 @@
+export { SuperbridgeApiService } from "./SuperbridgeApiService.js";

--- a/packages/cross-chain/test/protocols/superbridge/SuperbridgeApiService.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/SuperbridgeApiService.spec.ts
@@ -5,8 +5,8 @@ import type {
     HttpResponse,
 } from "../../../src/core/interfaces/httpClient.interface.js";
 import { HttpError } from "../../../src/core/errors/HttpError.exception.js";
-import { ProviderExecuteFailure } from "../../../src/core/errors/ProviderExecuteFailure.exception.js";
 import { ProviderGetQuoteFailure } from "../../../src/core/errors/ProviderGetQuoteFailure.exception.js";
+import { ProviderGetStatusFailure } from "../../../src/core/errors/ProviderGetStatusFailure.exception.js";
 import { SuperbridgeApiService } from "../../../src/protocols/superbridge/services/SuperbridgeApiService.js";
 
 const VALID_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
@@ -71,13 +71,13 @@ describe("SuperbridgeApiService", () => {
             const result = await service.getActivity("0xabc");
 
             expect(result).toHaveLength(1);
-            expect(mockGet).toHaveBeenCalledWith("/v1/activity?txHash=0xabc");
+            expect(mockGet).toHaveBeenCalledWith("/v1/activity", { params: { txHash: "0xabc" } });
         });
 
-        it("wraps errors with ProviderExecuteFailure", async () => {
+        it("wraps errors with ProviderGetStatusFailure", async () => {
             mockGet.mockRejectedValue(new HttpError("bad", "https://x", 500, { message: "boom" }));
 
-            await expect(service.getActivity("0xabc")).rejects.toThrow(ProviderExecuteFailure);
+            await expect(service.getActivity("0xabc")).rejects.toThrow(ProviderGetStatusFailure);
         });
     });
 

--- a/packages/cross-chain/test/protocols/superbridge/SuperbridgeApiService.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/SuperbridgeApiService.spec.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+    HttpClient,
+    HttpResponse,
+} from "../../../src/core/interfaces/httpClient.interface.js";
+import { HttpError } from "../../../src/core/errors/HttpError.exception.js";
+import { ProviderExecuteFailure } from "../../../src/core/errors/ProviderExecuteFailure.exception.js";
+import { ProviderGetQuoteFailure } from "../../../src/core/errors/ProviderGetQuoteFailure.exception.js";
+import { SuperbridgeApiService } from "../../../src/protocols/superbridge/services/SuperbridgeApiService.js";
+
+const VALID_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+
+function mockOk<T>(data: T): HttpResponse<T> {
+    return { status: 200, data, headers: new Headers() };
+}
+
+describe("SuperbridgeApiService", () => {
+    let service: SuperbridgeApiService;
+    let mockGet: ReturnType<typeof vi.fn>;
+    let mockPost: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGet = vi.fn();
+        mockPost = vi.fn();
+        const http: HttpClient = { get: mockGet, post: mockPost, request: vi.fn() };
+        service = new SuperbridgeApiService(http);
+    });
+
+    describe("getRoutes()", () => {
+        it("validates the request and returns the parsed response", async () => {
+            mockPost.mockResolvedValue(mockOk({ results: [] }));
+
+            const result = await service.getRoutes({
+                fromTokenAddress: VALID_ADDRESS,
+                toTokenAddress: VALID_ADDRESS,
+                amount: "1000",
+                slippage: 0,
+            });
+
+            expect(result.results).toEqual([]);
+            expect(mockPost).toHaveBeenCalledWith(
+                "/v1/routes",
+                expect.objectContaining({ amount: "1000" }),
+            );
+        });
+
+        it("wraps rate limit errors with ProviderGetQuoteFailure", async () => {
+            mockPost.mockRejectedValue(new HttpError("rate", "https://x", 429, {}));
+
+            await expect(
+                service.getRoutes({
+                    fromTokenAddress: VALID_ADDRESS,
+                    toTokenAddress: VALID_ADDRESS,
+                    amount: "1000",
+                    slippage: 0,
+                }),
+            ).rejects.toThrow(ProviderGetQuoteFailure);
+        });
+    });
+
+    describe("getActivity()", () => {
+        it("requests the activity by tx hash and returns the parsed response", async () => {
+            mockGet.mockResolvedValue(
+                mockOk([
+                    { id: "bridge-1", steps: [{ type: "transaction", transactionStatus: "done" }] },
+                ]),
+            );
+
+            const result = await service.getActivity("0xabc");
+
+            expect(result).toHaveLength(1);
+            expect(mockGet).toHaveBeenCalledWith("/v1/activity?txHash=0xabc");
+        });
+
+        it("wraps errors with ProviderExecuteFailure", async () => {
+            mockGet.mockRejectedValue(new HttpError("bad", "https://x", 500, { message: "boom" }));
+
+            await expect(service.getActivity("0xabc")).rejects.toThrow(ProviderExecuteFailure);
+        });
+    });
+
+    describe("submitGasless()", () => {
+        it("returns the parsed submission response", async () => {
+            mockPost.mockResolvedValue(mockOk({ txHash: "0xabc", status: "submitted" }));
+
+            const result = await service.submitGasless({ typedData: "{}", signature: "0xsig" });
+
+            expect(result.txHash).toBe("0xabc");
+        });
+    });
+});

--- a/packages/cross-chain/test/protocols/superbridge/schemas.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/schemas.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+    SuperbridgeActivityResponseSchema,
+    SuperbridgeRoutesRequestSchema,
+    SuperbridgeRoutesResponseSchema,
+    SuperbridgeSubmitGaslessResponseSchema,
+    SuperbridgeTokensResponseSchema,
+} from "../../../src/protocols/superbridge/schemas.js";
+
+const ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+
+describe("SuperbridgeRoutesRequestSchema", () => {
+    it("parses a valid routes request", () => {
+        const request = {
+            fromChainId: "1",
+            toChainId: "8453",
+            fromTokenAddress: ADDRESS,
+            toTokenAddress: ADDRESS,
+            amount: "1000000",
+            slippage: 0,
+        } satisfies z.input<typeof SuperbridgeRoutesRequestSchema>;
+
+        const parsed = SuperbridgeRoutesRequestSchema.parse(request);
+
+        expect(parsed.amount).toBe("1000000");
+        expect(parsed.slippage).toBe(0);
+    });
+
+    it("rejects a request missing the amount", () => {
+        expect(() =>
+            SuperbridgeRoutesRequestSchema.parse({
+                fromTokenAddress: ADDRESS,
+                toTokenAddress: ADDRESS,
+                slippage: 0,
+            }),
+        ).toThrow();
+    });
+});
+
+describe("SuperbridgeRoutesResponseSchema", () => {
+    it("parses a response with a quote result and an error result", () => {
+        const response = {
+            results: [
+                {
+                    meta: { id: "op-deposit-cdm", provider: { name: "optimism" } },
+                    result: {
+                        initiatingTransaction: {
+                            type: "evm",
+                            chainId: "1",
+                            to: ADDRESS,
+                            data: "0xfeed",
+                        },
+                        token: { address: ADDRESS, chainId: "1", symbol: "USDC", decimals: 6 },
+                        receiveToken: {
+                            address: ADDRESS,
+                            chainId: "8453",
+                            symbol: "USDC",
+                            decimals: 6,
+                        },
+                        receive: "995",
+                        duration: 120,
+                    },
+                },
+                { result: { code: "AMOUNT_TOO_LARGE" } },
+            ],
+        } satisfies z.input<typeof SuperbridgeRoutesResponseSchema>;
+
+        const parsed = SuperbridgeRoutesResponseSchema.parse(response);
+
+        expect(parsed.results).toHaveLength(2);
+        expect(parsed.results[0]!.meta?.id).toBe("op-deposit-cdm");
+    });
+});
+
+describe("SuperbridgeActivityResponseSchema", () => {
+    it("parses an activity item with transaction and wait steps", () => {
+        const activity = [
+            {
+                id: "bridge-1",
+                type: "bridge",
+                fromChainId: "1",
+                toChainId: "8453",
+                steps: [
+                    {
+                        type: "transaction",
+                        transactionStatus: "done",
+                        confirmation: { transactionHash: "0xabc", status: "confirmed" },
+                    },
+                    {
+                        type: "wait",
+                        waitStatus: "in-progress",
+                        waitType: "op-challenge-period",
+                        expectedDuration: 604800000,
+                    },
+                ],
+            },
+        ] satisfies z.input<typeof SuperbridgeActivityResponseSchema>;
+
+        const [parsed] = SuperbridgeActivityResponseSchema.parse(activity);
+
+        expect(parsed!.id).toBe("bridge-1");
+        expect(parsed!.steps).toHaveLength(2);
+    });
+
+    it("rejects a transaction step with an unknown status", () => {
+        expect(() =>
+            SuperbridgeActivityResponseSchema.parse([
+                { id: "bridge-1", steps: [{ type: "transaction", transactionStatus: "bogus" }] },
+            ]),
+        ).toThrow();
+    });
+});
+
+describe("SuperbridgeSubmitGaslessResponseSchema", () => {
+    it("parses a submission response", () => {
+        const parsed = SuperbridgeSubmitGaslessResponseSchema.parse({
+            txHash: "0xabc",
+            status: "submitted",
+        });
+
+        expect(parsed.txHash).toBe("0xabc");
+    });
+});
+
+describe("SuperbridgeTokensResponseSchema", () => {
+    it("parses a paginated tokens page", () => {
+        const page = {
+            tokens: [{ address: ADDRESS, chainId: "1", symbol: "USDC", decimals: 6 }],
+            nextCursor: "next-page",
+        } satisfies z.input<typeof SuperbridgeTokensResponseSchema>;
+
+        const parsed = SuperbridgeTokensResponseSchema.parse(page);
+
+        expect(parsed.tokens).toHaveLength(1);
+        expect(parsed.nextCursor).toBe("next-page");
+    });
+
+    it("accepts a null cursor on the final page", () => {
+        const parsed = SuperbridgeTokensResponseSchema.parse({ tokens: [], nextCursor: null });
+
+        expect(parsed.nextCursor).toBeNull();
+    });
+});

--- a/packages/cross-chain/test/protocols/superbridge/schemas.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/schemas.spec.ts
@@ -63,7 +63,7 @@ describe("SuperbridgeRoutesResponseSchema", () => {
                         duration: 120,
                     },
                 },
-                { result: { code: "AMOUNT_TOO_LARGE" } },
+                { result: { type: "AmountTooLarge", maximum: "1000000" } },
             ],
         } satisfies z.input<typeof SuperbridgeRoutesResponseSchema>;
 
@@ -71,6 +71,7 @@ describe("SuperbridgeRoutesResponseSchema", () => {
 
         expect(parsed.results).toHaveLength(2);
         expect(parsed.results[0]!.meta?.id).toBe("op-deposit-cdm");
+        expect(parsed.results[1]!.result).toMatchObject({ type: "AmountTooLarge" });
     });
 });
 


### PR DESCRIPTION
Stacks on the Superbridge scaffold branch (`efi-976-...`), so review that one first. Implements EFI-996.

Adds the Zod schemas that mirror the Superbridge HTTP API and a thin client over them — the foundation the adapters will build on.

**What's here**
- `schemas.ts`: request/response shapes for routes, activity, gasless submission, and tokens.
- `SuperbridgeApiService`: typed wrapper over `HttpClient` with `getRoutes`, `getActivity`, and `submitGasless`.
- `SuperbridgeProvider` now builds and holds the service.
- Unit tests for schema parsing and for the service (mocked HTTP).

`getQuotes` and `getTrackingConfig` still throw `ProviderExecuteNotImplemented` — the adapters and the build-tx (`get_step_transaction`) path are out of scope here and come in their own cards.
