### PR TITLE
feat(cross-chain): add the Superbridge gasless submission mode

### DIFF
--- a/.changeset/superbridge-gasless-submission.md
+++ b/.changeset/superbridge-gasless-submission.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Add the Superbridge gasless submission mode
+
+Implement `SuperbridgeProvider.submitOrder` for the signature-based (gasless) route: `adaptSubmitGaslessRequest` builds the `/v1/submit_gasless` body from the quote's signature-step metadata and the user's signature, and `adaptSubmitGaslessResponse` maps the response to a `SubmitOrderResponse` (failing when no transaction hash comes back). Gasless quotes are already emitted by `getQuotes` when `submissionModes` includes `"gasless"`. Adds unit tests on both submit adapters and the provider submit path.

--- a/packages/cross-chain/src/protocols/superbridge/adapters/index.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/index.ts
@@ -3,3 +3,5 @@ export { parseSuperbridgeTokens } from "./discoveryAdapter.js";
 export { adaptOpenedIntentResponse } from "./openedIntentResponseAdapter.js";
 export { adaptQuoteRequest } from "./quoteRequestAdapter.js";
 export { adaptQuoteResponse } from "./quoteResponseAdapter.js";
+export { adaptSubmitGaslessRequest } from "./submitGaslessRequestAdapter.js";
+export { adaptSubmitGaslessResponse } from "./submitGaslessResponseAdapter.js";

--- a/packages/cross-chain/src/protocols/superbridge/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/quoteResponseAdapter.ts
@@ -12,6 +12,7 @@ import type {
     SuperbridgeRouteStep,
     SuperbridgeTokenApproval,
 } from "../schemas.js";
+import { ProviderGetQuoteFailure } from "../../../internal.js";
 import { SuperbridgeRouteQuoteSchema, SuperbridgeTypedDataSchema } from "../schemas.js";
 
 const MODE_BY_TX_TYPE = {
@@ -24,6 +25,8 @@ const MODE_BY_TX_TYPE = {
  *
  * Keeps only successful quotes (those with an `initiatingTransaction`) whose
  * initiating transaction type matches an enabled submission mode.
+ *
+ * @throws {ProviderGetQuoteFailure} When every route requires a submission mode that is not enabled.
  */
 export function adaptQuoteResponse(
     response: SuperbridgeRoutesResponse,
@@ -32,12 +35,25 @@ export function adaptQuoteResponse(
     modes: ReadonlySet<SubmissionMode>,
 ): Quote[] {
     const quotes: Quote[] = [];
+    const unavailableModes = new Set<SubmissionMode>();
     for (const result of response.results) {
         const parsed = SuperbridgeRouteQuoteSchema.safeParse(result.result);
         if (!parsed.success) continue;
-        const quote = adaptRouteQuote(parsed.data, result.meta, providerId, params, modes);
+        const mode = MODE_BY_TX_TYPE[parsed.data.initiatingTransaction.type];
+        if (!modes.has(mode)) {
+            unavailableModes.add(mode);
+            continue;
+        }
+        const quote = adaptRouteQuote(parsed.data, result.meta, providerId, params);
         if (quote) quotes.push(quote);
     }
+
+    if (quotes.length === 0 && unavailableModes.size > 0) {
+        throw new ProviderGetQuoteFailure(
+            `No Superbridge routes match the enabled submission modes. Available routes require: ${[...unavailableModes].join(", ")}`,
+        );
+    }
+
     return quotes;
 }
 
@@ -46,10 +62,7 @@ function adaptRouteQuote(
     meta: SuperbridgeRouteMeta | undefined,
     providerId: string,
     params: QuoteRequest,
-    modes: ReadonlySet<SubmissionMode>,
 ): Quote | null {
-    if (!modes.has(MODE_BY_TX_TYPE[route.initiatingTransaction.type])) return null;
-
     const routeId = meta?.id;
     const mainStep = buildMainStep(route, routeId);
     if (!mainStep) return null;
@@ -97,6 +110,7 @@ function buildSignatureStep(
 ): SignatureStep | null {
     const parsed = SuperbridgeTypedDataSchema.safeParse(safeJsonParse(tx.typedData));
     if (!parsed.success) return null;
+    if (!routeId) return null;
 
     return {
         kind: "signature",

--- a/packages/cross-chain/src/protocols/superbridge/adapters/submitGaslessRequestAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/submitGaslessRequestAdapter.ts
@@ -1,0 +1,34 @@
+import type { Hex } from "viem";
+
+import type { Quote } from "../../../core/schemas/quote.js";
+import type { SuperbridgeSubmitGaslessRequest } from "../schemas.js";
+import { ProviderExecuteFailure } from "../../../internal.js";
+import { SuperbridgeGaslessStepMetadataSchema } from "../schemas.js";
+
+/**
+ * Build a Superbridge `/v1/submit_gasless` request from a quote's signature step
+ * metadata and the user's signature.
+ *
+ * @throws {ProviderExecuteFailure} When the quote lacks gasless metadata.
+ */
+export function adaptSubmitGaslessRequest(
+    quote: Quote,
+    signature: Hex,
+): SuperbridgeSubmitGaslessRequest {
+    const signatureStep = quote.order.steps.find((step) => step.kind === "signature");
+    const metadata = SuperbridgeGaslessStepMetadataSchema.safeParse(signatureStep?.metadata);
+
+    if (!metadata.success) {
+        throw new ProviderExecuteFailure(
+            "Missing Superbridge gasless metadata in signature step. Ensure submissionModes includes 'gasless'.",
+            `quoteId: ${quote.quoteId}`,
+        );
+    }
+
+    return {
+        typedData: metadata.data.superbridgeTypedData,
+        signature,
+        id: metadata.data.superbridgeRouteId,
+        chainId: metadata.data.superbridgeChainId,
+    };
+}

--- a/packages/cross-chain/src/protocols/superbridge/adapters/submitGaslessResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/submitGaslessResponseAdapter.ts
@@ -1,0 +1,27 @@
+import { isHex } from "viem";
+
+import type { SubmitOrderResponse } from "../../../core/schemas/quote.js";
+import type { SuperbridgeSubmitGaslessResponse } from "../schemas.js";
+import { ProviderExecuteFailure } from "../../../internal.js";
+
+/**
+ * Build an SDK SubmitOrderResponse from a Superbridge gasless submission response.
+ *
+ * @throws {ProviderExecuteFailure} When the response carries no transaction hash.
+ */
+export function adaptSubmitGaslessResponse(
+    response: SuperbridgeSubmitGaslessResponse,
+): SubmitOrderResponse {
+    const candidate = response.txHash ?? response.id;
+    if (!candidate || !isHex(candidate)) {
+        throw new ProviderExecuteFailure(
+            "Superbridge gasless submission returned no transaction hash",
+        );
+    }
+
+    return {
+        orderId: candidate,
+        status: response.status,
+        message: response.message,
+    };
+}

--- a/packages/cross-chain/src/protocols/superbridge/adapters/submitGaslessResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/submitGaslessResponseAdapter.ts
@@ -12,15 +12,15 @@ import { ProviderExecuteFailure } from "../../../internal.js";
 export function adaptSubmitGaslessResponse(
     response: SuperbridgeSubmitGaslessResponse,
 ): SubmitOrderResponse {
-    const candidate = response.txHash ?? response.id;
-    if (!candidate || !isHex(candidate)) {
+    const txHash = response.txHash;
+    if (!txHash || !isHex(txHash)) {
         throw new ProviderExecuteFailure(
             "Superbridge gasless submission returned no transaction hash",
         );
     }
 
     return {
-        orderId: candidate,
+        orderId: txHash,
         status: response.status,
         message: response.message,
     };

--- a/packages/cross-chain/src/protocols/superbridge/provider.ts
+++ b/packages/cross-chain/src/protocols/superbridge/provider.ts
@@ -12,6 +12,7 @@ import type {
     PreTrackerParams,
     Quote,
     QuoteRequest,
+    SubmitOrderResponse,
 } from "../../internal.js";
 import type { SuperbridgeConfigs } from "./types.js";
 import {
@@ -24,6 +25,8 @@ import {
     adaptOpenedIntentResponse,
     adaptQuoteRequest,
     adaptQuoteResponse,
+    adaptSubmitGaslessRequest,
+    adaptSubmitGaslessResponse,
     extractFillEvent,
     parseSuperbridgeTokens,
 } from "./adapters/index.js";
@@ -107,6 +110,18 @@ export class SuperbridgeProvider extends CrossChainProvider {
                 error instanceof Error ? error.stack : undefined,
             );
         }
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * Submits a signed gasless authorization to `/v1/submit_gasless`.
+     * Reads the typed data from the signature step metadata set during quote adaptation.
+     */
+    override async submitOrder(quote: Quote, signature: Hex): Promise<SubmitOrderResponse> {
+        const request = adaptSubmitGaslessRequest(quote, signature);
+        const response = await this.apiService.submitGasless(request);
+        return adaptSubmitGaslessResponse(response);
     }
 
     /**

--- a/packages/cross-chain/test/protocols/superbridge/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/quoteResponseAdapter.spec.ts
@@ -6,6 +6,7 @@ import type {
     SuperbridgeRouteResult,
     SuperbridgeRoutesResponse,
 } from "../../../../src/protocols/superbridge/schemas.js";
+import { ProviderGetQuoteFailure } from "../../../../src/core/errors/ProviderGetQuoteFailure.exception.js";
 import { adaptQuoteResponse } from "../../../../src/protocols/superbridge/adapters/quoteResponseAdapter.js";
 
 const USER = "0x1234567890abcdef1234567890abcdef12345678";
@@ -130,15 +131,22 @@ describe("adaptQuoteResponse", () => {
         expect(quotes).toHaveLength(0);
     });
 
-    it("skips gasless routes when only user-transaction mode is enabled", () => {
+    it("throws when every route requires a submission mode that is not enabled", () => {
+        expect(() =>
+            adaptQuoteResponse(response([gaslessResult()]), PROVIDER_ID, request(), userTxModes),
+        ).toThrow(ProviderGetQuoteFailure);
+    });
+
+    it("returns matching quotes and ignores routes for other submission modes", () => {
         const quotes = adaptQuoteResponse(
-            response([gaslessResult()]),
+            response([evmResult(), gaslessResult()]),
             PROVIDER_ID,
             request(),
             userTxModes,
         );
 
-        expect(quotes).toHaveLength(0);
+        expect(quotes).toHaveLength(1);
+        expect(quotes[0]!.order.steps[0]!.kind).toBe("transaction");
     });
 
     it("maps a gasless route to a signature quote when enabled", () => {
@@ -151,6 +159,31 @@ describe("adaptQuoteResponse", () => {
 
         expect(quotes).toHaveLength(1);
         expect(quotes[0]!.order.steps[0]!.kind).toBe("signature");
+    });
+
+    it("skips a gasless route that carries invalid typed data", () => {
+        const result: SuperbridgeRouteResult = {
+            meta: { id: "route-gasless" },
+            result: {
+                initiatingTransaction: {
+                    type: "evm-gasless",
+                    chainId: "1",
+                    typedData: "not-valid-json",
+                },
+            },
+        };
+
+        const quotes = adaptQuoteResponse(response([result]), PROVIDER_ID, request(), gaslessModes);
+
+        expect(quotes).toHaveLength(0);
+    });
+
+    it("skips a gasless route that is missing the route id", () => {
+        const result: SuperbridgeRouteResult = { result: gaslessResult().result };
+
+        const quotes = adaptQuoteResponse(response([result]), PROVIDER_ID, request(), gaslessModes);
+
+        expect(quotes).toHaveLength(0);
     });
 
     it("prepends revoke and approval steps in order", () => {

--- a/packages/cross-chain/test/protocols/superbridge/adapters/submitGaslessRequestAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/submitGaslessRequestAdapter.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import type { Quote } from "../../../../src/core/schemas/quote.js";
+import { ProviderExecuteFailure } from "../../../../src/core/errors/ProviderExecuteFailure.exception.js";
+import { adaptSubmitGaslessRequest } from "../../../../src/protocols/superbridge/adapters/submitGaslessRequestAdapter.js";
+
+const ADDR = "0x1234567890abcdef1234567890abcdef12345678";
+
+function preview(): Quote["preview"] {
+    return {
+        inputs: [{ chainId: 1, accountAddress: ADDR, assetAddress: ADDR, amount: "1000" }],
+        outputs: [{ chainId: 8453, accountAddress: ADDR, assetAddress: ADDR, amount: "990" }],
+    };
+}
+
+function gaslessQuote(): Quote {
+    return {
+        order: {
+            steps: [
+                {
+                    kind: "signature",
+                    chainId: 1,
+                    signaturePayload: {
+                        signatureType: "eip712",
+                        domain: {},
+                        primaryType: "Order",
+                        types: {},
+                        message: {},
+                    },
+                    metadata: {
+                        superbridgeTypedData: "{}",
+                        superbridgeRouteId: "r1",
+                        superbridgeChainId: "1",
+                    },
+                },
+            ],
+        },
+        preview: preview(),
+        provider: "superbridge",
+    };
+}
+
+describe("adaptSubmitGaslessRequest", () => {
+    it("builds a request from the signature step metadata", () => {
+        const request = adaptSubmitGaslessRequest(gaslessQuote(), "0xsignature");
+
+        expect(request.typedData).toBe("{}");
+        expect(request.signature).toBe("0xsignature");
+        expect(request.id).toBe("r1");
+    });
+
+    it("throws when gasless metadata is missing", () => {
+        const quote: Quote = {
+            order: {
+                steps: [{ kind: "transaction", chainId: 1, transaction: { to: ADDR, data: "0x" } }],
+            },
+            preview: preview(),
+            provider: "superbridge",
+        };
+
+        expect(() => adaptSubmitGaslessRequest(quote, "0xsignature")).toThrow(
+            ProviderExecuteFailure,
+        );
+    });
+});

--- a/packages/cross-chain/test/protocols/superbridge/adapters/submitGaslessResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/submitGaslessResponseAdapter.spec.ts
@@ -19,4 +19,8 @@ describe("adaptSubmitGaslessResponse", () => {
             ProviderExecuteFailure,
         );
     });
+
+    it("does not fall back to a hex id when the transaction hash is absent", () => {
+        expect(() => adaptSubmitGaslessResponse({ id: FILL_TX })).toThrow(ProviderExecuteFailure);
+    });
 });

--- a/packages/cross-chain/test/protocols/superbridge/adapters/submitGaslessResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/submitGaslessResponseAdapter.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { ProviderExecuteFailure } from "../../../../src/core/errors/ProviderExecuteFailure.exception.js";
+import { adaptSubmitGaslessResponse } from "../../../../src/protocols/superbridge/adapters/submitGaslessResponseAdapter.js";
+
+const FILL_TX = "0xabc1230000000000000000000000000000000000000000000000000000000000";
+
+describe("adaptSubmitGaslessResponse", () => {
+    it("maps a submission response to a submit order response", () => {
+        expect(adaptSubmitGaslessResponse({ txHash: FILL_TX, status: "submitted" })).toEqual({
+            orderId: FILL_TX,
+            status: "submitted",
+            message: undefined,
+        });
+    });
+
+    it("throws when the response carries no transaction hash", () => {
+        expect(() => adaptSubmitGaslessResponse({ id: "uuid-not-hex" })).toThrow(
+            ProviderExecuteFailure,
+        );
+    });
+});

--- a/packages/cross-chain/test/protocols/superbridge/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/provider.spec.ts
@@ -196,6 +196,23 @@ describe("SuperbridgeProvider", () => {
         });
     });
 
+    describe("submitOrder()", () => {
+        it("submits a gasless signature and returns the tx hash", async () => {
+            const gaslessProvider = new SuperbridgeProvider({
+                submissionModes: ["gasless"],
+                apiKey: API_KEY,
+            });
+            mockPost.mockResolvedValueOnce(httpOk({ results: [makeGaslessRouteResult()] }));
+            const [quote] = await gaslessProvider.getQuotes(makeQuoteRequest());
+
+            mockPost.mockResolvedValueOnce(httpOk({ txHash: FILL_TX_HASH, status: "submitted" }));
+            const response = await gaslessProvider.submitOrder(quote!, "0xsignature");
+
+            expect(response.orderId).toBe(FILL_TX_HASH);
+            expect(response.status).toBe("submitted");
+        });
+    });
+
     describe("getTrackingConfig()", () => {
         it("builds activity-based tracking and index pre-tracker", () => {
             const config = provider.getTrackingConfig();

--- a/packages/cross-chain/test/protocols/superbridge/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/provider.spec.ts
@@ -85,9 +85,8 @@ function makeGaslessRouteResult(): unknown {
         message: { amount: INPUT_AMOUNT },
     });
     return {
+        meta: { id: "route-gasless", provider: { name: "across-v3" } },
         result: {
-            id: "route-gasless",
-            provider: { name: "across-v3" },
             initiatingTransaction: {
                 type: "evm-gasless",
                 chainId: String(ORIGIN_CHAIN_ID),
@@ -149,12 +148,12 @@ describe("SuperbridgeProvider", () => {
             expect(quotes[0]!.fees?.bridgeFee?.amount).toBe("5000");
         });
 
-        it("filters out gasless routes when only user-transaction mode is enabled", async () => {
+        it("throws when every route requires a submission mode that is not enabled", async () => {
             mockPost.mockResolvedValue(httpOk({ results: [makeGaslessRouteResult()] }));
 
-            const quotes = await provider.getQuotes(makeQuoteRequest());
-
-            expect(quotes).toHaveLength(0);
+            await expect(provider.getQuotes(makeQuoteRequest())).rejects.toBeInstanceOf(
+                ProviderGetQuoteFailure,
+            );
         });
 
         it("returns a signature quote when gasless mode is enabled", async () => {


### PR DESCRIPTION
Adds the gasless (signature-based) submission path alongside the user-transaction one, building on the quote flow from EFI-998.

Closes EFI-1000.

## What's here

- **`submitGaslessRequestAdapter`** — `adaptSubmitGaslessRequest` reads the signature step's gasless metadata (`superbridgeTypedData`, `superbridgeRouteId`, `superbridgeChainId`) and the user's signature to build a `/v1/submit_gasless` body. Throws `ProviderExecuteFailure` when the quote carries no gasless metadata (i.e. `submissionModes` didn't include `gasless`).
- **`submitGaslessResponseAdapter`** — `adaptSubmitGaslessResponse` maps the submission response to a `SubmitOrderResponse`, failing when no transaction hash comes back.
- **`provider.submitOrder`** — override that wires both adapters through the API service.

Gasless quotes themselves are already produced by `getQuotes` (the quote-response adapter emits a signature step when `submissionModes` includes `gasless`), so no quote-side change was needed here.

## Tests

Unit tests on both submit adapters, plus a provider `submitOrder` path test (quote → sign → submit). 49 Superbridge tests green; typecheck and lint clean.

## Deviations from the issue

- **No `validators/signatureEnvelopeValidator.ts`.** The reference implementation keeps the gasless validation inside the adapters: the typed data is validated by `SuperbridgeTypedDataSchema` when the quote is built, and `adaptSubmitGaslessRequest` validates the step metadata. A standalone envelope validator would be redundant.
- **Docs entry and the real-route e2e check are not in this PR.** They read better once the provider is wired into the factory (EFI-997) and creatable by name; flagging them as remaining closing tasks for the parent.

## Note

Stacked on `efi-1007-add-discovery-assets`. The diff here is only the EFI-1000 changes.
