### PR TITLE
fix(cross-chain): accept null swap steps and approvalTxns in Across quotes

### DIFF
--- a/.changeset/across-nullable-steps.md
+++ b/.changeset/across-nullable-steps.md
@@ -1,0 +1,5 @@
+---
+"@wonderland/interop-cross-chain": patch
+---
+
+Accept explicit `null` in Across `/swap/approval` responses for `steps.originSwap`, `steps.destinationSwap` and `approvalTxns`. The Across API now serializes absent steps as `null` instead of omitting them, which broke quote parsing for every route.

--- a/packages/cross-chain/src/protocols/across/provider.ts
+++ b/packages/cross-chain/src/protocols/across/provider.ts
@@ -883,6 +883,6 @@ export class AcrossProvider extends CrossChainProvider {
         if (response.crossSwapType === "bridgeableToAny") return true;
         if (response.crossSwapType === "anyToAny") return true;
         if (response.crossSwapType === "bridgeableToBridgeableIndirect") return true;
-        return response.steps?.destinationSwap !== undefined;
+        return response.steps?.destinationSwap != null;
     }
 }

--- a/packages/cross-chain/src/protocols/across/schemas.ts
+++ b/packages/cross-chain/src/protocols/across/schemas.ts
@@ -121,9 +121,9 @@ export const AcrossDestinationSwapStepSchema = z.object({
 });
 
 export const AcrossStepsSchema = z.object({
-    originSwap: AcrossOriginSwapStepSchema.optional(),
-    bridge: AcrossBridgeStepSchema.optional(),
-    destinationSwap: AcrossDestinationSwapStepSchema.optional(),
+    originSwap: AcrossOriginSwapStepSchema.nullish(),
+    bridge: AcrossBridgeStepSchema.nullish(),
+    destinationSwap: AcrossDestinationSwapStepSchema.nullish(),
 });
 
 export const AcrossBridgeFeeWithBreakdownSchema = FeeSchema.extend({
@@ -181,7 +181,7 @@ export const AcrossGetQuoteResponseSchema = z.object({
     id: z.string(),
     crossSwapType: AcrossCrossSwapTypeSchema.optional(),
     amountType: z.string().optional(),
-    approvalTxns: z.array(AcrossApprovalTxSchema).optional(),
+    approvalTxns: z.array(AcrossApprovalTxSchema).nullish(),
     checks: AcrossChecksSchema.optional(),
     steps: AcrossStepsSchema.optional(),
     inputToken: TokenSchema,

--- a/packages/cross-chain/test/providers/AcrossProvider.spec.ts
+++ b/packages/cross-chain/test/providers/AcrossProvider.spec.ts
@@ -307,6 +307,40 @@ describe("AcrossProvider", () => {
             expect(quote!.fallbackToken).toBeUndefined();
         });
 
+        it("parses swap steps serialized as null and keeps fallbackToken undefined", async () => {
+            vi.mocked(httpRequest).mockResolvedValueOnce({
+                status: 200,
+                data: getMockedAcrossApiResponse({
+                    crossSwapType: "bridgeableToBridgeable",
+                    approvalTxns: null,
+                    steps: {
+                        originSwap: null,
+                        bridge: {
+                            inputAmount: "1000000000000000000",
+                            outputAmount: "999000000000000000",
+                            tokenIn: {
+                                address: TESTNET_TOKENS.WETH_SEPOLIA,
+                                chainId: CHAIN_IDS.SEPOLIA,
+                                decimals: 18,
+                                symbol: "WETH",
+                            },
+                            tokenOut: {
+                                address: TESTNET_TOKENS.WETH_BASE_SEPOLIA,
+                                chainId: CHAIN_IDS.BASE_SEPOLIA,
+                                decimals: 18,
+                                symbol: "WETH",
+                            },
+                        },
+                        destinationSwap: null,
+                    },
+                }),
+                headers: new Headers(),
+            });
+
+            const [quote] = await provider.getQuotes(quoteRequest);
+            expect(quote!.fallbackToken).toBeUndefined();
+        });
+
         it("returns the bridge output token when the route ends in a destination swap", async () => {
             vi.mocked(httpRequest).mockResolvedValueOnce({
                 status: 200,


### PR DESCRIPTION
# 🤖 Linear

Closes EFI-1012

## Description

The Across API changed how it serializes `GET /swap/approval` responses: optional fields it used to omit now come back as explicit `null`. `steps.originSwap` and `steps.destinationSwap` are `null` on routes without a swap on that side, and `approvalTxns` is `null` on native ETH routes. Our schemas declared those fields with `.optional()`, which rejects `null`, so every Across quote failed with `Failed to parse Across quote` regardless of chain or token.

Changes:

- `protocols/across/schemas.ts`: `originSwap`, `bridge` and `destinationSwap` in `AcrossStepsSchema`, plus `approvalTxns` in `AcrossGetQuoteResponseSchema`, move from `.optional()` to `.nullish()`. The Across docs mark these fields as not required, so accepting `null` matches the spec.
- `protocols/across/provider.ts`: `hasDestinationSwap` now compares with `!= null`. With a `null` destinationSwap the old `!== undefined` check would report a destination swap that does not exist and attach a wrong `fallbackToken` to atomic routes.
- `test/providers/AcrossProvider.spec.ts`: regression test with `originSwap`/`destinationSwap`/`approvalTxns` set to `null`, asserting the quote parses and `fallbackToken` stays undefined.
- Changeset (`patch`) for `@wonderland/interop-cross-chain`.

Verified against the live API with 25 quotes through the aggregator across Ethereum, Optimism, Polygon, Base and Arbitrum (USDC, USDT, DAI, WETH, WBTC, cbBTC, ARB, OP and native ETH; same-asset, origin-swap, destination-swap and any-to-any routes): all 25 succeed with this change, 5 failed without it.

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [x] If it is a core feature, I have included comprehensive tests.