### PR TITLE
feat(cross-chain): implement Superbridge getQuotes for the user-transaction route

### DIFF
--- a/.changeset/superbridge-user-transaction-quotes.md
+++ b/.changeset/superbridge-user-transaction-quotes.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Implement Superbridge getQuotes for the user-transaction route
+
+Add the quote adapters (`quoteRequestAdapter`, `quoteResponseAdapter`) that map an SDK `QuoteRequest` to a Superbridge `/v1/routes` request and the response back to `Quote[]`, filtering routes to the canonical native bridges and keeping only the quotes whose initiating transaction matches an enabled submission mode. `SuperbridgeProvider.getQuotes` now wires both adapters and wraps failures in `ProviderGetQuoteFailure`. Submission and tracking still throw until later issues.

--- a/packages/cross-chain/src/protocols/superbridge/adapters/index.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/index.ts
@@ -1,0 +1,2 @@
+export { adaptQuoteRequest } from "./quoteRequestAdapter.js";
+export { adaptQuoteResponse } from "./quoteResponseAdapter.js";

--- a/packages/cross-chain/src/protocols/superbridge/adapters/quoteRequestAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/quoteRequestAdapter.ts
@@ -1,0 +1,41 @@
+import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
+import type { SuperbridgeRoutesRequest } from "../schemas.js";
+import {
+    NATIVE_ZERO_ADDRESS,
+    ProviderGetQuoteFailure,
+    withNativePlaceholder,
+} from "../../../internal.js";
+import { SUPERBRIDGE_CANONICAL_ROUTE_IDS, SUPERBRIDGE_DEFAULT_SLIPPAGE } from "../constants.js";
+import { SuperbridgeRoutesRequestSchema } from "../schemas.js";
+
+/**
+ * Convert an SDK QuoteRequest into a Superbridge `/v1/routes` request body.
+ *
+ * @throws {ProviderGetQuoteFailure} When the required input amount is missing.
+ */
+export function adaptQuoteRequest(params: QuoteRequest): SuperbridgeRoutesRequest {
+    const amount = params.input.amount;
+    if (!amount) {
+        throw new ProviderGetQuoteFailure("Superbridge requires input.amount to be defined");
+    }
+
+    return SuperbridgeRoutesRequestSchema.parse({
+        fromChainId: String(params.input.chainId),
+        toChainId: String(params.output.chainId),
+        fromTokenAddress: withNativePlaceholder(
+            params.input.assetAddress,
+            "eip155",
+            NATIVE_ZERO_ADDRESS,
+        ),
+        toTokenAddress: withNativePlaceholder(
+            params.output.assetAddress,
+            "eip155",
+            NATIVE_ZERO_ADDRESS,
+        ),
+        amount,
+        sender: params.user,
+        recipient: params.output.recipient ?? params.user,
+        slippage: SUPERBRIDGE_DEFAULT_SLIPPAGE,
+        routeIds: [...SUPERBRIDGE_CANONICAL_ROUTE_IDS],
+    });
+}

--- a/packages/cross-chain/src/protocols/superbridge/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/quoteResponseAdapter.ts
@@ -1,0 +1,208 @@
+import type { SignatureStep, Step, TransactionStep } from "../../../core/schemas/order.js";
+import type { SubmissionMode } from "../../../core/schemas/providerConfig.js";
+import type { Quote, QuoteFeeEntry, QuoteFees } from "../../../core/schemas/quote.js";
+import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
+import type {
+    SuperbridgeEvmGaslessTransaction,
+    SuperbridgeFeeGroup,
+    SuperbridgeFeeItem,
+    SuperbridgeRouteMeta,
+    SuperbridgeRouteQuote,
+    SuperbridgeRoutesResponse,
+    SuperbridgeRouteStep,
+    SuperbridgeTokenApproval,
+} from "../schemas.js";
+import { SuperbridgeRouteQuoteSchema, SuperbridgeTypedDataSchema } from "../schemas.js";
+
+const MODE_BY_TX_TYPE = {
+    evm: "user-transaction",
+    "evm-gasless": "gasless",
+} as const;
+
+/**
+ * Build SDK Quotes from a Superbridge `/v1/routes` response.
+ *
+ * Keeps only successful quotes (those with an `initiatingTransaction`) whose
+ * initiating transaction type matches an enabled submission mode.
+ */
+export function adaptQuoteResponse(
+    response: SuperbridgeRoutesResponse,
+    providerId: string,
+    params: QuoteRequest,
+    modes: ReadonlySet<SubmissionMode>,
+): Quote[] {
+    const quotes: Quote[] = [];
+    for (const result of response.results) {
+        const parsed = SuperbridgeRouteQuoteSchema.safeParse(result.result);
+        if (!parsed.success) continue;
+        const quote = adaptRouteQuote(parsed.data, result.meta, providerId, params, modes);
+        if (quote) quotes.push(quote);
+    }
+    return quotes;
+}
+
+function adaptRouteQuote(
+    route: SuperbridgeRouteQuote,
+    meta: SuperbridgeRouteMeta | undefined,
+    providerId: string,
+    params: QuoteRequest,
+    modes: ReadonlySet<SubmissionMode>,
+): Quote | null {
+    if (!modes.has(MODE_BY_TX_TYPE[route.initiatingTransaction.type])) return null;
+
+    const routeId = meta?.id;
+    const mainStep = buildMainStep(route, routeId);
+    if (!mainStep) return null;
+
+    return {
+        order: { steps: [...buildApprovalSteps(route), mainStep] },
+        preview: buildPreview(route, params),
+        eta: route.duration ?? sumWaitSeconds(route.steps),
+        partialFill: false,
+        provider: providerId,
+        fees: adaptFees(route.fees),
+        metadata: {
+            superbridgeProvider: meta?.provider?.name,
+            superbridgeRouteId: routeId,
+        },
+    };
+}
+
+/** Total wait time across a quote's wait steps, in seconds (used as the ETA). */
+function sumWaitSeconds(steps: SuperbridgeRouteStep[] | undefined): number | undefined {
+    if (!steps) return undefined;
+    const totalMs = steps.reduce(
+        (acc, step) => acc + (step.type === "wait" ? (step.expectedDuration ?? 0) : 0),
+        0,
+    );
+    return totalMs > 0 ? Math.round(totalMs / 1000) : undefined;
+}
+
+function buildMainStep(route: SuperbridgeRouteQuote, routeId: string | undefined): Step | null {
+    const tx = route.initiatingTransaction;
+    if (tx.type === "evm") {
+        return {
+            kind: "transaction",
+            chainId: Number(tx.chainId),
+            description: "Submit transaction to Superbridge",
+            transaction: { to: tx.to, data: tx.data, value: tx.value },
+        };
+    }
+    return buildSignatureStep(tx, routeId);
+}
+
+function buildSignatureStep(
+    tx: SuperbridgeEvmGaslessTransaction,
+    routeId: string | undefined,
+): SignatureStep | null {
+    const parsed = SuperbridgeTypedDataSchema.safeParse(safeJsonParse(tx.typedData));
+    if (!parsed.success) return null;
+
+    return {
+        kind: "signature",
+        chainId: Number(tx.chainId),
+        description: "Sign gasless authorization for Superbridge",
+        signaturePayload: {
+            signatureType: "eip712",
+            domain: parsed.data.domain,
+            primaryType: parsed.data.primaryType,
+            types: parsed.data.types,
+            message: parsed.data.message,
+        },
+        metadata: {
+            superbridgeTypedData: tx.typedData,
+            superbridgeChainId: tx.chainId,
+            superbridgeRouteId: routeId,
+        },
+    };
+}
+
+function buildApprovalSteps(route: SuperbridgeRouteQuote): TransactionStep[] {
+    const steps: TransactionStep[] = [];
+    if (route.revokeTokenApproval) {
+        steps.push(toApprovalStep(route.revokeTokenApproval, "Revoke existing token allowance"));
+    }
+    if (route.tokenApproval) {
+        steps.push(toApprovalStep(route.tokenApproval, "Approve token for Superbridge"));
+    }
+    if (route.gasTokenApproval) {
+        steps.push(toApprovalStep(route.gasTokenApproval, "Approve gas token for Superbridge"));
+    }
+    return steps;
+}
+
+function toApprovalStep(approval: SuperbridgeTokenApproval, description: string): TransactionStep {
+    return {
+        kind: "transaction",
+        category: "approval",
+        chainId: Number(approval.tx.chainId),
+        description,
+        transaction: {
+            to: approval.tx.to,
+            data: approval.tx.data,
+            value: approval.tx.value,
+        },
+    };
+}
+
+function buildPreview(route: SuperbridgeRouteQuote, params: QuoteRequest): Quote["preview"] {
+    return {
+        inputs: [
+            {
+                chainId: params.input.chainId,
+                accountAddress: params.user,
+                assetAddress: route.token?.address ?? params.input.assetAddress,
+                amount: params.input.amount ?? "0",
+            },
+        ],
+        outputs: [
+            {
+                chainId: params.output.chainId,
+                accountAddress: params.output.recipient ?? params.user,
+                assetAddress: route.receiveToken?.address ?? params.output.assetAddress,
+                amount: route.receive ?? params.output.amount ?? "0",
+            },
+        ],
+    };
+}
+
+function safeJsonParse(value: string): unknown {
+    try {
+        return JSON.parse(value);
+    } catch {
+        return undefined;
+    }
+}
+
+/** Map Superbridge fee groups to the SDK-standard QuoteFees shape. */
+function adaptFees(feeGroups: SuperbridgeFeeGroup[] | undefined): QuoteFees | undefined {
+    const items = (feeGroups ?? []).flatMap((group) => group.items);
+    if (items.length === 0) return undefined;
+
+    const gasItem = items.find(isGasFee);
+    const bridgeItem = items.find((item) => !isGasFee(item));
+
+    const fees: QuoteFees = {};
+    if (gasItem) fees.originGas = toFeeEntry(gasItem);
+    if (bridgeItem) fees.bridgeFee = toFeeEntry(bridgeItem);
+
+    if (!fees.originGas && !fees.bridgeFee) return undefined;
+    return fees;
+}
+
+function isGasFee(item: SuperbridgeFeeItem): boolean {
+    return (item.name ?? "").toLowerCase().includes("gas");
+}
+
+function toFeeEntry(item: SuperbridgeFeeItem): QuoteFeeEntry {
+    return {
+        amount: item.amount,
+        token: item.token
+            ? {
+                  symbol: item.token.symbol,
+                  decimals: item.token.decimals,
+                  address: item.token.address,
+              }
+            : undefined,
+    };
+}

--- a/packages/cross-chain/src/protocols/superbridge/constants.ts
+++ b/packages/cross-chain/src/protocols/superbridge/constants.ts
@@ -9,3 +9,27 @@ export const SUPERBRIDGE_DEFAULT_SUBMISSION_MODES = ["user-transaction"] as cons
 
 /** Default per-request timeout (ms) so HTTP calls cannot hang indefinitely. */
 export const SUPERBRIDGE_REQUEST_TIMEOUT_MS = 30_000;
+
+/** Default slippage sent to `/v1/routes`. Native/canonical bridges are 1:1, so 0. */
+export const SUPERBRIDGE_DEFAULT_SLIPPAGE = 0;
+
+/** Canonical/native rollup bridge route identifiers. Used to filter `/v1/routes` to native bridging. */
+export const SUPERBRIDGE_CANONICAL_ROUTE_IDS = [
+    "op-deposit-cdm",
+    "op-deposit-portal",
+    "op-withdrawal-cdm",
+    "op-withdrawal-messagepasser",
+    "arb-deposit-retryable",
+    "ArbitrumWithdrawal",
+    "ZksyncDeposit",
+    "ZksyncWithdrawal",
+    "TaikoDeposit",
+    "TaikoWithdrawal",
+    "LineaDeposit",
+    "LineaWithdrawal",
+    "StarknetDeposit",
+    "StarknetWithdrawal",
+    "LxlyDeposit",
+    "LxlyWithdrawal",
+    "LxlyCross",
+] as const;

--- a/packages/cross-chain/src/protocols/superbridge/provider.ts
+++ b/packages/cross-chain/src/protocols/superbridge/provider.ts
@@ -15,7 +15,9 @@ import {
     FetchHttpClient,
     ProviderConfigFailure,
     ProviderExecuteNotImplemented,
+    ProviderGetQuoteFailure,
 } from "../../internal.js";
+import { adaptQuoteRequest, adaptQuoteResponse } from "./adapters/index.js";
 import {
     SUPERBRIDGE_API_URL,
     SUPERBRIDGE_DEFAULT_SUBMISSION_MODES,
@@ -76,9 +78,25 @@ export class SuperbridgeProvider extends CrossChainProvider {
         }
     }
 
-    /** @inheritdoc */
-    async getQuotes(_params: QuoteRequest): Promise<Quote[]> {
-        throw new ProviderExecuteNotImplemented(this.getProviderId());
+    /**
+     * @inheritdoc
+     *
+     * Fetches bridging routes from `/v1/routes` and maps each successful route
+     * whose initiating transaction matches an enabled submission mode.
+     */
+    async getQuotes(params: QuoteRequest): Promise<Quote[]> {
+        try {
+            const request = adaptQuoteRequest(params);
+            const response = await this.apiService.getRoutes(request);
+            return adaptQuoteResponse(response, this.providerId, params, this.submissionModes);
+        } catch (error) {
+            if (error instanceof ProviderGetQuoteFailure) throw error;
+            throw new ProviderGetQuoteFailure(
+                error instanceof Error ? error.message : "Failed to get Superbridge quotes",
+                undefined,
+                error instanceof Error ? error.stack : undefined,
+            );
+        }
     }
 
     /** @inheritdoc */

--- a/packages/cross-chain/test/protocols/superbridge/adapters/quoteRequestAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/quoteRequestAdapter.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import type { QuoteRequest } from "../../../../src/core/schemas/quoteRequest.js";
+import { ProviderGetQuoteFailure } from "../../../../src/core/errors/ProviderGetQuoteFailure.exception.js";
+import { NATIVE_ASSET_ADDRESS, NATIVE_ZERO_ADDRESS } from "../../../../src/core/utils/token.js";
+import { adaptQuoteRequest } from "../../../../src/protocols/superbridge/adapters/quoteRequestAdapter.js";
+
+const USER = "0x1234567890abcdef1234567890abcdef12345678";
+const TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+
+function req(overrides?: Partial<QuoteRequest>): QuoteRequest {
+    return {
+        user: USER,
+        input: { chainId: 1, assetAddress: TOKEN, amount: "1000" },
+        output: { chainId: 8453, assetAddress: TOKEN },
+        ...overrides,
+    };
+}
+
+describe("adaptQuoteRequest", () => {
+    it("maps an SDK request to the routes body", () => {
+        expect(adaptQuoteRequest(req())).toMatchObject({
+            fromChainId: "1",
+            toChainId: "8453",
+            fromTokenAddress: TOKEN,
+            toTokenAddress: TOKEN,
+            amount: "1000",
+            sender: USER,
+            recipient: USER,
+            slippage: 0,
+        });
+    });
+
+    it("maps the native placeholder to the zero address", () => {
+        const out = adaptQuoteRequest(
+            req({ input: { chainId: 1, assetAddress: NATIVE_ASSET_ADDRESS, amount: "1000" } }),
+        );
+        expect(out.fromTokenAddress).toBe(NATIVE_ZERO_ADDRESS);
+    });
+
+    it("throws when the input amount is missing", () => {
+        expect(() =>
+            adaptQuoteRequest(req({ input: { chainId: 1, assetAddress: TOKEN } })),
+        ).toThrow(ProviderGetQuoteFailure);
+    });
+
+    it("filters to canonical native route ids", () => {
+        const out = adaptQuoteRequest(req());
+
+        expect(out.routeIds).toContain("op-deposit-portal");
+        expect(out.routeIds).toContain("ArbitrumWithdrawal");
+        expect(out.routeIds).not.toContain("Across");
+    });
+});

--- a/packages/cross-chain/test/protocols/superbridge/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/quoteResponseAdapter.spec.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+
+import type { SubmissionMode } from "../../../../src/core/schemas/providerConfig.js";
+import type { QuoteRequest } from "../../../../src/core/schemas/quoteRequest.js";
+import type {
+    SuperbridgeRouteResult,
+    SuperbridgeRoutesResponse,
+} from "../../../../src/protocols/superbridge/schemas.js";
+import { adaptQuoteResponse } from "../../../../src/protocols/superbridge/adapters/quoteResponseAdapter.js";
+
+const USER = "0x1234567890abcdef1234567890abcdef12345678";
+const TO = "0x1111111111111111111111111111111111111111";
+const RECEIVE_TOKEN = "0x2222222222222222222222222222222222222222";
+const PROVIDER_ID = "superbridge";
+
+function request(): QuoteRequest {
+    return {
+        user: USER,
+        input: { chainId: 1, assetAddress: TO, amount: "1000" },
+        output: { chainId: 8453, assetAddress: TO },
+    };
+}
+
+function evmResult(): SuperbridgeRouteResult {
+    return {
+        meta: { id: "route-1", provider: { name: "across-v3" } },
+        result: {
+            initiatingTransaction: {
+                type: "evm",
+                chainId: "1",
+                to: TO,
+                data: "0xfeed",
+                value: "1000",
+            },
+            token: { address: TO, chainId: "uuid-from", symbol: "USDC", decimals: 6 },
+            receiveToken: {
+                address: RECEIVE_TOKEN,
+                chainId: "uuid-to",
+                symbol: "USDbC",
+                decimals: 6,
+            },
+            receive: "995",
+            duration: 42,
+        },
+    };
+}
+
+function gaslessResult(): SuperbridgeRouteResult {
+    return {
+        meta: { id: "route-gasless" },
+        result: {
+            initiatingTransaction: {
+                type: "evm-gasless",
+                chainId: "1",
+                typedData: JSON.stringify({
+                    domain: { chainId: 1 },
+                    types: { Order: [{ name: "a", type: "uint256" }] },
+                    primaryType: "Order",
+                    message: { a: "1" },
+                }),
+            },
+        },
+    };
+}
+
+function response(results: SuperbridgeRouteResult[]): SuperbridgeRoutesResponse {
+    return { results };
+}
+
+const userTxModes: ReadonlySet<SubmissionMode> = new Set(["user-transaction"]);
+const gaslessModes: ReadonlySet<SubmissionMode> = new Set(["gasless"]);
+
+describe("adaptQuoteResponse", () => {
+    it("maps an evm route to a transaction quote", () => {
+        const quotes = adaptQuoteResponse(
+            response([evmResult()]),
+            PROVIDER_ID,
+            request(),
+            userTxModes,
+        );
+
+        expect(quotes).toHaveLength(1);
+        expect(quotes[0]!.order.steps[0]!.kind).toBe("transaction");
+        expect(quotes[0]!.eta).toBe(42);
+        expect(quotes[0]!.metadata?.superbridgeRouteId).toBe("route-1");
+        expect(quotes[0]!.metadata?.superbridgeProvider).toBe("across-v3");
+    });
+
+    it("maps token, receiveToken and receive into the preview with numeric chain ids", () => {
+        const quotes = adaptQuoteResponse(
+            response([evmResult()]),
+            PROVIDER_ID,
+            request(),
+            userTxModes,
+        );
+
+        const { inputs, outputs } = quotes[0]!.preview;
+        expect(inputs[0]!.chainId).toBe(1);
+        expect(inputs[0]!.assetAddress).toBe(TO);
+        expect(inputs[0]!.amount).toBe("1000");
+        expect(outputs[0]!.chainId).toBe(8453);
+        expect(outputs[0]!.assetAddress).toBe(RECEIVE_TOKEN);
+        expect(outputs[0]!.amount).toBe("995");
+    });
+
+    it("derives eta from wait step durations when duration is absent", () => {
+        const result = evmResult();
+        const quote = result.result as Record<string, unknown>;
+        delete quote.duration;
+        quote.steps = [
+            { type: "transaction", action: "Initiate" },
+            { type: "wait", waitType: "op-dispute-game", expectedDuration: 2052000 },
+            { type: "wait", waitType: "op-challenge-period", expectedDuration: 604800000 },
+        ];
+
+        const quotes = adaptQuoteResponse(response([result]), PROVIDER_ID, request(), userTxModes);
+
+        expect(quotes[0]!.eta).toBe(606852);
+    });
+
+    it("skips error variants without an initiating transaction", () => {
+        const errorResult: SuperbridgeRouteResult = { result: { code: "AMOUNT_TOO_LARGE" } };
+        const quotes = adaptQuoteResponse(
+            response([errorResult]),
+            PROVIDER_ID,
+            request(),
+            userTxModes,
+        );
+
+        expect(quotes).toHaveLength(0);
+    });
+
+    it("skips gasless routes when only user-transaction mode is enabled", () => {
+        const quotes = adaptQuoteResponse(
+            response([gaslessResult()]),
+            PROVIDER_ID,
+            request(),
+            userTxModes,
+        );
+
+        expect(quotes).toHaveLength(0);
+    });
+
+    it("maps a gasless route to a signature quote when enabled", () => {
+        const quotes = adaptQuoteResponse(
+            response([gaslessResult()]),
+            PROVIDER_ID,
+            request(),
+            gaslessModes,
+        );
+
+        expect(quotes).toHaveLength(1);
+        expect(quotes[0]!.order.steps[0]!.kind).toBe("signature");
+    });
+
+    it("prepends revoke and approval steps in order", () => {
+        const result = evmResult();
+        const quote = result.result as Record<string, unknown>;
+        quote.revokeTokenApproval = {
+            contractAddress: TO,
+            tokenAddress: TO,
+            tx: { type: "evm", chainId: "1", to: TO, data: "0xrevoke" },
+        };
+        quote.tokenApproval = {
+            contractAddress: TO,
+            tokenAddress: TO,
+            tx: { type: "evm", chainId: "1", to: TO, data: "0xapprove" },
+        };
+
+        const quotes = adaptQuoteResponse(response([result]), PROVIDER_ID, request(), userTxModes);
+
+        expect(quotes[0]!.order.steps).toHaveLength(3);
+        expect(quotes[0]!.order.steps[0]!.category).toBe("approval");
+        expect(quotes[0]!.order.steps[2]!.kind).toBe("transaction");
+    });
+
+    it("maps a gas fee to originGas and a non-gas fee to bridgeFee", () => {
+        const result = evmResult();
+        const token = { address: TO, chainId: "1", symbol: "ETH", decimals: 18 };
+        (result.result as Record<string, unknown>).fees = [
+            { items: [{ name: "Gas fee", amount: "100", token }] },
+            { items: [{ name: "Bridge fee", amount: "200", token }] },
+        ];
+
+        const quotes = adaptQuoteResponse(response([result]), PROVIDER_ID, request(), userTxModes);
+
+        expect(quotes[0]!.fees?.originGas?.amount).toBe("100");
+        expect(quotes[0]!.fees?.bridgeFee?.amount).toBe("200");
+    });
+
+    it("omits fees when the route has none", () => {
+        const quotes = adaptQuoteResponse(
+            response([evmResult()]),
+            PROVIDER_ID,
+            request(),
+            userTxModes,
+        );
+
+        expect(quotes[0]!.fees).toBeUndefined();
+    });
+});

--- a/packages/cross-chain/test/protocols/superbridge/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/provider.spec.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { HttpClient } from "../../../src/core/interfaces/httpClient.interface.js";
+import type { QuoteRequest } from "../../../src/core/schemas/quoteRequest.js";
+import { ProviderConfigFailure } from "../../../src/core/errors/ProviderConfigFailure.exception.js";
+import { ProviderGetQuoteFailure } from "../../../src/core/errors/ProviderGetQuoteFailure.exception.js";
+import { FetchHttpClient } from "../../../src/core/utils/httpClient.js";
+import { SuperbridgeProvider } from "../../../src/protocols/superbridge/provider.js";
+
+const VALID_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+const NATIVE = "0x0000000000000000000000000000000000000000";
+const ORIGIN_CHAIN_ID = 1;
+const DESTINATION_CHAIN_ID = 8453;
+const INPUT_AMOUNT = "10000000000000000";
+const OUTPUT_AMOUNT = "9990000000000000";
+const TX_DATA = "0xdeadbeef";
+const PROTOCOL_NAME = "superbridge";
+const API_KEY = "sb-test-key";
+
+vi.mock("../../../src/core/utils/httpClient.js", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../../../src/core/utils/httpClient.js")>();
+    return { ...actual, FetchHttpClient: vi.fn() };
+});
+
+const mockPost = vi.fn();
+const mockGet = vi.fn();
+
+function makeQuoteRequest(overrides?: Partial<QuoteRequest>): QuoteRequest {
+    return {
+        user: VALID_ADDRESS,
+        input: { chainId: ORIGIN_CHAIN_ID, assetAddress: NATIVE, amount: INPUT_AMOUNT },
+        output: { chainId: DESTINATION_CHAIN_ID, assetAddress: NATIVE },
+        ...overrides,
+    };
+}
+
+function makeEvmRouteResult(): unknown {
+    return {
+        result: {
+            id: "route-1",
+            provider: { name: "across-v3" },
+            initiatingTransaction: {
+                type: "evm",
+                chainId: String(ORIGIN_CHAIN_ID),
+                to: VALID_ADDRESS,
+                data: TX_DATA,
+                value: INPUT_AMOUNT,
+            },
+            fromToken: {
+                address: NATIVE,
+                chainId: String(ORIGIN_CHAIN_ID),
+                symbol: "ETH",
+                decimals: 18,
+            },
+            toToken: {
+                address: NATIVE,
+                chainId: String(DESTINATION_CHAIN_ID),
+                symbol: "ETH",
+                decimals: 18,
+            },
+            fromAmount: INPUT_AMOUNT,
+            receiveAmount: OUTPUT_AMOUNT,
+            duration: 60,
+            fees: [
+                {
+                    items: [
+                        {
+                            name: "Bridge fee",
+                            amount: "5000",
+                            token: { address: NATIVE, chainId: "1", symbol: "ETH", decimals: 18 },
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+function makeGaslessRouteResult(): unknown {
+    const typedData = JSON.stringify({
+        domain: { chainId: ORIGIN_CHAIN_ID, name: "Superbridge" },
+        types: { Order: [{ name: "amount", type: "uint256" }] },
+        primaryType: "Order",
+        message: { amount: INPUT_AMOUNT },
+    });
+    return {
+        result: {
+            id: "route-gasless",
+            provider: { name: "across-v3" },
+            initiatingTransaction: {
+                type: "evm-gasless",
+                chainId: String(ORIGIN_CHAIN_ID),
+                typedData,
+            },
+        },
+    };
+}
+
+function httpOk(data: unknown): { status: number; data: unknown; headers: Headers } {
+    return { status: 200, data, headers: new Headers() };
+}
+
+describe("SuperbridgeProvider", () => {
+    let provider: SuperbridgeProvider;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(FetchHttpClient).mockImplementation(function (this: HttpClient) {
+            (this as unknown as { get: typeof mockGet; post: typeof mockPost }).get = mockGet;
+            (this as unknown as { get: typeof mockGet; post: typeof mockPost }).post = mockPost;
+        } as unknown as typeof FetchHttpClient);
+        provider = new SuperbridgeProvider({ apiKey: API_KEY });
+    });
+
+    describe("constructor", () => {
+        it("uses default config when only an api key is provided", () => {
+            expect(provider.protocolName).toBe(PROTOCOL_NAME);
+            expect(provider.providerId).toBe(PROTOCOL_NAME);
+        });
+
+        it("accepts a custom provider id", () => {
+            expect(
+                new SuperbridgeProvider({ providerId: "sb-custom", apiKey: API_KEY }).providerId,
+            ).toBe("sb-custom");
+        });
+
+        it("rejects an invalid base url", () => {
+            expect(
+                () => new SuperbridgeProvider({ baseUrl: "not-a-url", apiKey: API_KEY }),
+            ).toThrow(ProviderConfigFailure);
+        });
+
+        it("rejects a missing api key", () => {
+            expect(() => new SuperbridgeProvider({ apiKey: "" })).toThrow(ProviderConfigFailure);
+        });
+    });
+
+    describe("getQuotes()", () => {
+        it("returns a transaction quote for an evm route", async () => {
+            mockPost.mockResolvedValue(httpOk({ results: [makeEvmRouteResult()] }));
+
+            const quotes = await provider.getQuotes(makeQuoteRequest());
+
+            expect(quotes).toHaveLength(1);
+            expect(quotes[0]!.provider).toBe(PROTOCOL_NAME);
+            expect(quotes[0]!.order.steps[0]!.kind).toBe("transaction");
+            expect(quotes[0]!.eta).toBe(60);
+            expect(quotes[0]!.fees?.bridgeFee?.amount).toBe("5000");
+        });
+
+        it("filters out gasless routes when only user-transaction mode is enabled", async () => {
+            mockPost.mockResolvedValue(httpOk({ results: [makeGaslessRouteResult()] }));
+
+            const quotes = await provider.getQuotes(makeQuoteRequest());
+
+            expect(quotes).toHaveLength(0);
+        });
+
+        it("returns a signature quote when gasless mode is enabled", async () => {
+            const gaslessProvider = new SuperbridgeProvider({
+                submissionModes: ["gasless"],
+                apiKey: API_KEY,
+            });
+            mockPost.mockResolvedValue(httpOk({ results: [makeGaslessRouteResult()] }));
+
+            const quotes = await gaslessProvider.getQuotes(makeQuoteRequest());
+
+            expect(quotes).toHaveLength(1);
+            expect(quotes[0]!.order.steps[0]!.kind).toBe("signature");
+        });
+
+        it("prepends an approval step for erc-20 routes", async () => {
+            const result = makeEvmRouteResult();
+            (result as { result: Record<string, unknown> }).result.tokenApproval = {
+                contractAddress: VALID_ADDRESS,
+                tokenAddress: VALID_ADDRESS,
+                amount: INPUT_AMOUNT,
+                tx: { type: "evm", chainId: "1", to: VALID_ADDRESS, data: "0xapprove" },
+            };
+            mockPost.mockResolvedValue(httpOk({ results: [result] }));
+
+            const quotes = await provider.getQuotes(makeQuoteRequest());
+
+            expect(quotes[0]!.order.steps).toHaveLength(2);
+            expect(quotes[0]!.order.steps[0]!.kind).toBe("transaction");
+            expect(quotes[0]!.order.steps[0]!.category).toBe("approval");
+        });
+
+        it("wraps unexpected errors in ProviderGetQuoteFailure", async () => {
+            mockPost.mockRejectedValue(new Error("boom"));
+
+            await expect(provider.getQuotes(makeQuoteRequest())).rejects.toBeInstanceOf(
+                ProviderGetQuoteFailure,
+            );
+        });
+    });
+});


### PR DESCRIPTION
Wires `getQuotes` for the Superbridge user-transaction route, building on the schemas and API service from EFI-996.

Closes EFI-998.

## What's here

- **`quoteRequestAdapter`** — maps an SDK `QuoteRequest` to a `/v1/routes` body: stringified chain ids, native placeholder normalized to the zero address, recipient defaulting to the sender, and `routeIds` pinned to the canonical native bridges (`SUPERBRIDGE_CANONICAL_ROUTE_IDS`). Throws `ProviderGetQuoteFailure` when `input.amount` is missing.
- **`quoteResponseAdapter`** — maps a `/v1/routes` response to `Quote[]`. Skips error variants, keeps only routes whose initiating transaction matches an enabled submission mode, prepends revoke/approval steps, derives the ETA from `duration` (falling back to the sum of wait steps), builds the preview, and folds the fee mapping in (gas → `originGas`, the rest → `bridgeFee`).
- **`provider.getQuotes`** — runs both adapters against the API service and wraps anything unexpected in `ProviderGetQuoteFailure`.
- **Constants** — `SUPERBRIDGE_DEFAULT_SLIPPAGE` and `SUPERBRIDGE_CANONICAL_ROUTE_IDS`.

## Tests

Unit tests on both adapters with mocked payloads, plus `getQuotes` coverage on the provider (evm route, gasless filtered out under user-transaction mode, approval step prepended, error wrapping). 35 Superbridge tests green; typecheck and lint clean.

## Scope

User-transaction route only. Gasless submission (`submitOrder`) lands in EFI-1000 and tracking in EFI-999, so those still throw `ProviderExecuteNotImplemented`.

## Note

Stacked on `efi-996-add-superbridge-schemas-and-api-service`; review/merge that one first. The diff here is only the EFI-998 changes.
