### PR TITLE
fix(benchmark): rank quote race by output token, not USD value

### DIFF
--- a/apps/benchmark/app/components/race-table/constants.ts
+++ b/apps/benchmark/app/components/race-table/constants.ts
@@ -9,7 +9,12 @@ export const RACE_TABLE_COLUMNS: readonly BenchmarkColumn[] = [
   { key: 'rank', label: 'rank', className: 'w-10 md:w-12' },
   { key: 'provider', label: 'provider', className: 'md:w-60' },
   { key: 'latency', label: 'latency', className: 'hidden md:table-cell' },
-  { key: 'output', label: 'output', className: 'text-right md:w-[200px]' },
+  {
+    key: 'output',
+    label: 'output',
+    className: 'text-right md:w-[200px]',
+    tooltip: 'The winner is the provider that returns the most output.',
+  },
   { key: 'eta', label: 'eta', className: 'hidden md:table-cell md:w-[100px] text-right' },
   { key: 'status', label: 'status', className: 'hidden md:table-cell md:w-[160px] text-right' },
 ];

--- a/apps/benchmark/app/components/race-table/raceRows.ts
+++ b/apps/benchmark/app/components/race-table/raceRows.ts
@@ -47,7 +47,7 @@ export function orderRaceRows(rows: RaceRow[]): RaceRow[] {
     if (right.status === 'errored' && left.status !== 'errored') return -1;
 
     if (left.status === 'settled' && right.status === 'settled') {
-      return parseOptionalNumber(right.quote?.outputAmountUsd) - parseOptionalNumber(left.quote?.outputAmountUsd);
+      return compareByOutputDesc(left, right);
     }
 
     return providerIndex(left.provider.id) - providerIndex(right.provider.id);
@@ -94,7 +94,7 @@ export function findBestProvider(rows: RaceRow[], metric: 'output' | 'latency'):
   const settled = rows.filter((row) => row.status === 'settled' && row.quote);
   const sorted = [...settled].sort((left, right) => {
     if (metric === 'output') {
-      return parseOptionalNumber(right.quote?.outputAmountUsd) - parseOptionalNumber(left.quote?.outputAmountUsd);
+      return compareByOutputDesc(left, right);
     }
 
     return valueOrInfinity(left.quote?.latencyMs) - valueOrInfinity(right.quote?.latencyMs);
@@ -107,6 +107,27 @@ export function parseOptionalNumber(value: string | number | undefined): number 
   if (value === undefined) return 0;
   const parsed = typeof value === 'number' ? value : Number.parseFloat(value);
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+// Output amounts are integer base units of the destination asset. The race
+// always quotes the same output asset (USDC->USDC), so they compare directly,
+// and BigInt keeps it exact for 18-decimal tokens. A missing amount sorts last.
+// Ranking by the token received (not its USD value) is both the right measure
+// and robust: providers that omit a USD price still compete on equal footing.
+function outputBaseUnits(quote: ProviderQuoteResult | undefined): bigint {
+  if (quote?.outputAmount === undefined) return 0n;
+  try {
+    return BigInt(quote.outputAmount);
+  } catch {
+    return 0n;
+  }
+}
+
+// Descending by output received: the provider that returns the most wins.
+function compareByOutputDesc(left: RaceRow, right: RaceRow): number {
+  const a = outputBaseUnits(left.quote);
+  const b = outputBaseUnits(right.quote);
+  return a < b ? 1 : a > b ? -1 : 0;
 }
 
 const DECIMAL_AMOUNT_RE = /^\d+(\.\d+)?$/;


### PR DESCRIPTION
Team feedback: relay was crowned WINNER with 99.9697 USDC while across (99.9826) and lifi (99.9862) returned more USDC. The winner and row order were decided by `outputAmountUsd`, which is optional, the SDK leaves it undefined for some providers. `parseOptionalNumber(undefined)` returns 0, so providers without a USD price sank to the bottom even when they returned more tokens, crowning the wrong provider and biasing the benchmark against them.

The race quotes the same asset on both ends (USDC→USDC, the request fixes the output asset), so every provider returns the same token and the received amount is directly comparable. `orderRaceRows` and `findBestProvider('output')` now compare `outputAmount` as BigInt base units (exact for 18-decimal tokens); `outputAmountUsd` stays for display only. A missing amount sorts last.

Also made the criterion explicit: the OUTPUT column header now carries a tooltip, "The winner is the provider that returns the most output."

Verified in the browser: the provider returning the most USDC now wins and rows order by output descending, regardless of whether a provider reports a USD price.

Closes EFI-1013