### PR TITLE
fix(cross-chain): address bridge-UI QA feedback (observability gaps + docs drift)

### DIFF
--- a/.changeset/surface-skipped-providers.md
+++ b/.changeset/surface-skipped-providers.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Surface providers skipped by asset discovery in `getQuotes` errors
+
+`Aggregator.getQuotes` previously dropped a provider entirely when the discovery cache marked the requested input or output asset as unsupported — the provider appeared in neither `quotes` nor `errors`, making it indistinguishable from a flaky aggregation. Skipped providers now appear in `errors` with an `UnsupportedAsset` exception, `latencyMs: 0`, and the provider id, so UIs can label the reason instead of silently hiding the provider.

--- a/.changeset/validate-route-query.md
+++ b/.changeset/validate-route-query.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Validate `RouteQuery` input in `Aggregator.getProvidersForRoute`
+
+`getProvidersForRoute` previously returned `[]` for any malformed query — wrong shape, missing fields, non-hex addresses — which was indistinguishable from "no provider supports this route". Input now goes through a zod schema (`RouteQuerySchema`) so callers get a `ZodError` for bad input and an empty array only when the route really is unsupported. Quote requests have always been validated; route queries now match.

--- a/.changeset/validate-route-query.md
+++ b/.changeset/validate-route-query.md
@@ -5,3 +5,7 @@
 Validate `RouteQuery` input in `Aggregator.getProvidersForRoute`
 
 `getProvidersForRoute` previously returned `[]` for any malformed query — wrong shape, missing fields, non-hex addresses — which was indistinguishable from "no provider supports this route". Input now goes through a zod schema (`RouteQuerySchema`) so callers get a `ZodError` for bad input and an empty array only when the route really is unsupported. Quote requests have always been validated; route queries now match.
+
+`RouteQuerySchema` and the `RouteQuery` type are exported from the package entrypoint so consumers can validate input themselves before calling.
+
+Behavior change for callers that previously relied on the silent `[]` fallback: bad input now throws synchronously inside the awaited promise. Wrap calls in `try/catch` (or pre-validate with `RouteQuerySchema.safeParse`) to discriminate input errors from "no supported provider".

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ lcov.info
 
 .serie/
 .mcp.json
+.smithers/

--- a/.gitignore
+++ b/.gitignore
@@ -80,4 +80,3 @@ lcov.info
 
 .serie/
 .mcp.json
-.smithers/

--- a/apps/docs/src/pages/cross-chain/api.mdx
+++ b/apps/docs/src/pages/cross-chain/api.mdx
@@ -622,7 +622,7 @@ interface Quote {
     quoteId?: string;
     failureHandling?: string;
     partialFill?: boolean;
-    fallbackToken?: QuotePreviewEntry; // asset delivered when the destination swap fails (e.g. a Bungee refund token)
+    fallbackToken?: QuotePreviewEntry; // asset delivered when the destination swap fails (e.g. an Across or Relay refund token)
     fees?: QuoteFees;
     tracking?: QuoteTracking;
     metadata?: Record<string, unknown>;

--- a/apps/docs/src/pages/cross-chain/api.mdx
+++ b/apps/docs/src/pages/cross-chain/api.mdx
@@ -150,16 +150,18 @@ A utility for managing multiple cross-chain providers and executing operations a
 
 ### AggregatorConfig
 
-| Field              | Type                   | Required | Default                       | Description                                                                                                                                                                                                                                                                                                    |
-| ------------------ | ---------------------- | -------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `providers`        | `CrossChainProvider[]` | Yes      | —                             | Providers to aggregate over.                                                                                                                                                                                                                                                                                   |
-| `sortingStrategy`  | `SortingStrategy`      | No       | `BestOutputStrategy`          | Sorts the merged quote list. See [Sorting Strategies](#sorting-strategies).                                                                                                                                                                                                                                    |
-| `timeoutMs`        | `number`               | No       | `15_000`                      | Per-provider quote-fetch timeout. Each `provider.getQuotes(...)` call races a `setTimeout`; providers that don't respond in time surface a `ProviderTimeout` in `response.errors` rather than stalling `getQuotes`. Others continue normally.                                                                  |
-| `trackerFactory`   | `{ createTracker }`    | No       | `new OrderTrackerFactory()`   | Factory used by `aggregator.track(...)` and `aggregator.prepareTracking(...)` to build per-provider `OrderTracker` instances. The default falls back to viem's public transport per chain — supply `new OrderTrackerFactory({ rpcUrls })` for production reliability. See [Order Tracker](#order-tracker).     |
-| `discoveryFactory` | `{ createService }`    | No       | `new AssetDiscoveryFactory()` | Factory used by `aggregator.discoverAssets(...)` and `aggregator.getProvidersForRoute(...)` to build per-provider `AssetDiscoveryService` instances. Providers with no discovery support are skipped. Supply a custom factory only when you want to override discovery wiring for every provider.              |
-| `approvalService`  | `ApprovalService`      | No       | —                             | Enriches sorted quotes with ERC-20 `approve` steps. See [Approval Service](#approval-service).                                                                                                                                                                                                                 |
-| `spenderValidator` | `SpenderValidator`     | No       | —                             | Validates each quote's spender and transaction targets against a consumer-owned allowlist. Untrusted quotes are dropped from `getQuotes` (and reported in `errors`) and make `buildQuote` throw `UntrustedSpender`. See [Spender Validation](#spender-validation).                                             |
-| `sameAssetService` | `SameAssetService`     | No       | —                             | Resolves whether `buildQuote`'s input and output are the same asset, from a consumer-owned `assetId → chainId → address` map. When set, it replaces the default symbol/decimals/shared-provider heuristic; unknown pairings throw `DifferentAssetNotAllowed`. See [Same-Asset Identity](#same-asset-identity). |
+The factory accepts `CreateAggregatorConfig`, which extends the runtime `AggregatorConfig` only in that `providers` also accepts the protocol-name strings (`"across"`, `"relay"`, `"bungee"`, `"lifi-intents"`) the factory resolves to provider instances on your behalf.
+
+| Field              | Type                                                | Required | Default                       | Description                                                                                                                                                                                                                                                                                                    |
+| ------------------ | --------------------------------------------------- | -------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `providers`        | `(CrossChainProvider \| OptionalConfigProtocols)[]` | Yes      | —                             | Provider instances or protocol-name strings (`"across"`, `"relay"`, `"bungee"`, `"lifi-intents"`) that the factory creates with defaults. The two forms can be mixed.                                                                                                                                          |
+| `sortingStrategy`  | `SortingStrategy`                                   | No       | `BestOutputStrategy`          | Sorts the merged quote list. See [Sorting Strategies](#sorting-strategies).                                                                                                                                                                                                                                    |
+| `timeoutMs`        | `number`                                            | No       | `15_000`                      | Per-provider quote-fetch timeout. Each `provider.getQuotes(...)` call races a `setTimeout`; providers that don't respond in time surface a `ProviderTimeout` in `response.errors` rather than stalling `getQuotes`. Others continue normally.                                                                  |
+| `trackerFactory`   | `{ createTracker }`                                 | No       | `new OrderTrackerFactory()`   | Factory used by `aggregator.track(...)` and `aggregator.prepareTracking(...)` to build per-provider `OrderTracker` instances. The default falls back to viem's public transport per chain — supply `new OrderTrackerFactory({ rpcUrls })` for production reliability. See [Order Tracker](#order-tracker).     |
+| `discoveryFactory` | `{ createService }`                                 | No       | `new AssetDiscoveryFactory()` | Factory used by `aggregator.discoverAssets(...)` and `aggregator.getProvidersForRoute(...)` to build per-provider `AssetDiscoveryService` instances. Providers with no discovery support are skipped. Supply a custom factory only when you want to override discovery wiring for every provider.              |
+| `approvalService`  | `ApprovalService`                                   | No       | —                             | Enriches sorted quotes with ERC-20 `approve` steps. See [Approval Service](#approval-service).                                                                                                                                                                                                                 |
+| `spenderValidator` | `SpenderValidator`                                  | No       | —                             | Validates each quote's spender and transaction targets against a consumer-owned allowlist. Untrusted quotes are dropped from `getQuotes` (and reported in `errors`) and make `buildQuote` throw `UntrustedSpender`. See [Spender Validation](#spender-validation).                                             |
+| `sameAssetService` | `SameAssetService`                                  | No       | —                             | Resolves whether `buildQuote`'s input and output are the same asset, from a consumer-owned `assetId → chainId → address` map. When set, it replaces the default symbol/decimals/shared-provider heuristic; unknown pairings throw `DifferentAssetNotAllowed`. See [Same-Asset Identity](#same-asset-identity). |
 
 ### Aggregator Class
 
@@ -513,6 +515,36 @@ A class that tracks cross-chain orders through their lifecycle.
     console.log(status.status); // OrderStatus
     ```
 
+-   **on**(event: OrderStatus | OrderTrackerEvent, listener): this
+
+    Subscribes to status updates and tracker lifecycle events. Listeners attached _before_ `startTracking()` are guaranteed to see the first update — register them eagerly. Each `OrderStatus` value (`Pending`, `Finalized`, `Failed`, `Refunded`, …) is its own event, and the two non-status events (`OrderTrackerEvent.Timeout`, `OrderTrackerEvent.Error`) cover SDK-side timeouts and unexpected errors. Mirrors Node's `EventEmitter.on` and returns the tracker for chaining; pair with `off()` / `once()` from the same emitter API.
+
+    ```typescript
+    import { OrderStatus, OrderTrackerEvent } from "@wonderland/interop-cross-chain";
+
+    tracker.on(OrderStatus.Pending, (update) => console.log("Pending:", update.message));
+    tracker.on(OrderStatus.Finalized, (update) => console.log("Done!", update.fillTxHash));
+    tracker.on(OrderTrackerEvent.Timeout, (payload) => console.warn(payload.message));
+    tracker.on(OrderTrackerEvent.Error, (error) => console.error(error));
+    ```
+
+-   **startTracking**(params: WatchOrderParams): Promise\<OrderTrackingInfo\>
+
+    Event-based counterpart to `watchOrder`. Resolves with the order's final tracking info once a terminal status is reached and emits updates through the listeners attached with `on()`. Only the `txHash` flow is supported; for escrow-only orders, drive the `watchOrder()` async generator directly. To attach listeners before the transaction is broadcast, get the tracker from `aggregator.prepareTracking(providerId)`.
+
+    ```typescript
+    const tracker = aggregator.prepareTracking(quote.provider);
+    tracker.on(OrderStatus.Finalized, (update) => console.log("Done!", update.fillTxHash));
+
+    // ...send the user transaction, then:
+    const finalStatus = await tracker.startTracking({
+        txHash,
+        originChainId: 11155111,
+        destinationChainId: 84532,
+        timeout: 10 * 60 * 1000,
+    });
+    ```
+
 ## Types
 
 ### QuoteRequest
@@ -535,6 +567,21 @@ interface QuoteRequest {
     swapType?: "exact-input" | "exact-output"; // default: "exact-input"
 }
 ```
+
+The two `amount` fields are individually optional, but `swapType` determines which one is required: `"exact-input"` requires `input.amount` and `"exact-output"` requires `output.amount`. Requests that omit the matching amount are rejected by `QuoteRequestSchema` before reaching any provider.
+
+### RouteQuery
+
+```typescript
+interface RouteQuery {
+    originChainId: number; // numeric chain id (e.g. 1, 42161)
+    originAsset: string; // plain 0x token address on the origin chain
+    destinationChainId: number;
+    destinationAsset: string; // plain 0x token address on the destination chain
+}
+```
+
+Passed to [`Aggregator.getProvidersForRoute`](#aggregator-class). Validated by `RouteQuerySchema`: malformed input (wrong shape, missing fields, non-hex address) throws a `ZodError`. An empty result array means "no configured provider supports this route", not "your input was wrong".
 
 ### BuildQuoteRequest
 
@@ -566,31 +613,33 @@ interface BuildQuoteRequest {
 interface Quote {
     order: Order;
     preview: {
-        inputs: {
-            chainId: number;
-            accountAddress: string;
-            assetAddress: string;
-            amount: string;
-            amountUsd?: string;
-        }[];
-        outputs: {
-            chainId: number;
-            accountAddress: string;
-            assetAddress: string;
-            amount: string;
-            amountUsd?: string;
-        }[];
+        inputs: QuotePreviewEntry[];
+        outputs: QuotePreviewEntry[]; // outputs may set `minAmount` when the provider exposes a slippage floor
     };
     provider: string;
-    validUntil?: number; // quote validity (unix timestamp)
-    eta?: number; // estimated time to completion (seconds)
+    validUntil?: number; // best-effort quote-validity unix timestamp; populated only when the upstream provider returns one (currently OIF and LiFi Intents)
+    eta?: number; // estimated time to completion, in seconds
     quoteId?: string;
     failureHandling?: string;
     partialFill?: boolean;
+    fallbackToken?: QuotePreviewEntry; // asset delivered when the destination swap fails (e.g. a Bungee refund token)
     fees?: QuoteFees;
     tracking?: QuoteTracking;
     metadata?: Record<string, unknown>;
     latencyMs?: number; // Provider response time in ms, measured by the aggregator
+}
+```
+
+### QuotePreviewEntry
+
+```typescript
+interface QuotePreviewEntry {
+    chainId: number;
+    accountAddress: string;
+    assetAddress: string;
+    amount: string;
+    minAmount?: string; // outputs only — slippage floor when the provider exposes one
+    amountUsd?: string;
 }
 ```
 
@@ -620,11 +669,13 @@ interface QuoteTracking {
 
 ```typescript
 interface QuoteFees {
-    bridgeFee?: QuoteFeeEntry; // Bridge/relayer fee
-    bridgeFeePct?: string; // Fee as percentage (wei-encoded, 1e18 = 100%)
+    bridgeFee?: QuoteFeeEntry; // Bridge/relayer fee in input-token units
+    bridgeFeePct?: string; // Fee as a fraction, wei-scaled (1e18 = 100%). Decode as Number(value) / 1e18 — e.g. "122032826830417" ≈ 0.0122%.
     originGas?: QuoteFeeEntry; // Origin chain gas cost
 }
 ```
+
+Each `QuoteFees` field is populated only when the upstream provider exposes the corresponding data; consumers should treat every field as optional and fall back to `quote.preview` for the user-facing input/output amounts.
 
 ### Order
 
@@ -633,6 +684,61 @@ interface Order {
     steps: (SignatureStep | TransactionStep)[];
     lock?: LockMechanism;
     checks?: OrderChecks;
+    metadata?: Record<string, unknown>;
+}
+```
+
+### TransactionStep
+
+```typescript
+interface TransactionStep {
+    kind: "transaction";
+    category?: "approval"; // set by the approval service on prepended approve steps
+    chainId: number;
+    description?: string;
+    transaction: {
+        to: string;
+        data: string;
+        value?: string;
+        gas?: string;
+        maxFeePerGas?: string;
+        maxPriorityFeePerGas?: string;
+    };
+}
+```
+
+`category` is currently set only for the ERC-20 `approve` steps that the [Approval Service](#approval-service) prepends to `order.steps`. Use the helpers below to identify them programmatically — labeling wallet prompts as "Approve USDC" vs "Bridge" is the canonical use case.
+
+```typescript
+import {
+    getApprovalSteps,
+    getTransactionSteps,
+    isApprovalStep,
+} from "@wonderland/interop-cross-chain";
+
+for (const step of quote.order.steps) {
+    const label = isApprovalStep(step) ? "Approve" : "Bridge";
+    // ...send the transaction with `label` in the wallet prompt
+}
+
+const approvals = getApprovalSteps(quote.order); // TransactionStep[] with category === "approval"
+const txSteps = getTransactionSteps(quote.order); // every TransactionStep, approvals included
+```
+
+### SignatureStep
+
+```typescript
+interface SignatureStep {
+    kind: "signature";
+    chainId: number;
+    description?: string;
+    signaturePayload: {
+        signatureType: "eip712";
+        domain: Record<string, unknown>;
+        primaryType: string;
+        types: Record<string, { name: string; type: string }[]>;
+        message: Record<string, unknown>;
+    };
     metadata?: Record<string, unknown>;
 }
 ```
@@ -664,9 +770,18 @@ interface ExecutableQuote extends Quote {
 ```typescript
 interface GetQuotesResponse {
     quotes: ExecutableQuote[];
-    errors: { errorMsg: string; error: Error; latencyMs?: number }[];
+    errors: GetQuotesError[];
+}
+
+interface GetQuotesError {
+    error: Error;
+    errorMsg: string;
+    latencyMs?: number;
+    providerId?: string; // populated when the failing/skipped provider is known
 }
 ```
+
+A provider whose discovery cache reports the requested input or output asset as unsupported is reported here as an `UnsupportedAsset` error with `latencyMs: 0` — surfacing the skip rather than silently dropping the provider. Use `error instanceof UnsupportedAsset` to filter out "route just isn't supported" from real failures.
 
 ### TokenTransfer
 
@@ -820,13 +935,32 @@ Payload validation:
 | `oif-3009-v0`          | from, value, token address, expiration    |
 | `oif-user-open-v0`     | allowances (token, user, spender, amount) |
 
+### Bungee
+
+| Field                  | Type            | Required | Description                                                                                                                     |
+| ---------------------- | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `tier`                 | `BungeeApiTier` | No       | API tier: `"sandbox"` (default), `"dedicated"`, or `"frontend"`                                                                 |
+| `baseUrl`              | string          | No       | Custom API base URL. Overrides the URL derived from `tier`                                                                      |
+| `providerId`           | string          | No       | Custom provider identifier (default: `"bungee"`)                                                                                |
+| `apiKey`               | string          | No       | API key for the dedicated tier (sent via `x-api-key`)                                                                           |
+| `affiliateId`          | string          | No       | Affiliate id for tracking (sent via `affiliate`)                                                                                |
+| `feeBps`               | string          | No       | Convenience fee in basis points (e.g. `"50"` for 0.5%). Requires `feeTakerAddress`                                              |
+| `feeTakerAddress`      | string          | No       | Address that receives the convenience fee                                                                                       |
+| `submissionModes`      | string[]        | No       | `"user-transaction"` (onchain) and/or `"gasless"` (permit2). Default: `["user-transaction"]`                                    |
+| `slippage`             | string          | No       | Default slippage tolerance (e.g. `"0.5"` for 0.5%)                                                                              |
+| `refuel`               | boolean         | No       | Top up native gas on the destination chain                                                                                      |
+| `enableOtherProviders` | boolean         | No       | Include manual routes served by other bridges alongside Bungee's own auto route                                                 |
+| `enableMultipleRoutes` | boolean         | No       | Ask the provider for several route alternatives per quote (e.g. one for max output, another for fastest fill). Default: `false` |
+
+See the [Bungee Provider page](/cross-chain/bungee-provider) for tier endpoints, the gasless permit2 flow, and the manual-routes shape.
+
 ### LiFi Intents
 
-| Field            | Type                         | Required | Description                                                    |
-| ---------------- | ---------------------------- | -------- | -------------------------------------------------------------- |
-| `orderServerUrl` | string                       | Yes      | LI.FI order server URL (e.g. `https://order.li.fi`)            |
-| `providerId`     | string                       | No       | Custom provider identifier (default: `"lifi-intents"`)         |
-| `headers`        | Record&lt;string, string&gt; | No       | Custom HTTP headers sent with all requests to the order server |
+| Field            | Type                         | Required | Description                                                                                 |
+| ---------------- | ---------------------------- | -------- | ------------------------------------------------------------------------------------------- |
+| `orderServerUrl` | string                       | No       | LI.FI order server URL. Defaults to `LIFI_INTENTS_ORDER_SERVER_URL` (`https://order.li.fi`) |
+| `providerId`     | string                       | No       | Custom provider identifier (default: `"lifi-intents"`)                                      |
+| `headers`        | Record&lt;string, string&gt; | No       | Custom HTTP headers sent with all requests to the order server                              |
 
 Constraints:
 

--- a/apps/docs/src/pages/cross-chain/frontend-integration.mdx
+++ b/apps/docs/src/pages/cross-chain/frontend-integration.mdx
@@ -132,7 +132,7 @@ const aggregator = createAggregator({
 });
 ```
 
-The service reads on-chain allowances through a single `multicall` per chain and only prepends an `approve` step when the user's current allowance is below `required`. See [Automatic ERC-20 Approvals](/cross-chain/advanced-usage#automatic-erc-20-approvals) for the full configuration surface, including the `InfiniteAmountStrategy` variant.
+The service reads on-chain allowances through a single `multicall` per chain and only prepends an `approve` step when the user's current allowance is below `required`. Prepended steps carry `category: "approval"`; the [`isApprovalStep` / `getApprovalSteps`](/cross-chain/api#transactionstep) helpers let the UI label the wallet prompt accordingly ("Approve USDC" vs "Bridge"). See [Automatic ERC-20 Approvals](/cross-chain/advanced-usage#automatic-erc-20-approvals) for the full configuration surface, including the `InfiniteAmountStrategy` variant.
 
 `rpcUrls` is the right fit here because this demo bridges across multiple origin chains and the service reads allowances on each quote's input chain. Two other options exist for simpler setups: omit the config entirely to fall back to viem's default public RPC per chain (fine for quick experiments, rate-limited in production), or pass `publicClient` when every quote originates on the same chain (e.g. a checkout that only ever accepts USDC on mainnet). Note that reusing the wagmi `usePublicClient()` value here would not work — it is bound to one chain, and `publicClient` is used for every chain the service is asked about. See [Picking a client source](/cross-chain/advanced-usage#picking-a-client-source).
 

--- a/apps/docs/src/pages/cross-chain/getting-started.mdx
+++ b/apps/docs/src/pages/cross-chain/getting-started.mdx
@@ -155,24 +155,6 @@ for (const step of quote.order.steps) {
 }
 ```
 
-## Which chains and tokens are supported?
-
-Rather than hard-coding a supported-tokens list, ask the aggregator at runtime. `discoverAssets()` queries every configured provider in parallel and returns a pre-processed map keyed by numeric chain ID:
-
-```typescript
-const discovered = await aggregator.discoverAssets({ chainIds: [1, 8453] });
-
-// Token addresses available on each chain
-console.log(discovered.tokensByChain[1]); // Ethereum
-console.log(discovered.tokensByChain[8453]); // Base
-
-// Token metadata (nested by chain ID then lowercase address)
-const usdc = discovered.tokenMetadata[1]?.["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"];
-console.log(usdc?.symbol, usdc?.decimals); // "USDC", 6
-```
-
-Omit `chainIds` to discover across every chain each provider supports. For a single-provider variant and the full `DiscoveredAssets` shape, see the [API Reference](/cross-chain/api#aggregator).
-
 ## Compare quotes from multiple providers
 
 Use the `Aggregator` to fetch and sort quotes from multiple providers at once. For protocols whose config is optional (`across`, `relay`, `bungee`, `lifi-intents`) you can pass the protocol name directly and the aggregator creates the provider with defaults:
@@ -209,6 +191,24 @@ const aggregator = createAggregator({
 ```
 
 Each provider must have a unique `providerId`; passing two that resolve to the same id throws `DuplicateProvider`.
+
+## Which chains and tokens are supported?
+
+Rather than hard-coding a supported-tokens list, ask the aggregator at runtime. `discoverAssets()` queries every configured provider in parallel and returns a pre-processed map keyed by numeric chain ID:
+
+```typescript
+const discovered = await aggregator.discoverAssets({ chainIds: [1, 8453] });
+
+// Token addresses available on each chain
+console.log(discovered.tokensByChain[1]); // Ethereum
+console.log(discovered.tokensByChain[8453]); // Base
+
+// Token metadata (nested by chain ID then lowercase address)
+const usdc = discovered.tokenMetadata[1]?.["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"];
+console.log(usdc?.symbol, usdc?.decimals); // "USDC", 6
+```
+
+Omit `chainIds` to discover across every chain each provider supports. For a single-provider variant and the full `DiscoveredAssets` shape, see the [API Reference](/cross-chain/api#aggregator).
 
 ## Quick reference
 

--- a/apps/docs/src/pages/cross-chain/providers.mdx
+++ b/apps/docs/src/pages/cross-chain/providers.mdx
@@ -9,8 +9,8 @@ This document lists all cross-chain providers supported by the Interop SDK.
 
 ## Available Providers
 
-| Provider                                | Status | Description                                               |
-| --------------------------------------- | ------ | --------------------------------------------------------- |
+| Provider                                           | Status | Description                                               |
+| -------------------------------------------------- | ------ | --------------------------------------------------------- |
 | [Across Protocol](/cross-chain/across-provider)    | Active | Cross-chain token transfers using Across bridge           |
 | [Relay Protocol](/cross-chain/relay-provider)      | Active | Cross-chain token transfers using Relay bridge            |
 | [OIF](/cross-chain/oif-provider)                   | Active | Direct integration with OIF-compliant solvers             |
@@ -66,6 +66,24 @@ Only `across` and `relay` accept `isTestnet`. What it changes:
 | `relay`  | `api.relay.link` → `api.testnets.relay.link`  | Mainnet routes → testnet routes                            | API-based in both modes — no RPC URLs needed.                                  | API → static testnet list |
 
 `oif`, `bungee`, and `lifi-intents` don't take an `isTestnet` flag. For those providers, switch networks by pointing `url` / `orderServerUrl` / `baseUrl` at a testnet endpoint.
+
+## Optional `Quote` Fields Populated per Provider
+
+Every field below is optional on `Quote`. A provider only fills a field when its upstream API returns the underlying data, so the matrix reflects upstream behavior — not SDK gaps. Read [Quote](/cross-chain/api#quote) for the field shapes.
+
+| Field                            | Across | Relay | Bungee | LiFi Intents | OIF |
+| -------------------------------- | ------ | ----- | ------ | ------------ | --- |
+| `eta` (seconds)                  | ✅     | ✅    | ✅     | —            | ✅  |
+| `validUntil` (unix timestamp)    | —      | —     | —      | ✅           | ✅  |
+| `fees.bridgeFee`                 | ✅     | ✅    | ✅     | —            | —   |
+| `fees.bridgeFeePct` (1e18 scale) | ✅     | —     | —      | —            | —   |
+| `fees.originGas`                 | ✅     | ✅    | ✅     | —            | —   |
+| `fallbackToken`                  | ✅     | ✅    | —      | —            | —   |
+| `preview.outputs[].minAmount`    | ✅     | ✅    | ✅     | —            | —   |
+| `preview.*.amountUsd`            | —      | ✅    | ✅     | —            | —   |
+| `tracking.orderId`               | —      | ✅    | ✅     | ✅           | ✅  |
+
+UIs that compare providers side-by-side should treat every cell marked `—` as "missing upstream" — display a placeholder rather than filtering providers out. The aggregator's sorting strategies (`BestOutputStrategy`, `LowerEtaStrategy`) read `preview.outputs[0].amount` and `eta` directly, so they tolerate the missing-field case on their own.
 
 ## Order Tracking Requirements
 

--- a/apps/docs/src/pages/cross-chain/providers.mdx
+++ b/apps/docs/src/pages/cross-chain/providers.mdx
@@ -81,7 +81,7 @@ Every field below is optional on `Quote`. A provider only fills a field when its
 | `fallbackToken`                  | ✅     | ✅    | —      | —            | —   |
 | `preview.outputs[].minAmount`    | ✅     | ✅    | ✅     | —            | —   |
 | `preview.*.amountUsd`            | —      | ✅    | ✅     | —            | —   |
-| `tracking.orderId`               | —      | ✅    | ✅     | ✅           | ✅  |
+| `tracking.orderId`               | —      | ✅    | ✅     | —            | —   |
 
 UIs that compare providers side-by-side should treat every cell marked `—` as "missing upstream" — display a placeholder rather than filtering providers out. The aggregator's sorting strategies (`BestOutputStrategy`, `LowerEtaStrategy`) read `preview.outputs[0].amount` and `eta` directly, so they tolerate the missing-field case on their own.
 

--- a/apps/docs/src/pages/cross-chain/providers.mdx
+++ b/apps/docs/src/pages/cross-chain/providers.mdx
@@ -85,6 +85,15 @@ Every field below is optional on `Quote`. A provider only fills a field when its
 
 UIs that compare providers side-by-side should treat every cell marked `—` as "missing upstream" — display a placeholder rather than filtering providers out. The aggregator's sorting strategies (`BestOutputStrategy`, `LowerEtaStrategy`) read `preview.outputs[0].amount` and `eta` directly, so they tolerate the missing-field case on their own.
 
+### Address conventions
+
+Provider responses pass through upstream address formatting verbatim, so quote payloads from different providers may not be byte-equal even when they refer to the same asset:
+
+-   **Casing:** Across returns checksummed addresses; Relay and LiFi Intents return lowercase. Compare with `address.toLowerCase()` before equality-checking across providers.
+-   **Native sentinels:** Across and Relay use the zero address (`0x0000…0000`) for native gas tokens, while Bungee and OIF use the EIP-7528 form (`0xeeee…eeee`). Normalize with `toCanonicalNativeAddress(address, "eip155")` (or `isNativeAddress(address)`) when matching against a configured native placeholder.
+
+`Aggregator.discoverAssets()` already normalizes both — its `tokenMetadata` is keyed by lowercase address with native placeholders collapsed onto `NATIVE_ASSET_ADDRESS` — so consumers that drive routing from discovery output don't need to do this themselves.
+
 ## Order Tracking Requirements
 
 Different providers use different tracking mechanisms. Some need RPC URLs, others are fully API-based:

--- a/apps/docs/src/pages/cross-chain/providers.mdx
+++ b/apps/docs/src/pages/cross-chain/providers.mdx
@@ -90,7 +90,7 @@ UIs that compare providers side-by-side should treat every cell marked `—` as 
 Provider responses pass through upstream address formatting verbatim, so quote payloads from different providers may not be byte-equal even when they refer to the same asset:
 
 -   **Casing:** Across returns checksummed addresses; Relay and LiFi Intents return lowercase. Compare with `address.toLowerCase()` before equality-checking across providers.
--   **Native sentinels:** Across and Relay use the zero address (`0x0000…0000`) for native gas tokens, while Bungee and OIF use the EIP-7528 form (`0xeeee…eeee`). Normalize with `toCanonicalNativeAddress(address, "eip155")` (or `isNativeAddress(address)`) when matching against a configured native placeholder.
+-   **Native sentinels:** Across, Relay, OIF, and LiFi Intents use the zero address (`0x0000…0000`) for native gas tokens, while Bungee uses the EIP-7528 form (`0xeeee…eeee`). Normalize with `toCanonicalNativeAddress(address, "eip155")` (or `isNativeAddress(address)`) when matching against a configured native placeholder.
 
 `Aggregator.discoverAssets()` already normalizes both — its `tokenMetadata` is keyed by lowercase address with native placeholders collapsed onto `NATIVE_ASSET_ADDRESS` — so consumers that drive routing from discovery output don't need to do this themselves.
 

--- a/apps/docs/src/pages/cross-chain/providers.mdx
+++ b/apps/docs/src/pages/cross-chain/providers.mdx
@@ -90,7 +90,7 @@ UIs that compare providers side-by-side should treat every cell marked `—` as 
 Provider responses pass through upstream address formatting verbatim, so quote payloads from different providers may not be byte-equal even when they refer to the same asset:
 
 -   **Casing:** Across returns checksummed addresses; Relay and LiFi Intents return lowercase. Compare with `address.toLowerCase()` before equality-checking across providers.
--   **Native sentinels:** Across, Relay, OIF, and LiFi Intents use the zero address (`0x0000…0000`) for native gas tokens, while Bungee uses the EIP-7528 form (`0xeeee…eeee`). Normalize with `toCanonicalNativeAddress(address, "eip155")` (or `isNativeAddress(address)`) when matching against a configured native placeholder.
+-   **Native sentinels:** Across, Relay, OIF, and LiFi Intents use the zero address (`0x0000…0000`) for native gas tokens, while Bungee uses the EIP-7528 form (`0xeeee…eeee`). Normalize with `toCanonicalNativeAddress(address, "eip155")` (or `isNativeAddress(address, "eip155")`) when matching against a configured native placeholder.
 
 `Aggregator.discoverAssets()` already normalizes both — its `tokenMetadata` is keyed by lowercase address with native placeholders collapsed onto `NATIVE_ASSET_ADDRESS` — so consumers that drive routing from discovery output don't need to do this themselves.
 

--- a/packages/cross-chain/src/core/schemas/assetDiscovery.ts
+++ b/packages/cross-chain/src/core/schemas/assetDiscovery.ts
@@ -91,6 +91,23 @@ export const assetDiscoveryOptionsSchema = z.object({
     chainIds: z.array(z.number().int().positive()).optional(),
 });
 
+/**
+ * Schema for `Aggregator.getProvidersForRoute` queries.
+ *
+ * Catches malformed input (wrong shape, missing fields, non-hex addresses) up front
+ * rather than letting it silently fall through to "route unsupported".
+ */
+export const RouteQuerySchema = z.object({
+    originChainId: z.number().int().positive(),
+    originAsset: z
+        .string()
+        .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid origin asset address (expected 20-byte hex)"),
+    destinationChainId: z.number().int().positive(),
+    destinationAsset: z
+        .string()
+        .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid destination asset address (expected 20-byte hex)"),
+});
+
 // Type exports from schemas
 export type AssetInfoSchema = z.infer<typeof assetInfoSchema>;
 export type NetworkAssetsSchema = z.infer<typeof networkAssetsSchema>;

--- a/packages/cross-chain/src/core/schemas/assetDiscovery.ts
+++ b/packages/cross-chain/src/core/schemas/assetDiscovery.ts
@@ -9,6 +9,7 @@
 
 import { z } from "zod";
 
+import type { RouteQuery } from "../types/assetDiscovery.js";
 import { HexAddressSchema } from "./address.js";
 
 /**
@@ -96,8 +97,11 @@ export const assetDiscoveryOptionsSchema = z.object({
  *
  * Catches malformed input (wrong shape, missing fields, non-hex addresses) up front
  * rather than letting it silently fall through to "route unsupported".
+ *
+ * The `z.ZodType<RouteQuery>` annotation pins the schema to the `RouteQuery`
+ * interface, so the two cannot drift without a compile error.
  */
-export const RouteQuerySchema = z.object({
+export const RouteQuerySchema: z.ZodType<RouteQuery> = z.object({
     originChainId: z.number().int().positive(),
     originAsset: z
         .string()

--- a/packages/cross-chain/src/core/schemas/assetDiscovery.ts
+++ b/packages/cross-chain/src/core/schemas/assetDiscovery.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 
 import type { RouteQuery } from "../types/assetDiscovery.js";
 import { HexAddressSchema } from "./address.js";
+import { chainIdSchema } from "./common.js";
 
 /**
  * Schema for asset metadata
@@ -102,11 +103,11 @@ export const assetDiscoveryOptionsSchema = z.object({
  * interface, so the two cannot drift without a compile error.
  */
 export const RouteQuerySchema: z.ZodType<RouteQuery> = z.object({
-    originChainId: z.number().int().positive(),
+    originChainId: chainIdSchema,
     originAsset: z
         .string()
         .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid origin asset address (expected 20-byte hex)"),
-    destinationChainId: z.number().int().positive(),
+    destinationChainId: chainIdSchema,
     destinationAsset: z
         .string()
         .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid destination asset address (expected 20-byte hex)"),

--- a/packages/cross-chain/src/core/services/aggregator.ts
+++ b/packages/cross-chain/src/core/services/aggregator.ts
@@ -119,11 +119,11 @@ class Aggregator {
 
     /**
      * Check whether a provider supports all assets in the quote request.
-     * Returns `{ supported: false }` when any input or output asset is unsupported,
-     * letting callers either skip the provider (build path) or surface the skip as a
-     * `GetQuotesError` (aggregate path). Uses the pre-warmed discovery cache so this is
-     * typically instant. Discovery failures default to `{ supported: true }` so a flaky
-     * discovery layer does not silently hide live providers.
+     * Returns `false` when any input or output asset is unsupported, letting callers
+     * either skip the provider (build path) or surface the skip as a `GetQuotesError`
+     * via `buildSkippedProviderError` (aggregate path). Uses the pre-warmed discovery
+     * cache so this is typically instant. Discovery failures default to `true` so a
+     * flaky discovery layer does not silently hide live providers.
      */
     private async supportsRequestedAssets(
         provider: CrossChainProvider,

--- a/packages/cross-chain/src/core/services/aggregator.ts
+++ b/packages/cross-chain/src/core/services/aggregator.ts
@@ -21,9 +21,11 @@ import { AssetDiscoveryFailure } from "../errors/AssetDiscoveryFailure.exception
 import { DuplicateProvider } from "../errors/DuplicateProvider.exception.js";
 import { ProviderNotFound } from "../errors/ProviderNotFound.exception.js";
 import { ProviderTimeout } from "../errors/ProviderTimeout.exception.js";
+import { UnsupportedAsset } from "../errors/UnsupportedAsset.exception.js";
 import { UntrustedSpender } from "../errors/UntrustedSpender.exception.js";
 import { CrossChainProvider } from "../interfaces/crossChainProvider.interface.js";
 import { SortingStrategy } from "../interfaces/sortingStrategy.interface.js";
+import { RouteQuerySchema } from "../schemas/assetDiscovery.js";
 import { BestOutputStrategy } from "../sorting_strategies/bestOutput.strategy.js";
 import { mergeDiscoveredAssets } from "../utils/toDiscoveredAssets.js";
 import { toCanonicalNativeAddress } from "../utils/token.js";
@@ -117,8 +119,11 @@ class Aggregator {
 
     /**
      * Check whether a provider supports all assets in the quote request.
-     * Returns false if any input or output asset is not supported, avoiding unnecessary HTTP calls.
-     * Uses the pre-warmed discovery cache so this is typically instant.
+     * Returns `{ supported: false }` when any input or output asset is unsupported,
+     * letting callers either skip the provider (build path) or surface the skip as a
+     * `GetQuotesError` (aggregate path). Uses the pre-warmed discovery cache so this is
+     * typically instant. Discovery failures default to `{ supported: true }` so a flaky
+     * discovery layer does not silently hide live providers.
      */
     private async supportsRequestedAssets(
         provider: CrossChainProvider,
@@ -155,6 +160,21 @@ class Aggregator {
         }
     }
 
+    /**
+     * Build a `GetQuotesError` entry for a provider that asset discovery skipped, so the
+     * caller can tell "no quote because the route is unsupported" apart from "the provider
+     * disappeared".
+     */
+    private buildSkippedProviderError(providerId: string, params: QuoteRequest): GetQuotesError {
+        const error = new UnsupportedAsset(providerId, params.input, params.output);
+        return {
+            error,
+            errorMsg: error.message,
+            latencyMs: 0,
+            providerId,
+        };
+    }
+
     private splitQuotesAndErrors(quotes: (ExecutableQuote | GetQuotesError)[]): GetQuotesResponse {
         return {
             quotes: quotes.filter((quote) => "order" in quote) as ExecutableQuote[],
@@ -172,7 +192,7 @@ class Aggregator {
             [...this.providers.values()].map(async (provider) => {
                 const isSupported = await this.supportsRequestedAssets(provider, params);
                 if (!isSupported) {
-                    return [];
+                    return this.buildSkippedProviderError(provider.getProviderId(), params);
                 }
 
                 const startedAt = performance.now();
@@ -389,17 +409,22 @@ class Aggregator {
 
     /**
      * Find which providers support a given origin/destination route.
+     *
+     * @throws ZodError when `query` is missing required fields or contains a malformed
+     *   chain id / asset address, so callers can distinguish "bad input" from
+     *   "route unsupported" (which returns `[]`).
      */
     async getProvidersForRoute(query: RouteQuery): Promise<string[]> {
+        const validated = RouteQuerySchema.parse(query);
         const assets = await this.discoverAssets();
 
         const originMeta =
-            assets.tokenMetadata[query.originChainId]?.[
-                toCanonicalNativeAddress(query.originAsset, "eip155")
+            assets.tokenMetadata[validated.originChainId]?.[
+                toCanonicalNativeAddress(validated.originAsset, "eip155")
             ];
         const destMeta =
-            assets.tokenMetadata[query.destinationChainId]?.[
-                toCanonicalNativeAddress(query.destinationAsset, "eip155")
+            assets.tokenMetadata[validated.destinationChainId]?.[
+                toCanonicalNativeAddress(validated.destinationAsset, "eip155")
             ];
 
         if (!originMeta || !destMeta) {

--- a/packages/cross-chain/src/external.ts
+++ b/packages/cross-chain/src/external.ts
@@ -82,6 +82,9 @@ export {
     SameAssetMapSchema,
     type SameAssetMap,
     type SameAssetService,
+    // Route query validation
+    RouteQuerySchema,
+    type RouteQuery,
     // SDK schema types
     type ExecutableQuote,
     type QuoteFeeEntry,

--- a/packages/cross-chain/test/services/aggregator.discovery.spec.ts
+++ b/packages/cross-chain/test/services/aggregator.discovery.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createAggregator, CrossChainProvider } from "../../src/internal.js";
+import { createAggregator, CrossChainProvider, UnsupportedAsset } from "../../src/internal.js";
 
 // Plain 0x test addresses
 const USDC_ETH = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
@@ -215,6 +215,40 @@ describe("Aggregator - Asset Discovery", () => {
     });
 
     describe("getProvidersForRoute", () => {
+        it("throws on malformed RouteQuery input rather than silently returning []", async () => {
+            const provider = createMockProvider("across", {
+                type: "static",
+                config: {
+                    networks: [
+                        {
+                            chainId: 1,
+                            assets: [{ address: USDC_ETH, symbol: "USDC", decimals: 6 }],
+                        },
+                    ],
+                },
+            });
+
+            const executor = createAggregator({ providers: [provider] });
+
+            // QuoteRequest-shaped input (wrong) — should throw instead of returning [].
+            await expect(
+                executor.getProvidersForRoute({
+                    input: { chainId: 1, assetAddress: USDC_ETH },
+                    output: { chainId: 42161, assetAddress: USDC_ARB },
+                } as unknown as Parameters<typeof executor.getProvidersForRoute>[0]),
+            ).rejects.toThrow();
+
+            // Non-hex origin address should throw too.
+            await expect(
+                executor.getProvidersForRoute({
+                    originChainId: 1,
+                    originAsset: "not-an-address",
+                    destinationChainId: 42161,
+                    destinationAsset: USDC_ARB,
+                }),
+            ).rejects.toThrow();
+        });
+
         it("should return providers supporting both origin and destination assets", async () => {
             const provider = createMockProvider("across", {
                 type: "static",
@@ -392,6 +426,59 @@ describe("Aggregator - Asset Discovery", () => {
 
             expect(viaZero).toEqual(expect.arrayContaining(["bungee", "across"]));
             expect(viaEee).toEqual(expect.arrayContaining(["bungee", "across"]));
+        });
+
+        it("surfaces providers skipped by discovery as UnsupportedAsset errors in getQuotes", async () => {
+            const supporting = createMockProvider("across", {
+                type: "static",
+                config: {
+                    networks: [
+                        {
+                            chainId: 1,
+                            assets: [{ address: USDC_ETH, symbol: "USDC", decimals: 6 }],
+                        },
+                        {
+                            chainId: 42161,
+                            assets: [{ address: USDC_ARB, symbol: "USDC", decimals: 6 }],
+                        },
+                    ],
+                },
+            });
+            (supporting.getQuotes as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+            const skipping = createMockProvider("relay", {
+                type: "static",
+                config: {
+                    networks: [
+                        {
+                            chainId: 1,
+                            assets: [{ address: WETH_ETH, symbol: "WETH", decimals: 18 }],
+                        },
+                    ],
+                },
+            });
+            const skippingGetQuotes = skipping.getQuotes as ReturnType<typeof vi.fn>;
+            skippingGetQuotes.mockResolvedValue([]);
+
+            const executor = createAggregator({ providers: [supporting, skipping] });
+
+            const response = await executor.getQuotes({
+                user: "0x0000000000000000000000000000000000000001",
+                input: { chainId: 1, assetAddress: USDC_ETH, amount: "1000000" },
+                output: {
+                    chainId: 42161,
+                    assetAddress: USDC_ARB,
+                    recipient: "0x0000000000000000000000000000000000000001",
+                },
+                swapType: "exact-input",
+            });
+
+            expect(skippingGetQuotes).not.toHaveBeenCalled();
+            expect(response.errors).toHaveLength(1);
+            const [skipped] = response.errors;
+            expect(skipped?.providerId).toBe("relay");
+            expect(skipped?.latencyMs).toBe(0);
+            expect(skipped?.error).toBeInstanceOf(UnsupportedAsset);
         });
 
         it("should return multiple providers when both support the route", async () => {

--- a/packages/cross-chain/test/services/aggregator.discovery.spec.ts
+++ b/packages/cross-chain/test/services/aggregator.discovery.spec.ts
@@ -247,6 +247,17 @@ describe("Aggregator - Asset Discovery", () => {
                     destinationAsset: USDC_ARB,
                 }),
             ).rejects.toThrow();
+
+            // Chain ids above Number.MAX_SAFE_INTEGER lose precision as numeric
+            // object keys, so they must be rejected rather than miss the lookup.
+            await expect(
+                executor.getProvidersForRoute({
+                    originChainId: 2 ** 53,
+                    originAsset: USDC_ETH,
+                    destinationChainId: 42161,
+                    destinationAsset: USDC_ARB,
+                }),
+            ).rejects.toThrow();
         });
 
         it("should return providers supporting both origin and destination assets", async () => {


### PR DESCRIPTION
## Summary

Addresses all 12 issues from the bridge-UI QA pass (`QA_FEEDBACK.md`, filed against `@wonderland/interop-cross-chain@0.13.2`). Each item was re-triaged against current `dev` before fixing — a few were already partially resolved by #367.

### SDK changes (with changesets, both `minor`)

- **Surface skipped providers** (QA #1): `getQuotes` previously dropped a provider entirely when asset discovery marked the route unsupported — absent from both `quotes` and `errors`. Skipped providers now appear in `errors` with an `UnsupportedAsset` error and `latencyMs: 0`. Reuses `errors[]` rather than adding a new `skipped[]` field to keep the response shape stable.
- **Validate `RouteQuery` input** (QA #2): `getProvidersForRoute` silently returned `[]` for malformed queries — indistinguishable from "route unsupported". Input now goes through `RouteQuerySchema` (exported, pinned to the `RouteQuery` interface via `z.ZodType` annotation). **Behavior change:** bad input now throws a `ZodError`; flagged in the changeset.

### Docs changes

- `TransactionStep.category`/`isApprovalStep`/`getApprovalSteps` documented (QA #3); `validUntil` marked best-effort with the accurate provider list — verified against adapters (QA #4); real `CreateAggregatorConfig` signature (QA #5); `RouteQuery` fields (QA #6); per-provider quote-field support table (QA #7); event-tracking API incl. `prepareTracking` (QA #8); `Quote` drift — `fallbackToken`, `minAmount`, `eta` seconds, 1e18-scaled `bridgeFeePct` (QA #9); swapType/amount requirement (QA #10); address conventions — casing + native sentinels (QA #11); getting-started ordering (QA #12).

All docs claims were verified against the source rather than the QA report.

## Test plan

- New unit tests: malformed `RouteQuery` throws; skipped provider surfaces as `UnsupportedAsset` in `errors` without calling the provider.
- Full suite: 1309 tests passing, lint 0 errors, type-check clean.
