### PR TITLE
feat(cross-chain): add Superbridge order tracking

### DIFF
--- a/.changeset/superbridge-order-tracking.md
+++ b/.changeset/superbridge-order-tracking.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Add Superbridge order tracking
+
+Wire `SuperbridgeProvider.getTrackingConfig` on top of the `/v1/activity` and `/v1/index_transaction` endpoints. Tracking uses the API-based opened-intent parser and fill watcher (`adaptOpenedIntentResponse`, `extractFillEvent`), with `/v1/index_transaction` as the pre-tracker. Adds unit tests on the activity and opened-intent adapters.

--- a/packages/cross-chain/src/protocols/superbridge/adapters/activityAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/activityAdapter.ts
@@ -48,7 +48,6 @@ export function extractFillEvent(
     return {
         event: null,
         status: anyStepStarted(bridge) ? OrderStatus.Executing : OrderStatus.Pending,
-        fillTxHash,
     };
 }
 
@@ -59,14 +58,13 @@ export function findBridge(
 ): SuperbridgeActivity | undefined {
     if (originTxHash) {
         const target = originTxHash.toLowerCase();
-        const matched = activities.find((activity) =>
+        return activities.find((activity) =>
             activity.steps.some(
                 (step) =>
                     step.type === "transaction" &&
                     step.confirmation?.transactionHash?.toLowerCase() === target,
             ),
         );
-        if (matched) return matched;
     }
     return activities[0];
 }
@@ -94,10 +92,18 @@ function anyStepStarted(bridge: SuperbridgeActivity): boolean {
 }
 
 function findFillTxHash(bridge: SuperbridgeActivity): Hex | undefined {
+    const destinationChainId = bridge.toChainId;
     let last: string | undefined;
     for (const step of bridge.steps) {
         if (step.type !== "transaction") continue;
         if (step.transactionStatus !== "done" && step.transactionStatus !== "auto") continue;
+        if (
+            destinationChainId !== undefined &&
+            step.chainId !== undefined &&
+            step.chainId !== destinationChainId
+        ) {
+            continue;
+        }
         const hash = step.confirmation?.transactionHash;
         if (typeof hash === "string") last = hash;
     }

--- a/packages/cross-chain/src/protocols/superbridge/adapters/activityAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/activityAdapter.ts
@@ -1,9 +1,9 @@
 import type { Hex } from "viem";
 import { isHex } from "viem";
 
-import type { FillEvent, GetFillParams, OrderFailureReason } from "../../../internal.js";
+import type { FillEvent, GetFillParams } from "../../../internal.js";
 import type { SuperbridgeActivity, SuperbridgeActivityStep } from "../schemas.js";
-import { OrderStatus } from "../../../internal.js";
+import { OrderFailureReason, OrderStatus } from "../../../internal.js";
 import { SuperbridgeActivityResponseSchema } from "../schemas.js";
 
 /**
@@ -27,6 +27,11 @@ export function extractFillEvent(
     const bridge = findBridge(parsed.data, params.openTxHash);
     if (!bridge) {
         return { event: null, status: OrderStatus.Pending };
+    }
+
+    const failure = detectTerminalFailure(bridge, params);
+    if (failure) {
+        return { event: null, status: OrderStatus.Failed, failureReason: failure };
     }
 
     const fillTxHash = findFillTxHash(bridge);
@@ -68,6 +73,39 @@ export function findBridge(
         if (matched) return matched;
     }
     return activities[0];
+}
+
+function detectTerminalFailure(
+    bridge: SuperbridgeActivity,
+    params: GetFillParams,
+): OrderFailureReason | undefined {
+    for (const step of bridge.steps) {
+        if (step.type === "transaction") {
+            const confirmationStatus = step.confirmation?.status;
+            if (confirmationStatus === "reverted") {
+                return isOriginStep(step, params)
+                    ? OrderFailureReason.OriginTxReverted
+                    : OrderFailureReason.Unknown;
+            }
+            if (confirmationStatus === "dropped" || step.transactionStatus === "invalidated") {
+                return OrderFailureReason.Unknown;
+            }
+        } else if (step.type === "wait" && step.waitStatus === "invalidated") {
+            return OrderFailureReason.Unknown;
+        }
+    }
+    return undefined;
+}
+
+function isOriginStep(
+    step: Extract<SuperbridgeActivityStep, { type: "transaction" }>,
+    params: GetFillParams,
+): boolean {
+    const hash = step.confirmation?.transactionHash;
+    if (hash && params.openTxHash && hash.toLowerCase() === params.openTxHash.toLowerCase()) {
+        return true;
+    }
+    return step.chainId !== undefined && step.chainId === String(params.originChainId);
 }
 
 function isStepDone(step: SuperbridgeActivityStep): boolean {

--- a/packages/cross-chain/src/protocols/superbridge/adapters/activityAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/activityAdapter.ts
@@ -94,15 +94,18 @@ function anyStepStarted(bridge: SuperbridgeActivity): boolean {
 
 function findFillTxHash(bridge: SuperbridgeActivity): Hex | undefined {
     const destinationChainId = bridge.toChainId;
-    let last: string | undefined;
+    let lastOnDestination: string | undefined;
+    let lastCompleted: string | undefined;
     for (const step of bridge.steps) {
         if (step.type !== "transaction") continue;
         if (step.transactionStatus !== "done" && step.transactionStatus !== "auto") continue;
-        if (destinationChainId !== undefined && step.chainId !== destinationChainId) {
-            continue;
-        }
         const hash = step.confirmation?.transactionHash;
-        if (typeof hash === "string") last = hash;
+        if (typeof hash !== "string") continue;
+        lastCompleted = hash;
+        if (destinationChainId === undefined || step.chainId === destinationChainId) {
+            lastOnDestination = hash;
+        }
     }
-    return last !== undefined && isHex(last) ? last : undefined;
+    const fillTxHash = lastOnDestination ?? lastCompleted;
+    return fillTxHash !== undefined && isHex(fillTxHash) ? fillTxHash : undefined;
 }

--- a/packages/cross-chain/src/protocols/superbridge/adapters/activityAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/activityAdapter.ts
@@ -58,13 +58,14 @@ export function findBridge(
 ): SuperbridgeActivity | undefined {
     if (originTxHash) {
         const target = originTxHash.toLowerCase();
-        return activities.find((activity) =>
+        const matched = activities.find((activity) =>
             activity.steps.some(
                 (step) =>
                     step.type === "transaction" &&
                     step.confirmation?.transactionHash?.toLowerCase() === target,
             ),
         );
+        if (matched) return matched;
     }
     return activities[0];
 }
@@ -97,11 +98,7 @@ function findFillTxHash(bridge: SuperbridgeActivity): Hex | undefined {
     for (const step of bridge.steps) {
         if (step.type !== "transaction") continue;
         if (step.transactionStatus !== "done" && step.transactionStatus !== "auto") continue;
-        if (
-            destinationChainId !== undefined &&
-            step.chainId !== undefined &&
-            step.chainId !== destinationChainId
-        ) {
+        if (destinationChainId !== undefined && step.chainId !== destinationChainId) {
             continue;
         }
         const hash = step.confirmation?.transactionHash;

--- a/packages/cross-chain/src/protocols/superbridge/adapters/activityAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/activityAdapter.ts
@@ -1,0 +1,105 @@
+import type { Hex } from "viem";
+import { isHex } from "viem";
+
+import type { FillEvent, GetFillParams, OrderFailureReason } from "../../../internal.js";
+import type { SuperbridgeActivity, SuperbridgeActivityStep } from "../schemas.js";
+import { OrderStatus } from "../../../internal.js";
+import { SuperbridgeActivityResponseSchema } from "../schemas.js";
+
+/**
+ * Extract fill status and fill event from a Superbridge `/v1/activity` response.
+ * Used by the core fill watcher to detect completion.
+ */
+export function extractFillEvent(
+    response: unknown,
+    params: GetFillParams,
+): {
+    event: FillEvent | null;
+    status: OrderStatus;
+    failureReason?: OrderFailureReason;
+    fillTxHash?: string;
+} {
+    const parsed = SuperbridgeActivityResponseSchema.safeParse(response);
+    if (!parsed.success) {
+        return { event: null, status: OrderStatus.Pending };
+    }
+
+    const bridge = findBridge(parsed.data, params.openTxHash);
+    if (!bridge) {
+        return { event: null, status: OrderStatus.Pending };
+    }
+
+    const fillTxHash = findFillTxHash(bridge);
+
+    if (bridge.steps.every(isStepDone) && fillTxHash) {
+        return {
+            event: {
+                fillTxHash,
+                blockNumber: 0n,
+                timestamp: 0,
+                originChainId: params.originChainId,
+                orderId: params.orderId,
+            },
+            status: OrderStatus.Finalized,
+            fillTxHash,
+        };
+    }
+
+    return {
+        event: null,
+        status: anyStepStarted(bridge) ? OrderStatus.Executing : OrderStatus.Pending,
+        fillTxHash,
+    };
+}
+
+/** Find the activity whose origin step matches the given transaction hash. */
+export function findBridge(
+    activities: SuperbridgeActivity[],
+    originTxHash: string | undefined,
+): SuperbridgeActivity | undefined {
+    if (originTxHash) {
+        const target = originTxHash.toLowerCase();
+        const matched = activities.find((activity) =>
+            activity.steps.some(
+                (step) =>
+                    step.type === "transaction" &&
+                    step.confirmation?.transactionHash?.toLowerCase() === target,
+            ),
+        );
+        if (matched) return matched;
+    }
+    return activities[0];
+}
+
+function isStepDone(step: SuperbridgeActivityStep): boolean {
+    if (step.type === "transaction") {
+        return step.transactionStatus === "done" || step.transactionStatus === "auto";
+    }
+    if (step.type === "wait") {
+        return step.waitStatus === "done";
+    }
+    return true;
+}
+
+function anyStepStarted(bridge: SuperbridgeActivity): boolean {
+    return bridge.steps.some((step) => {
+        if (step.type === "transaction") {
+            return step.transactionStatus === "done" || step.transactionStatus === "auto";
+        }
+        if (step.type === "wait") {
+            return step.waitStatus === "done" || step.waitStatus === "in-progress";
+        }
+        return false;
+    });
+}
+
+function findFillTxHash(bridge: SuperbridgeActivity): Hex | undefined {
+    let last: string | undefined;
+    for (const step of bridge.steps) {
+        if (step.type !== "transaction") continue;
+        if (step.transactionStatus !== "done" && step.transactionStatus !== "auto") continue;
+        const hash = step.confirmation?.transactionHash;
+        if (typeof hash === "string") last = hash;
+    }
+    return last !== undefined && isHex(last) ? last : undefined;
+}

--- a/packages/cross-chain/src/protocols/superbridge/adapters/index.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/index.ts
@@ -1,2 +1,4 @@
+export { extractFillEvent, findBridge } from "./activityAdapter.js";
+export { adaptOpenedIntentResponse } from "./openedIntentResponseAdapter.js";
 export { adaptQuoteRequest } from "./quoteRequestAdapter.js";
 export { adaptQuoteResponse } from "./quoteResponseAdapter.js";

--- a/packages/cross-chain/src/protocols/superbridge/adapters/openedIntentResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/openedIntentResponseAdapter.ts
@@ -1,0 +1,46 @@
+import type { Hex } from "viem";
+import { zeroAddress } from "viem";
+
+import type { OpenedIntent } from "../../../internal.js";
+import { OpenedIntentNotFoundError } from "../../../internal.js";
+import { SUPERBRIDGE_PROTOCOL_NAME } from "../constants.js";
+import { SuperbridgeActivityResponseSchema } from "../schemas.js";
+import { findBridge } from "./activityAdapter.js";
+
+/**
+ * Adapt a Superbridge `/v1/activity` response into an OpenedIntent.
+ *
+ * Uses the origin transaction hash as the order identifier and reads the
+ * destination chain from the matched activity.
+ *
+ * @throws {OpenedIntentNotFoundError} When no matching activity is found.
+ */
+export function adaptOpenedIntentResponse(response: unknown, txHash: Hex): OpenedIntent {
+    const parsed = SuperbridgeActivityResponseSchema.safeParse(response);
+    if (!parsed.success) {
+        throw new OpenedIntentNotFoundError(txHash, SUPERBRIDGE_PROTOCOL_NAME);
+    }
+
+    const bridge = findBridge(parsed.data, txHash);
+    if (!bridge) {
+        throw new OpenedIntentNotFoundError(txHash, SUPERBRIDGE_PROTOCOL_NAME);
+    }
+
+    const destinationChainId = bridge.toChainId ? Number(bridge.toChainId) : undefined;
+
+    return {
+        user: zeroAddress,
+        originChainId: bridge.fromChainId ? Number(bridge.fromChainId) : 0,
+        openDeadline: 0,
+        fillDeadline: 0xffffffff,
+        orderId: txHash,
+        maxSpent: [],
+        minReceived: [],
+        fillInstructions: destinationChainId
+            ? [{ destinationChainId, destinationSettler: zeroAddress, originData: "0x" }]
+            : [],
+        txHash,
+        blockNumber: 0n,
+        originContract: zeroAddress,
+    };
+}

--- a/packages/cross-chain/src/protocols/superbridge/adapters/openedIntentResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/openedIntentResponseAdapter.ts
@@ -26,21 +26,32 @@ export function adaptOpenedIntentResponse(response: unknown, txHash: Hex): Opene
         throw new OpenedIntentNotFoundError(txHash, SUPERBRIDGE_PROTOCOL_NAME);
     }
 
-    const destinationChainId = bridge.toChainId ? Number(bridge.toChainId) : undefined;
+    const originChainId = parseChainId(bridge.fromChainId);
+    const destinationChainId = parseChainId(bridge.toChainId);
+    if (originChainId === undefined || destinationChainId === undefined) {
+        throw new OpenedIntentNotFoundError(txHash, SUPERBRIDGE_PROTOCOL_NAME);
+    }
 
     return {
         user: zeroAddress,
-        originChainId: bridge.fromChainId ? Number(bridge.fromChainId) : 0,
+        originChainId,
         openDeadline: 0,
         fillDeadline: 0xffffffff,
         orderId: txHash,
         maxSpent: [],
         minReceived: [],
-        fillInstructions: destinationChainId
-            ? [{ destinationChainId, destinationSettler: zeroAddress, originData: "0x" }]
-            : [],
+        fillInstructions: [
+            { destinationChainId, destinationSettler: zeroAddress, originData: "0x" },
+        ],
         txHash,
         blockNumber: 0n,
         originContract: zeroAddress,
     };
+}
+
+/** Parse a Superbridge chain id string into a positive integer, or undefined when invalid. */
+function parseChainId(value: string | undefined): number | undefined {
+    if (!value) return undefined;
+    const chainId = Number(value);
+    return Number.isInteger(chainId) && chainId > 0 ? chainId : undefined;
 }

--- a/packages/cross-chain/src/protocols/superbridge/provider.ts
+++ b/packages/cross-chain/src/protocols/superbridge/provider.ts
@@ -1,11 +1,14 @@
+import type { Hex } from "viem";
 import { ZodError } from "zod";
 
 import type { SubmissionMode } from "../../core/schemas/providerConfig.js";
 import type {
     FillWatcherConfig,
+    GetFillParams,
     HttpClient,
     OpenedIntentParserConfig,
     PreTrackerConfig,
+    PreTrackerParams,
     Quote,
     QuoteRequest,
 } from "../../internal.js";
@@ -14,10 +17,14 @@ import {
     CrossChainProvider,
     FetchHttpClient,
     ProviderConfigFailure,
-    ProviderExecuteNotImplemented,
     ProviderGetQuoteFailure,
 } from "../../internal.js";
-import { adaptQuoteRequest, adaptQuoteResponse } from "./adapters/index.js";
+import {
+    adaptOpenedIntentResponse,
+    adaptQuoteRequest,
+    adaptQuoteResponse,
+    extractFillEvent,
+} from "./adapters/index.js";
 import {
     SUPERBRIDGE_API_URL,
     SUPERBRIDGE_DEFAULT_SUBMISSION_MODES,
@@ -99,12 +106,54 @@ export class SuperbridgeProvider extends CrossChainProvider {
         }
     }
 
-    /** @inheritdoc */
+    /**
+     * @inheritdoc
+     * Returns API-based tracking config using the Superbridge `/v1/activity` endpoint,
+     * with `/v1/index_transaction` as the pre-tracker.
+     */
     getTrackingConfig(): {
         openedIntentParserConfig: OpenedIntentParserConfig;
         fillWatcherConfig: FillWatcherConfig;
-        preTrackerConfig?: PreTrackerConfig;
+        preTrackerConfig: PreTrackerConfig;
     } {
-        throw new ProviderExecuteNotImplemented(this.getProviderId());
+        const headers = this.apiHeaders;
+
+        return {
+            openedIntentParserConfig: {
+                type: "api",
+                config: {
+                    protocolName: SUPERBRIDGE_PROTOCOL_NAME,
+                    headers,
+                    buildUrl: (txHash: Hex): string =>
+                        `${this.baseUrl}/v1/activity?txHash=${txHash}`,
+                    extractOpenedIntent: adaptOpenedIntentResponse,
+                },
+            },
+            fillWatcherConfig: {
+                type: "api-based",
+                baseUrl: this.baseUrl,
+                headers,
+                pollingInterval: 5000,
+                retry: {
+                    maxAttempts: 3,
+                    initialDelay: 2000,
+                    maxDelay: 15000,
+                    backoffMultiplier: 2,
+                },
+                buildEndpoint: (params: GetFillParams): string =>
+                    `/v1/activity?txHash=${params.openTxHash ?? params.orderId}`,
+                extractFillEvent,
+            },
+            preTrackerConfig: {
+                type: "api",
+                protocolName: SUPERBRIDGE_PROTOCOL_NAME,
+                buildUrl: (): string => `${this.baseUrl}/v1/index_transaction`,
+                buildBody: (params: PreTrackerParams): Record<string, unknown> => ({
+                    txHash: params.txHash,
+                    chainId: String(params.originChainId),
+                }),
+                headers,
+            },
+        };
     }
 }

--- a/packages/cross-chain/test/protocols/superbridge/adapters/activityAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/activityAdapter.spec.ts
@@ -146,7 +146,7 @@ describe("findBridge", () => {
         expect(findBridge(parsed, ORIGIN_TX)?.id).toBe("bridge-1");
     });
 
-    it("returns undefined when an origin tx hash is given but no step matches", () => {
+    it("falls back to the first activity when no step matches the origin tx hash", () => {
         const parsed = SuperbridgeActivityResponseSchema.parse(
             activity([
                 {
@@ -157,6 +157,6 @@ describe("findBridge", () => {
             ]),
         );
 
-        expect(findBridge(parsed, ORIGIN_TX)).toBeUndefined();
+        expect(findBridge(parsed, ORIGIN_TX)?.id).toBe("bridge-1");
     });
 });

--- a/packages/cross-chain/test/protocols/superbridge/adapters/activityAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/activityAdapter.spec.ts
@@ -108,6 +108,26 @@ describe("extractFillEvent", () => {
         expect(out.fillTxHash).toBeUndefined();
     });
 
+    it("falls back to the last completed tx when steps omit a chain id", () => {
+        const response = activity([
+            {
+                type: "transaction",
+                transactionStatus: "done",
+                confirmation: { transactionHash: ORIGIN_TX },
+            },
+            {
+                type: "transaction",
+                transactionStatus: "done",
+                confirmation: { transactionHash: FILL_TX },
+            },
+        ]);
+
+        const out = extractFillEvent(response, params());
+
+        expect(out.status).toBe(OrderStatus.Finalized);
+        expect(out.event?.fillTxHash).toBe(FILL_TX);
+    });
+
     it("selects the destination-chain tx as the fill, not a later origin-chain tx", () => {
         const response = activity([
             {

--- a/packages/cross-chain/test/protocols/superbridge/adapters/activityAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/activityAdapter.spec.ts
@@ -84,6 +84,51 @@ describe("extractFillEvent", () => {
         expect(out.status).toBe(OrderStatus.Pending);
         expect(out.event).toBeNull();
     });
+
+    it("does not expose a fill tx hash before finalization", () => {
+        const response = activity([
+            {
+                type: "transaction",
+                chainId: "1",
+                transactionStatus: "done",
+                confirmation: { transactionHash: ORIGIN_TX },
+            },
+            {
+                type: "transaction",
+                chainId: "8453",
+                transactionStatus: "done",
+                confirmation: { transactionHash: FILL_TX },
+            },
+            { type: "wait", waitStatus: "in-progress" },
+        ]);
+
+        const out = extractFillEvent(response, params());
+
+        expect(out.status).toBe(OrderStatus.Executing);
+        expect(out.fillTxHash).toBeUndefined();
+    });
+
+    it("selects the destination-chain tx as the fill, not a later origin-chain tx", () => {
+        const response = activity([
+            {
+                type: "transaction",
+                chainId: "8453",
+                transactionStatus: "done",
+                confirmation: { transactionHash: FILL_TX },
+            },
+            {
+                type: "transaction",
+                chainId: "1",
+                transactionStatus: "done",
+                confirmation: { transactionHash: ORIGIN_TX },
+            },
+        ]);
+
+        const out = extractFillEvent(response, params());
+
+        expect(out.status).toBe(OrderStatus.Finalized);
+        expect(out.event?.fillTxHash).toBe(FILL_TX);
+    });
 });
 
 describe("findBridge", () => {
@@ -99,5 +144,19 @@ describe("findBridge", () => {
         );
 
         expect(findBridge(parsed, ORIGIN_TX)?.id).toBe("bridge-1");
+    });
+
+    it("returns undefined when an origin tx hash is given but no step matches", () => {
+        const parsed = SuperbridgeActivityResponseSchema.parse(
+            activity([
+                {
+                    type: "transaction",
+                    transactionStatus: "done",
+                    confirmation: { transactionHash: FILL_TX },
+                },
+            ]),
+        );
+
+        expect(findBridge(parsed, ORIGIN_TX)).toBeUndefined();
     });
 });

--- a/packages/cross-chain/test/protocols/superbridge/adapters/activityAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/activityAdapter.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import type { GetFillParams } from "../../../../src/core/types/orderTracking.js";
+import { OrderStatus } from "../../../../src/core/types/orderTracking.js";
+import {
+    extractFillEvent,
+    findBridge,
+} from "../../../../src/protocols/superbridge/adapters/activityAdapter.js";
+import { SuperbridgeActivityResponseSchema } from "../../../../src/protocols/superbridge/schemas.js";
+
+const ORIGIN_TX = "0x0riginaa00000000000000000000000000000000000000000000000000000000";
+const FILL_TX = "0xf1110000000000000000000000000000000000000000000000000000000000aa";
+
+function params(): GetFillParams {
+    return {
+        orderId: ORIGIN_TX,
+        openTxHash: ORIGIN_TX,
+        originChainId: 1,
+        destinationChainId: 8453,
+    };
+}
+
+function activity(steps: unknown[]): unknown {
+    return [
+        {
+            id: "bridge-1",
+            provider: { name: "across-v3" },
+            fromChainId: "1",
+            toChainId: "8453",
+            steps,
+        },
+    ];
+}
+
+describe("extractFillEvent", () => {
+    it("returns Finalized with the fill tx when all steps are done", () => {
+        const response = activity([
+            {
+                type: "transaction",
+                chainId: "1",
+                transactionStatus: "done",
+                confirmation: { transactionHash: ORIGIN_TX },
+            },
+            {
+                type: "transaction",
+                chainId: "8453",
+                transactionStatus: "done",
+                confirmation: { transactionHash: FILL_TX },
+            },
+        ]);
+
+        const out = extractFillEvent(response, params());
+
+        expect(out.status).toBe(OrderStatus.Finalized);
+        expect(out.event?.fillTxHash).toBe(FILL_TX);
+    });
+
+    it("returns Executing while a step is still in progress", () => {
+        const response = activity([
+            {
+                type: "transaction",
+                chainId: "1",
+                transactionStatus: "done",
+                confirmation: { transactionHash: ORIGIN_TX },
+            },
+            {
+                type: "wait",
+                waitStatus: "in-progress",
+                waitType: "op-challenge-period",
+                startedAt: 1000,
+                expectedDuration: 604800000,
+            },
+        ]);
+
+        const out = extractFillEvent(response, params());
+
+        expect(out.status).toBe(OrderStatus.Executing);
+        expect(out.event).toBeNull();
+    });
+
+    it("returns Pending when no activity matches", () => {
+        const out = extractFillEvent([], params());
+
+        expect(out.status).toBe(OrderStatus.Pending);
+        expect(out.event).toBeNull();
+    });
+});
+
+describe("findBridge", () => {
+    it("matches the activity by origin transaction hash", () => {
+        const parsed = SuperbridgeActivityResponseSchema.parse(
+            activity([
+                {
+                    type: "transaction",
+                    transactionStatus: "done",
+                    confirmation: { transactionHash: ORIGIN_TX },
+                },
+            ]),
+        );
+
+        expect(findBridge(parsed, ORIGIN_TX)?.id).toBe("bridge-1");
+    });
+});

--- a/packages/cross-chain/test/protocols/superbridge/adapters/activityAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/activityAdapter.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { GetFillParams } from "../../../../src/core/types/orderTracking.js";
-import { OrderStatus } from "../../../../src/core/types/orderTracking.js";
+import { OrderFailureReason, OrderStatus } from "../../../../src/core/types/orderTracking.js";
 import {
     extractFillEvent,
     findBridge,
@@ -148,6 +148,96 @@ describe("extractFillEvent", () => {
 
         expect(out.status).toBe(OrderStatus.Finalized);
         expect(out.event?.fillTxHash).toBe(FILL_TX);
+    });
+
+    it("marks the order Failed when the origin tx reverted", () => {
+        const response = activity([
+            {
+                type: "transaction",
+                chainId: "1",
+                transactionStatus: "done",
+                confirmation: { transactionHash: ORIGIN_TX, status: "reverted" },
+            },
+            { type: "transaction", chainId: "8453", transactionStatus: "not-ready" },
+        ]);
+
+        const out = extractFillEvent(response, params());
+
+        expect(out.status).toBe(OrderStatus.Failed);
+        expect(out.failureReason).toBe(OrderFailureReason.OriginTxReverted);
+        expect(out.event).toBeNull();
+    });
+
+    it("marks the order Failed when a confirmation was dropped", () => {
+        const response = activity([
+            {
+                type: "transaction",
+                chainId: "1",
+                transactionStatus: "done",
+                confirmation: { transactionHash: ORIGIN_TX, status: "dropped" },
+            },
+            { type: "transaction", chainId: "8453", transactionStatus: "not-ready" },
+        ]);
+
+        const out = extractFillEvent(response, params());
+
+        expect(out.status).toBe(OrderStatus.Failed);
+        expect(out.failureReason).toBe(OrderFailureReason.Unknown);
+        expect(out.event).toBeNull();
+    });
+
+    it("marks the order Failed when a transaction step is invalidated", () => {
+        const response = activity([
+            {
+                type: "transaction",
+                chainId: "1",
+                transactionStatus: "done",
+                confirmation: { transactionHash: ORIGIN_TX },
+            },
+            { type: "transaction", chainId: "8453", transactionStatus: "invalidated" },
+        ]);
+
+        const out = extractFillEvent(response, params());
+
+        expect(out.status).toBe(OrderStatus.Failed);
+        expect(out.failureReason).toBe(OrderFailureReason.Unknown);
+        expect(out.event).toBeNull();
+    });
+
+    it("marks the order Failed when an upgrade event invalidates a wait step", () => {
+        const response = activity([
+            {
+                type: "transaction",
+                chainId: "1",
+                transactionStatus: "done",
+                confirmation: { transactionHash: ORIGIN_TX },
+            },
+            { type: "upgrade-event" },
+            { type: "wait", waitStatus: "invalidated", waitType: "op-challenge-period" },
+        ]);
+
+        const out = extractFillEvent(response, params());
+
+        expect(out.status).toBe(OrderStatus.Failed);
+        expect(out.failureReason).toBe(OrderFailureReason.Unknown);
+        expect(out.event).toBeNull();
+    });
+
+    it("does not report Finalized when the only completed step reverted", () => {
+        const response = activity([
+            {
+                type: "transaction",
+                chainId: "8453",
+                transactionStatus: "done",
+                confirmation: { transactionHash: FILL_TX, status: "reverted" },
+            },
+        ]);
+
+        const out = extractFillEvent(response, params());
+
+        expect(out.status).toBe(OrderStatus.Failed);
+        expect(out.failureReason).toBe(OrderFailureReason.Unknown);
+        expect(out.event).toBeNull();
     });
 });
 

--- a/packages/cross-chain/test/protocols/superbridge/adapters/openedIntentResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/openedIntentResponseAdapter.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { OpenedIntentNotFoundError } from "../../../../src/core/errors/OpenedIntentNotFound.exception.js";
+import { adaptOpenedIntentResponse } from "../../../../src/protocols/superbridge/adapters/openedIntentResponseAdapter.js";
+
+const ORIGIN_TX = "0x0riginaa00000000000000000000000000000000000000000000000000000000";
+
+describe("adaptOpenedIntentResponse", () => {
+    it("returns the opened intent with the destination chain", () => {
+        const response = [
+            {
+                id: "bridge-1",
+                fromChainId: "1",
+                toChainId: "8453",
+                steps: [
+                    {
+                        type: "transaction",
+                        transactionStatus: "done",
+                        confirmation: { transactionHash: ORIGIN_TX },
+                    },
+                ],
+            },
+        ];
+
+        const intent = adaptOpenedIntentResponse(response, ORIGIN_TX);
+
+        expect(intent.orderId).toBe(ORIGIN_TX);
+        expect(intent.originChainId).toBe(1);
+        expect(intent.fillInstructions[0]!.destinationChainId).toBe(8453);
+    });
+
+    it("throws when no activity matches", () => {
+        expect(() => adaptOpenedIntentResponse([], ORIGIN_TX)).toThrow(OpenedIntentNotFoundError);
+    });
+});

--- a/packages/cross-chain/test/protocols/superbridge/adapters/openedIntentResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/openedIntentResponseAdapter.spec.ts
@@ -32,4 +32,44 @@ describe("adaptOpenedIntentResponse", () => {
     it("throws when no activity matches", () => {
         expect(() => adaptOpenedIntentResponse([], ORIGIN_TX)).toThrow(OpenedIntentNotFoundError);
     });
+
+    it("throws when the destination chain is missing", () => {
+        const response = [
+            {
+                id: "bridge-1",
+                fromChainId: "1",
+                steps: [
+                    {
+                        type: "transaction",
+                        transactionStatus: "done",
+                        confirmation: { transactionHash: ORIGIN_TX },
+                    },
+                ],
+            },
+        ];
+
+        expect(() => adaptOpenedIntentResponse(response, ORIGIN_TX)).toThrow(
+            OpenedIntentNotFoundError,
+        );
+    });
+
+    it("throws when the origin chain is missing", () => {
+        const response = [
+            {
+                id: "bridge-1",
+                toChainId: "8453",
+                steps: [
+                    {
+                        type: "transaction",
+                        transactionStatus: "done",
+                        confirmation: { transactionHash: ORIGIN_TX },
+                    },
+                ],
+            },
+        ];
+
+        expect(() => adaptOpenedIntentResponse(response, ORIGIN_TX)).toThrow(
+            OpenedIntentNotFoundError,
+        );
+    });
 });

--- a/packages/cross-chain/test/protocols/superbridge/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/provider.spec.ts
@@ -14,6 +14,7 @@ const DESTINATION_CHAIN_ID = 8453;
 const INPUT_AMOUNT = "10000000000000000";
 const OUTPUT_AMOUNT = "9990000000000000";
 const TX_DATA = "0xdeadbeef";
+const FILL_TX_HASH = "0xabc1230000000000000000000000000000000000000000000000000000000000";
 const PROTOCOL_NAME = "superbridge";
 const API_KEY = "sb-test-key";
 
@@ -192,6 +193,19 @@ describe("SuperbridgeProvider", () => {
             await expect(provider.getQuotes(makeQuoteRequest())).rejects.toBeInstanceOf(
                 ProviderGetQuoteFailure,
             );
+        });
+    });
+
+    describe("getTrackingConfig()", () => {
+        it("builds activity-based tracking and index pre-tracker", () => {
+            const config = provider.getTrackingConfig();
+
+            expect(config.openedIntentParserConfig.type).toBe("api");
+            expect(config.preTrackerConfig.type).toBe("api");
+            expect(config.preTrackerConfig.buildUrl()).toContain("/v1/index_transaction");
+            expect(
+                config.preTrackerConfig.buildBody({ txHash: FILL_TX_HASH, originChainId: 1 }),
+            ).toEqual({ txHash: FILL_TX_HASH, chainId: "1" });
         });
     });
 });


### PR DESCRIPTION
Adds the tracking surface for Superbridge so an order can be followed from open to fill, building on the quote flow from EFI-998.

Closes EFI-999.

## What's here

- **`activityAdapter`** — `extractFillEvent` parses a `/v1/activity` response for the core fill watcher (Finalized once every step is done and a fill tx exists, Executing while a step is in progress, Pending otherwise), plus `findBridge` to match the activity by origin tx hash.
- **`openedIntentResponseAdapter`** — `adaptOpenedIntentResponse` turns a `/v1/activity` response into an `OpenedIntent`, using the origin tx hash as the order id and reading the destination chain; throws `OpenedIntentNotFoundError` when nothing matches.
- **`provider.getTrackingConfig`** — API-based opened-intent parser + fill watcher (same shape as Bungee) over `/v1/activity`, with `/v1/index_transaction` as the pre-tracker.

## Tests

Unit tests on the activity and opened-intent adapters with mocked status payloads, plus provider coverage for `getTrackingConfig`. 42 Superbridge tests green; typecheck and lint clean.

## Scope

Tracking only. Token discovery (`getDiscoveryConfig`) moved to its own issue (EFI-1007) and is not in this PR. The canonical Prove/Finalise build step (`getStepTransaction`) is intentionally out of scope. `getOrderExplorers` is left to the base-class default since Superbridge documents no explorer URL.

## Note

Stacked on `efi-998-implement-getquotes-and-submission-for-the-user-transaction`. The diff here is only the EFI-999 changes.
