### PR TITLE
feat(cross-chain): wire Superbridge into the provider factory and aggregator

### DIFF
--- a/.changeset/superbridge-factory-aggregator.md
+++ b/.changeset/superbridge-factory-aggregator.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Wire Superbridge into the provider factory and aggregator
+
+Register `superbridge` in `PROTOCOLS`, `SupportedProtocolsConfigs` and `PROTOCOL_FACTORIES`, and export `SuperbridgeProvider`/`SuperbridgeConfigs` from the package entrypoint. `createCrossChainProvider("superbridge", { apiKey })` now returns a `SuperbridgeProvider`, and the aggregator accepts a `SuperbridgeProvider` instance. Its config is required (`apiKey`), so — like `oif` — `superbridge` is not an optional-config protocol and is passed to `createAggregator` as an instance, not a bare string.

--- a/packages/cross-chain/src/external.ts
+++ b/packages/cross-chain/src/external.ts
@@ -23,6 +23,8 @@ export {
     BungeeProvider,
     BungeeApiTier,
     type BungeeConfigs,
+    SuperbridgeProvider,
+    type SuperbridgeConfigs,
     createCrossChainProvider,
     // Aggregator
     Aggregator,

--- a/packages/cross-chain/src/factories/crossChainProviderFactory.ts
+++ b/packages/cross-chain/src/factories/crossChainProviderFactory.ts
@@ -10,6 +10,7 @@ import {
     LifiIntentsProvider,
     OifProvider,
     RelayProvider,
+    SuperbridgeProvider,
     UnsupportedProtocol,
 } from "../internal.js";
 import { PROTOCOLS } from "./providers.js";
@@ -28,11 +29,12 @@ const PROTOCOL_FACTORIES: {
     [PROTOCOLS.BUNGEE]: (config) => new BungeeProvider(config ?? {}),
     [PROTOCOLS.OIF]: (config) => new OifProvider(config),
     [PROTOCOLS.LIFI_INTENTS]: (config) => new LifiIntentsProvider(config ?? {}),
+    [PROTOCOLS.SUPERBRIDGE]: (config) => new SuperbridgeProvider(config),
 };
 
 /**
  * Creates a provider for the given protocol; config is required for `oif`
- * and optional for `across`/`relay`/`bungee`/`lifi-intents`.
+ * and `superbridge`, and optional for `across`/`relay`/`bungee`/`lifi-intents`.
  *
  * @throws {UnsupportedProtocol} If the protocol is not registered.
  */

--- a/packages/cross-chain/src/factories/providers.ts
+++ b/packages/cross-chain/src/factories/providers.ts
@@ -4,6 +4,7 @@ import type {
     LifiIntentsProviderConfig,
     OifProviderConfig,
     RelayConfigs,
+    SuperbridgeConfigs,
 } from "../internal.js";
 
 export const PROTOCOLS = {
@@ -12,6 +13,7 @@ export const PROTOCOLS = {
     LIFI_INTENTS: "lifi-intents",
     RELAY: "relay",
     BUNGEE: "bungee",
+    SUPERBRIDGE: "superbridge",
 } as const;
 
 export type SupportedProtocols = (typeof PROTOCOLS)[keyof typeof PROTOCOLS];
@@ -23,6 +25,7 @@ export type SupportedProtocolsConfigs<P extends SupportedProtocols> = {
     [PROTOCOLS.BUNGEE]: BungeeConfigs;
     [PROTOCOLS.OIF]: OifProviderConfig;
     [PROTOCOLS.LIFI_INTENTS]: LifiIntentsProviderConfig;
+    [PROTOCOLS.SUPERBRIDGE]: SuperbridgeConfigs;
 }[P];
 
 /** Protocols whose config is optional. */

--- a/packages/cross-chain/test/services/aggregator.spec.ts
+++ b/packages/cross-chain/test/services/aggregator.spec.ts
@@ -211,6 +211,15 @@ describe("Aggregator", () => {
             expect(providers.get("mockProviderA")).toBe(mockProviderA);
         });
 
+        it("accepts a SuperbridgeProvider instance (config-required, like oif)", () => {
+            const superbridge = createCrossChainProvider("superbridge", { apiKey: "sb-test-key" });
+            const aggregator = createAggregator({ providers: [superbridge] });
+            const { providers } = aggregator as unknown as {
+                providers: Map<string, CrossChainProvider>;
+            };
+            expect(providers.get("superbridge")).toBe(superbridge);
+        });
+
         it("throws when a string and an instance resolve to the same providerId", () => {
             expect(() =>
                 createAggregator({

--- a/packages/cross-chain/test/services/crossChainProviderFactory.spec.ts
+++ b/packages/cross-chain/test/services/crossChainProviderFactory.spec.ts
@@ -8,6 +8,7 @@ import {
     LifiIntentsProvider,
     OifProvider,
     RelayProvider,
+    SuperbridgeProvider,
     UnsupportedProtocol,
 } from "../../src/internal.js";
 
@@ -79,6 +80,13 @@ describe("createCrossChainProvider", () => {
         });
 
         expect(provider).toBeInstanceOf(LifiIntentsProvider);
+    });
+
+    it("creates a SuperbridgeProvider with required config", () => {
+        const provider = createCrossChainProvider("superbridge", { apiKey: "sb-test-key" });
+
+        expect(provider).toBeInstanceOf(SuperbridgeProvider);
+        expect(provider.getProviderId()).toBe("superbridge");
     });
 
     it("throws an UnsupportedProtocol error for unsupported protocols", () => {


### PR DESCRIPTION
Registers Superbridge in the provider factory and aggregator so it can be created by name and passed to the aggregator. Last piece of the Superbridge provider work.

Closes EFI-997.

## Changes

- **`factories/providers.ts`** — add `SUPERBRIDGE: "superbridge"` to `PROTOCOLS` and `SuperbridgeConfigs` to `SupportedProtocolsConfigs`.
- **`factories/crossChainProviderFactory.ts`** — add the `PROTOCOL_FACTORIES` entry.
- **`external.ts`** — export `SuperbridgeProvider` and `SuperbridgeConfigs`.

`protocols/index.ts` already re-exported the provider from the scaffold, so no change there.

## Config is required (like `oif`)

Superbridge needs an `apiKey`, so it is **not** added to `OptionalConfigProtocols`. As with `oif`, that means it can't be passed to `createAggregator` as a bare string (the string form only accepts optional-config protocols) — it's passed as an instance. `createCrossChainProvider("superbridge", { apiKey })` is the string-name + config path.

## Tests

- `createCrossChainProvider("superbridge", { apiKey })` returns a `SuperbridgeProvider` with providerId `superbridge`.
- `createAggregator` registers a `SuperbridgeProvider` instance under `superbridge`.

82 tests green across the factory, aggregator and Superbridge suites; typecheck and lint clean.

## Note

Stacked on `efi-1000-add-the-gasless-submission-mode`. The docs entry and the real-route e2e check (parent acceptance) are still open and not in this PR.
