### PR TITLE
feat(cross-chain): add Superbridge asset discovery

### DIFF
--- a/.changeset/superbridge-discovery-assets.md
+++ b/.changeset/superbridge-discovery-assets.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Add Superbridge asset discovery
+
+Wire `SuperbridgeProvider.getDiscoveryConfig` on top of the paginated `/v1/tokens` endpoint, exposing the Superbridge token list through `custom-api` discovery. `parseSuperbridgeTokens` groups the tokens by chain id into `NetworkAssets[]`. Adds a unit test on the discovery adapter.

--- a/packages/cross-chain/src/protocols/superbridge/adapters/discoveryAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/discoveryAdapter.ts
@@ -1,0 +1,31 @@
+import type { AssetInfo, NetworkAssets } from "../../../core/types/assetDiscovery.js";
+import type { SuperbridgeToken } from "../schemas.js";
+import { SuperbridgeTokensResponseSchema } from "../schemas.js";
+
+/** Parse a Superbridge GET `/v1/tokens` response into `NetworkAssets[]`. */
+export function parseSuperbridgeTokens(data: unknown): NetworkAssets[] {
+    const { tokens } = SuperbridgeTokensResponseSchema.parse(data);
+    const byChain = new Map<number, AssetInfo[]>();
+
+    for (const token of tokens) {
+        const chainId = Number(token.chainId);
+        if (!Number.isFinite(chainId)) continue;
+        const assets = byChain.get(chainId) ?? [];
+        assets.push(toAssetInfo(token));
+        byChain.set(chainId, assets);
+    }
+
+    return [...byChain.entries()]
+        .map(([chainId, assets]) => ({ chainId, assets }))
+        .filter((network) => network.assets.length > 0);
+}
+
+function toAssetInfo(token: SuperbridgeToken): AssetInfo {
+    return {
+        address: token.address,
+        symbol: token.symbol,
+        decimals: token.decimals,
+        name: token.name,
+        logoURI: token.logoUri ?? undefined,
+    };
+}

--- a/packages/cross-chain/src/protocols/superbridge/adapters/index.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/index.ts
@@ -1,4 +1,5 @@
 export { extractFillEvent, findBridge } from "./activityAdapter.js";
+export { parseSuperbridgeTokens } from "./discoveryAdapter.js";
 export { adaptOpenedIntentResponse } from "./openedIntentResponseAdapter.js";
 export { adaptQuoteRequest } from "./quoteRequestAdapter.js";
 export { adaptQuoteResponse } from "./quoteResponseAdapter.js";

--- a/packages/cross-chain/src/protocols/superbridge/constants.ts
+++ b/packages/cross-chain/src/protocols/superbridge/constants.ts
@@ -33,3 +33,6 @@ export const SUPERBRIDGE_CANONICAL_ROUTE_IDS = [
     "LxlyWithdrawal",
     "LxlyCross",
 ] as const;
+
+/** Page size requested from the paginated `/v1/tokens` discovery endpoint (API caps it). */
+export const SUPERBRIDGE_TOKENS_PAGE_LIMIT = 100;

--- a/packages/cross-chain/src/protocols/superbridge/provider.ts
+++ b/packages/cross-chain/src/protocols/superbridge/provider.ts
@@ -3,6 +3,7 @@ import { ZodError } from "zod";
 
 import type { SubmissionMode } from "../../core/schemas/providerConfig.js";
 import type {
+    AssetDiscoveryConfig,
     FillWatcherConfig,
     GetFillParams,
     HttpClient,
@@ -24,12 +25,14 @@ import {
     adaptQuoteRequest,
     adaptQuoteResponse,
     extractFillEvent,
+    parseSuperbridgeTokens,
 } from "./adapters/index.js";
 import {
     SUPERBRIDGE_API_URL,
     SUPERBRIDGE_DEFAULT_SUBMISSION_MODES,
     SUPERBRIDGE_PROTOCOL_NAME,
     SUPERBRIDGE_REQUEST_TIMEOUT_MS,
+    SUPERBRIDGE_TOKENS_PAGE_LIMIT,
 } from "./constants.js";
 import { SuperbridgeApiService } from "./services/index.js";
 import { SuperbridgeConfigSchema } from "./types.js";
@@ -153,6 +156,21 @@ export class SuperbridgeProvider extends CrossChainProvider {
                     chainId: String(params.originChainId),
                 }),
                 headers,
+            },
+        };
+    }
+
+    /**
+     * @inheritdoc
+     * Returns API-based discovery config using the Superbridge `/v1/tokens` endpoint.
+     */
+    override getDiscoveryConfig(): AssetDiscoveryConfig {
+        return {
+            type: "custom-api",
+            config: {
+                assetsEndpoint: `${this.baseUrl}/v1/tokens?limit=${SUPERBRIDGE_TOKENS_PAGE_LIMIT}`,
+                parseResponse: parseSuperbridgeTokens,
+                headers: this.apiHeaders,
             },
         };
     }

--- a/packages/cross-chain/test/protocols/superbridge/adapters/discoveryAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/discoveryAdapter.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSuperbridgeTokens } from "../../../../src/protocols/superbridge/adapters/discoveryAdapter.js";
+
+describe("parseSuperbridgeTokens", () => {
+    it("groups tokens by chain id", () => {
+        const networks = parseSuperbridgeTokens({
+            tokens: [
+                {
+                    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    chainId: "1",
+                    symbol: "USDC",
+                    decimals: 6,
+                },
+                {
+                    address: "0x0000000000000000000000000000000000000000",
+                    chainId: "8453",
+                    symbol: "ETH",
+                    decimals: 18,
+                },
+            ],
+        });
+
+        expect(networks).toHaveLength(2);
+        const ethereum = networks.find((n) => n.chainId === 1);
+        expect(ethereum?.assets[0]!.symbol).toBe("USDC");
+    });
+});

--- a/packages/cross-chain/test/protocols/superbridge/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/provider.spec.ts
@@ -208,4 +208,15 @@ describe("SuperbridgeProvider", () => {
             ).toEqual({ txHash: FILL_TX_HASH, chainId: "1" });
         });
     });
+
+    describe("getDiscoveryConfig()", () => {
+        it("returns a custom-api discovery config", () => {
+            const config = provider.getDiscoveryConfig();
+
+            expect(config.type).toBe("custom-api");
+            if (config.type === "custom-api") {
+                expect(config.config.assetsEndpoint).toContain("/v1/tokens");
+            }
+        });
+    });
 });


### PR DESCRIPTION
Adds Superbridge token discovery so the aggregator knows which assets the provider supports. Split out of the tracking work (EFI-999) into its own issue.

Closes EFI-1007.

## What's here

- **`discoveryAdapter`** — `parseSuperbridgeTokens` parses a `/v1/tokens` response and groups the tokens by chain id into `NetworkAssets[]`, dropping entries with a non-numeric chain id.
- **`provider.getDiscoveryConfig`** — `custom-api` discovery pointing at the paginated `/v1/tokens` endpoint.
- **Constant** — `SUPERBRIDGE_TOKENS_PAGE_LIMIT`.

## Tests

Unit test on the discovery adapter, plus provider coverage for `getDiscoveryConfig`. 44 Superbridge tests green; typecheck and lint clean.

## Note

Stacked on `efi-999-add-superbridge-order-tracking`. The diff here is only the EFI-1007 changes.
