### PR TITLE
fix(benchmark): freeze quote race row order while loading

### DIFF
--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -11,3 +11,7 @@ pnpm --filter benchmark dev
 ```
 
 Open http://localhost:3000.
+
+## Caching
+
+Live quotes (section 01) are never cached, every run hits the providers fresh. The historical sections are cached: the leaderboard and the head-to-head's first paint come from the page render (revalidated hourly), while changing the head-to-head route refetches through a 60s-cached API route. So the canonical route can show slightly different freshness on first paint versus after re-selecting it.

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -14,4 +14,4 @@ Open http://localhost:3000.
 
 ## Caching
 
-Live quotes (section 01) are never cached, every run hits the providers fresh. The leaderboard (section 02) is cached via the page render (revalidated hourly).
+The whole page is server-rendered with hourly ISR (`revalidate=3600`), so each section's first paint can be up to an hour old. The quote race (section 01) then re-runs client-side on demand and fetches fresh quotes; the leaderboard (section 02) is not refetched after load.

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -14,4 +14,4 @@ Open http://localhost:3000.
 
 ## Caching
 
-Live quotes (section 01) are never cached, every run hits the providers fresh. The historical sections are cached: the leaderboard and the head-to-head's first paint come from the page render (revalidated hourly), while changing the head-to-head route refetches through a 60s-cached API route. So the canonical route can show slightly different freshness on first paint versus after re-selecting it.
+Live quotes (section 01) are never cached, every run hits the providers fresh. The leaderboard (section 02) is cached via the page render (revalidated hourly).

--- a/apps/benchmark/app/components/race-table/RaceTable.tsx
+++ b/apps/benchmark/app/components/race-table/RaceTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useReducedMotion } from 'framer-motion';
 import { BenchmarkTable } from '../BenchmarkTable';
 import { RaceTableRow } from './RaceTableRow';
@@ -11,11 +11,16 @@ import type { NetworkAssets } from '@wonderland/interop-cross-chain';
 import { useRequestBarStore } from '~/lib/requestBarStore';
 
 // Re-sorts rows to match a known provider order. Used to hold the last settled
-// order steady under the loading skeletons.
+// order steady under the loading skeletons. A provider missing from the known
+// order sorts after the known ones (rather than jumping to the top) so a
+// changed provider set doesn't reshuffle the frozen rows.
 function orderByProviderIds(rows: RaceRow[], providerIds: string[]): RaceRow[] {
   if (providerIds.length === 0) return rows;
   const rank = new Map(providerIds.map((id, index) => [id, index]));
-  return [...rows].sort((left, right) => (rank.get(left.provider.id) ?? 0) - (rank.get(right.provider.id) ?? 0));
+  const fallback = providerIds.length;
+  return [...rows].sort(
+    (left, right) => (rank.get(left.provider.id) ?? fallback) - (rank.get(right.provider.id) ?? fallback),
+  );
 }
 
 interface RaceTableProps {
@@ -36,12 +41,16 @@ export function RaceTable({ initialRows, initialChains }: RaceTableProps) {
   // them to canonical order and then back to winner-first once they settle,
   // which reads as the rows jumping around. Hold the last settled order under
   // the skeletons; only the settled result reorders, once.
-  const rows = useMemo(() => {
-    if (isLoading) return orderByProviderIds(rawRows, stableOrder.current);
-    const ordered = orderRaceRows(rawRows);
-    stableOrder.current = ordered.map((row) => row.provider.id);
-    return ordered;
-  }, [rawRows, isLoading]);
+  const rows = useMemo(
+    () => (isLoading ? orderByProviderIds(rawRows, stableOrder.current) : orderRaceRows(rawRows)),
+    [rawRows, isLoading],
+  );
+
+  // Remember the settled order after commit (not during render) so the next
+  // loading phase can hold it steady without a render-phase side effect.
+  useEffect(() => {
+    if (!isLoading) stableOrder.current = rows.map((row) => row.provider.id);
+  }, [isLoading, rows]);
 
   const winnerProviderId = useMemo(() => findBestProvider(rows, 'output'), [rows]);
   const firstProviderId = useMemo(() => findBestProvider(rows, 'latency'), [rows]);

--- a/apps/benchmark/app/components/race-table/RaceTable.tsx
+++ b/apps/benchmark/app/components/race-table/RaceTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useReducedMotion } from 'framer-motion';
 import { BenchmarkTable } from '../BenchmarkTable';
 import { RaceTableRow } from './RaceTableRow';
@@ -9,6 +9,14 @@ import { findBestProvider, orderRaceRows } from './raceRows';
 import type { RaceRow } from './types';
 import type { NetworkAssets } from '@wonderland/interop-cross-chain';
 import { useRequestBarStore } from '~/lib/requestBarStore';
+
+// Re-sorts rows to match a known provider order. Used to hold the last settled
+// order steady under the loading skeletons.
+function orderByProviderIds(rows: RaceRow[], providerIds: string[]): RaceRow[] {
+  if (providerIds.length === 0) return rows;
+  const rank = new Map(providerIds.map((id, index) => [id, index]));
+  return [...rows].sort((left, right) => (rank.get(left.provider.id) ?? 0) - (rank.get(right.provider.id) ?? 0));
+}
 
 interface RaceTableProps {
   initialRows: RaceRow[];
@@ -21,7 +29,19 @@ export function RaceTable({ initialRows, initialChains }: RaceTableProps) {
   const reduceMotion = useReducedMotion();
 
   const rawRows = storeRows.length > 0 ? storeRows : initialRows;
-  const rows = useMemo(() => orderRaceRows(rawRows), [rawRows]);
+  const isLoading = rawRows.some((row) => row.status === 'querying');
+  const stableOrder = useRef<string[]>([]);
+
+  // While any row is loading, freeze the order: re-sorting querying rows snaps
+  // them to canonical order and then back to winner-first once they settle,
+  // which reads as the rows jumping around. Hold the last settled order under
+  // the skeletons; only the settled result reorders, once.
+  const rows = useMemo(() => {
+    if (isLoading) return orderByProviderIds(rawRows, stableOrder.current);
+    const ordered = orderRaceRows(rawRows);
+    stableOrder.current = ordered.map((row) => row.provider.id);
+    return ordered;
+  }, [rawRows, isLoading]);
 
   const winnerProviderId = useMemo(() => findBestProvider(rows, 'output'), [rows]);
   const firstProviderId = useMemo(() => findBestProvider(rows, 'latency'), [rows]);


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix quote race row reordering by freezing last settled order during loading
<code>🐞 Bug fix</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

Hitting re-run on the live quote race made the rows reshuffle twice: first they snapped to canonical order (every row becomes `querying`, so `orderRaceRows` falls back to provider index), then back to winner-first once the new quotes settled. With the framer-motion layout animation, the rows visibly jumped back and forth.

Now the order is frozen while any row is loading. The table holds the last settled order under the skeletons (tracked in a ref so it survives even the first re-run, when the store starts empty), and only the settled result reorders, once. Skeleton rows carry no data, so nothing visible changes order, the data appears already in its final order.

Verified in the browser: settled order `[relay, bungee, across, lifi]` stays identical through the loading phase instead of resetting to canonical.

Closes EFI-1005

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Prevents race table rows from reshuffling while quotes are re-running and loading.
• Preserves the last settled provider order under skeleton rows until results settle.
• Updates ordering logic to only re-rank rows once, after all rows finish querying.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Request bar store"] --> B["RaceTable"] --> C{Loading?}
  C -->|"yes"| D["orderByProviderIds"] --> F["BenchmarkTable"] --> G["RaceTableRow"]
  C -->|"no"| E["orderRaceRows"] --> H["Update stableOrder ref"] --> F
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Disable layout animation while loading</b></summary>

- ➕ Eliminates visible jumping without changing sort semantics
- ➕ Potentially simpler than maintaining a stable order ref
- ➖ Still reorders data under the hood; can feel inconsistent when loading ends
- ➖ Reduces UI polish and may mask other ordering issues

</details>

<details>
<summary><b>2. Persist last settled order in the store (instead of a component ref)</b></summary>

- ➕ Single source of truth; stable ordering shared across components/views
- ➕ Survives component unmounts/remounts and navigation
- ➖ More cross-cutting change to state management
- ➖ Adds store complexity for a localized UI concern

</details>

**Recommendation:** The current approach (freeze order while any row is querying, using a ref to hold last settled provider IDs) is a good localized fix: it avoids double-reordering, preserves user-perceived stability, and keeps changes contained to RaceTable. Consider the store-level persistence only if multiple components need the same stable ordering semantics.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>RaceTable.tsx</strong> <code>Freeze row order during quote re-runs using last settled provider ordering</code> <code>+22/-2</code></summary>

<br/>

>Freeze row order during quote re-runs using last settled provider ordering
>
><pre>
>• Adds a provider-ID-based ordering helper and uses a ref to persist the last settled row order. While any row is querying, the table reuses the stored order to keep skeleton rows stable; once settled, it reorders normally and updates the stored order.
></pre>
>
><a href='https://github.com/defi-wonderland/interop-sdk/pull/387/files#diff-77ffefadee31d18756d094122b50d275324703d8b14ac5f83092d1c3696a5af7'>apps/benchmark/app/components/race-table/RaceTable.tsx</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>