### PR TITLE
fix(benchmark): remove mock LIVE/updated indicator from navbar

### DIFF
--- a/apps/benchmark/app/components/TopNav.tsx
+++ b/apps/benchmark/app/components/TopNav.tsx
@@ -1,8 +1,4 @@
 import Link from 'next/link';
-import { Label } from './Label';
-
-// TODO(pr-2): replace with live cache freshness from server revalidation.
-const MOCK_LAST_UPDATED = 'updated 14s ago';
 
 export function TopNav() {
   return (
@@ -21,13 +17,6 @@ export function TopNav() {
             <span>bench</span>
           </Link>
         </h1>
-        <div className='flex items-center gap-2.5'>
-          <Label className='inline-flex items-center gap-2 border border-border px-2.5 py-1'>
-            <span className='inline-block h-1.5 w-1.5 rounded-full bg-accent' aria-hidden='true' />
-            <span className='font-mono text-caption font-medium tracking-widest text-text-primary'>LIVE</span>
-          </Label>
-          <Label className='hidden font-mono text-label text-text-muted sm:inline'>{MOCK_LAST_UPDATED}</Label>
-        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix navbar by removing mock LIVE/updated indicator from benchmark TopNav
<code>🐞 Bug fix</code> <code>🕐 Less than 5 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

The navbar showed a `LIVE` badge and a hardcoded `updated 14s ago` label (`MOCK_LAST_UPDATED`, with a TODO to wire real freshness). The timestamp was fake and the LIVE badge implied real-time data the site doesn't have, the historical sections are cached. Removed the whole indicator; the navbar keeps just the `interop · bench` logo.

Swept the rest of the app for leftover mocked data: the only other user-visible mock is the head-to-head section, already replaced with live data in #354. Everything else (race quotes, leaderboard, head-to-head once wired) is real data; the remaining placeholders (dummy quoting address, em-dash for missing values) are legit.

Closes EFI-1006

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Remove misleading LIVE badge from benchmark navbar
• Drop hardcoded “updated 14s ago” freshness label and related mock constant
• Keep navbar focused on the interop · bench logo only
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  U([User]) --> N["TopNav"] --> L["Next.js Link"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Wire real cache freshness into navbar</b></summary>

- ➕ Communicates data staleness accurately when backed by real timestamps
- ➕ Can build trust for cached historical sections
- ➖ Requires server-side freshness source and consistent revalidation semantics
- ➖ Adds ongoing maintenance and risk of displaying incorrect freshness

</details>

<details>
<summary><b>2. Hide indicator behind a feature flag</b></summary>

- ➕ Allows gradual rollout once freshness is implemented
- ➕ Keeps the UI option available without misleading production users
- ➖ Adds feature-flag complexity for a small UI element
- ➖ Still requires follow-up work to ever be meaningful

</details>

**Recommendation:** Removing the indicator is the best near-term choice because the existing LIVE/freshness UI was explicitly mocked and misleading. Reintroduce a freshness indicator only once it can be driven by a reliable server-derived timestamp/revalidation signal (optionally guarded by a feature flag during rollout).

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>TopNav.tsx</strong> <code>Remove mock LIVE badge and hardcoded last-updated label</code> <code>+0/-11</code></summary>

<br/>

>Remove mock LIVE badge and hardcoded last-updated label
>
><pre>
>• Deletes the Label import, the MOCK_LAST_UPDATED constant, and the navbar UI that displayed a LIVE badge and fake freshness timestamp. The TopNav now renders only the logo/link header without the status indicator block.
></pre>
>
><a href='https://github.com/defi-wonderland/interop-sdk/pull/388/files#diff-804bd16c8c3e6089ee7dc04c58547f389a1c482834ca07d3ed832fb209e87e66'>apps/benchmark/app/components/TopNav.tsx</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>