### PR TITLE
feat(benchmark): show real per-provider sample window on the leaderboard

### DIFF
--- a/apps/benchmark/app/components/leaderboard/LeaderboardProviderCell.tsx
+++ b/apps/benchmark/app/components/leaderboard/LeaderboardProviderCell.tsx
@@ -1,0 +1,41 @@
+import { Icon } from '../Icon';
+import { formatFillCount, formatSampleWindow } from './formatters';
+import type { ProviderMeta } from '~/lib/providers';
+
+interface LeaderboardProviderCellProps {
+  provider: ProviderMeta;
+  fillCount: number | null;
+  windowSeconds: number | null;
+}
+
+// Leaderboard variant of the provider cell: under the name it carries the
+// sample's size and span together as secondary context (e.g. `1,200 fills · 2.7d`),
+// or the no-feed reason for a placeholder provider. Head-to-head keeps the plain
+// ProviderCell, so this lives on its own instead of branching one component.
+export function LeaderboardProviderCell({ provider, fillCount, windowSeconds }: LeaderboardProviderCellProps) {
+  const sublabel = buildSublabel(provider, fillCount, windowSeconds);
+
+  return (
+    <div className='flex items-center gap-2.5 md:gap-3'>
+      <Icon src={provider.iconUrl} alt='' size='md' />
+      <div className='flex min-w-0 flex-col gap-0.5'>
+        <span className='truncate font-sans text-mark font-medium tracking-[-0.0125em] text-text-primary md:text-base'>
+          {provider.displayName}
+        </span>
+        {sublabel ? (
+          <span className='truncate font-mono text-caption tracking-[0.02em] text-text-muted'>{sublabel}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function buildSublabel(provider: ProviderMeta, fillCount: number | null, windowSeconds: number | null): string | null {
+  // No public feed (e.g. the Bungee placeholder): say why, not a fill count.
+  if (!provider.hasGlobalFeed) return provider.noFeedReason ?? null;
+  // Has a feed but returned nothing usable (failed or empty window): no sublabel.
+  if (fillCount === null) return null;
+  const fills = `${formatFillCount(fillCount)} fills`;
+  const window = formatSampleWindow(windowSeconds);
+  return window === '—' ? fills : `${fills} · ${window}`;
+}

--- a/apps/benchmark/app/components/leaderboard/LeaderboardProviderCell.tsx
+++ b/apps/benchmark/app/components/leaderboard/LeaderboardProviderCell.tsx
@@ -36,6 +36,8 @@ function buildSublabel(provider: ProviderMeta, fillCount: number | null, windowS
   // Has a feed but returned nothing usable (failed or empty window): no sublabel.
   if (fillCount === null) return null;
   const fills = `${formatFillCount(fillCount)} fills`;
-  const window = formatSampleWindow(windowSeconds);
-  return window === '—' ? fills : `${fills} · ${window}`;
+  // Decide on the raw value, not the formatted string, so the cell isn't coupled
+  // to the formatter's placeholder. A single-fill sample has no span to show.
+  if (windowSeconds === null) return fills;
+  return `${fills} · ${formatSampleWindow(windowSeconds)}`;
 }

--- a/apps/benchmark/app/components/leaderboard/constants.tsx
+++ b/apps/benchmark/app/components/leaderboard/constants.tsx
@@ -1,6 +1,6 @@
 import { METRICS_CELL_NUM, METRICS_CELL_NUM_HIDDEN, METRICS_CELL_STACK, type MetricsColumn } from '../metricsTable';
-import { ProviderCell } from './ProviderCell';
-import { formatAvgFee, formatFillCount, formatFillSeconds, formatSuccessRate } from './formatters';
+import { LeaderboardProviderCell } from './LeaderboardProviderCell';
+import { formatAvgFee, formatFillSeconds, formatSuccessRate } from './formatters';
 import type { ProviderMeta } from '~/lib/providers';
 import { cn } from '~/lib/cn';
 
@@ -25,14 +25,13 @@ export const LEADERBOARD_COLUMNS: readonly LeaderboardColumn[] = [
     key: 'provider',
     label: 'PROVIDER',
     tdClass: METRICS_CELL_STACK,
-    render: (_metrics, ctx) => <ProviderCell provider={ctx.provider} />,
-  },
-  {
-    key: 'fills',
-    label: 'FILLS 24H',
-    className: 'hidden text-right md:table-cell md:w-32',
-    tdClass: `${METRICS_CELL_NUM_HIDDEN} text-text-primary`,
-    render: (metrics) => formatFillCount(metrics.fillCount),
+    render: (metrics, ctx) => (
+      <LeaderboardProviderCell
+        provider={ctx.provider}
+        fillCount={metrics.fillCount}
+        windowSeconds={metrics.sampleWindowSeconds}
+      />
+    ),
   },
   {
     key: 'success',

--- a/apps/benchmark/app/components/leaderboard/formatters.ts
+++ b/apps/benchmark/app/components/leaderboard/formatters.ts
@@ -22,7 +22,10 @@ export function formatSampleWindow(value: number | null): string {
   const hours = Math.round(value / 3600);
   if (hours < 24) return `${hours}h`;
   const days = value / 86_400;
-  return days < 10 ? `${days.toFixed(1)}d` : `${Math.round(days)}d`;
+  // Round to the displayed precision before the `< 10` check: 9.97d must read
+  // `10d`, not `10.0d` (raw 9.97 passes `< 10` but `toFixed(1)` renders 10.0).
+  const tenthDays = Math.round(days * 10) / 10;
+  return tenthDays < 10 ? `${tenthDays.toFixed(1)}d` : `${Math.round(days)}d`;
 }
 
 export function formatSuccessRate(value: number | null): string {

--- a/apps/benchmark/app/components/leaderboard/formatters.ts
+++ b/apps/benchmark/app/components/leaderboard/formatters.ts
@@ -9,6 +9,18 @@ export function formatFillCount(value: number | null): string {
   return Math.trunc(value).toLocaleString('en-US');
 }
 
+// Compact span the sample covers: `45m`, `8h`, `2.7d`. Days keep one decimal
+// under 10d (2.7d reads better than 3d) and round above it (33d, not 33.1d).
+export function formatSampleWindow(value: number | null): string {
+  if (!isUsableNumber(value) || value < 0) return PLACEHOLDER;
+  const minutes = value / 60;
+  if (minutes < 60) return `${Math.max(1, Math.round(minutes))}m`;
+  const hours = minutes / 60;
+  if (hours < 24) return `${Math.round(hours)}h`;
+  const days = hours / 24;
+  return days < 10 ? `${days.toFixed(1)}d` : `${Math.round(days)}d`;
+}
+
 export function formatSuccessRate(value: number | null): string {
   if (!isUsableNumber(value)) return PLACEHOLDER;
   // Clamp to [0, 100]: upstream rounding occasionally produces 1.0001 etc.

--- a/apps/benchmark/app/components/leaderboard/formatters.ts
+++ b/apps/benchmark/app/components/leaderboard/formatters.ts
@@ -9,15 +9,19 @@ export function formatFillCount(value: number | null): string {
   return Math.trunc(value).toLocaleString('en-US');
 }
 
-// Compact span the sample covers: `45m`, `8h`, `2.7d`. Days keep one decimal
-// under 10d (2.7d reads better than 3d) and round above it (33d, not 33.1d).
+// Compact span the sample covers: `0s`, `45s`, `8h`, `2.7d`. Round into each
+// unit before the threshold check so a near-boundary value rolls over (3599s →
+// `1h`, not `60m`) instead of rendering an out-of-range count. Days keep one
+// decimal under 10d (2.7d reads better than 3d) and round above it (33d).
 export function formatSampleWindow(value: number | null): string {
   if (!isUsableNumber(value) || value < 0) return PLACEHOLDER;
-  const minutes = value / 60;
-  if (minutes < 60) return `${Math.max(1, Math.round(minutes))}m`;
-  const hours = minutes / 60;
-  if (hours < 24) return `${Math.round(hours)}h`;
-  const days = hours / 24;
+  const seconds = Math.round(value);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(value / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(value / 3600);
+  if (hours < 24) return `${hours}h`;
+  const days = value / 86_400;
   return days < 10 ? `${days.toFixed(1)}d` : `${Math.round(days)}d`;
 }
 

--- a/apps/benchmark/app/lib/historyAggregation.ts
+++ b/apps/benchmark/app/lib/historyAggregation.ts
@@ -36,12 +36,22 @@ export function aggregateProviderSamples(providerId: ProviderId, samples: readon
   return {
     providerId,
     fillCount,
+    sampleWindowSeconds: sampleWindowSeconds(owned),
     successRate,
     p50FillSeconds: percentile(fillTimes, 50),
     p99FillSeconds: percentile(fillTimes, 99),
     avgFeeUsd: fees.length === 0 ? null : fees.reduce((a, b) => a + b, 0) / fees.length,
     volumeUsd: volumes.length === 0 ? null : volumes.reduce((a, b) => a + b, 0),
   };
+}
+
+// Seconds from the oldest to the newest sampled fill. Needs at least two
+// timestamps to form a span; a single fill (or none) has no window, so report
+// null instead of a misleading 0.
+function sampleWindowSeconds(samples: readonly HistorySample[]): number | null {
+  const timestamps = samples.map((s) => s.timestamp).filter((t) => Number.isFinite(t));
+  if (timestamps.length < 2) return null;
+  return (Math.max(...timestamps) - Math.min(...timestamps)) / 1000;
 }
 
 export function sortLeaderboardBySuccess(metrics: readonly ProviderMetrics[]): ProviderMetrics[] {

--- a/apps/benchmark/app/lib/services/providerMetrics.ts
+++ b/apps/benchmark/app/lib/services/providerMetrics.ts
@@ -27,6 +27,7 @@ function nullMetricsFor(providerId: ProviderId): ProviderMetrics {
   return {
     providerId,
     fillCount: null,
+    sampleWindowSeconds: null,
     successRate: null,
     p50FillSeconds: null,
     p99FillSeconds: null,

--- a/apps/benchmark/app/lib/types/historyMetrics.ts
+++ b/apps/benchmark/app/lib/types/historyMetrics.ts
@@ -28,6 +28,9 @@ export interface HistoryResult {
 export interface ProviderMetrics {
   providerId: ProviderId;
   fillCount: number | null;
+  // Seconds between the oldest and newest sampled fill: how far back this
+  // provider's sample reaches. Null when fewer than two fills make a span.
+  sampleWindowSeconds: number | null;
   successRate: number | null;
   p50FillSeconds: number | null;
   p99FillSeconds: number | null;

--- a/apps/benchmark/app/page.tsx
+++ b/apps/benchmark/app/page.tsx
@@ -90,7 +90,7 @@ export default async function Home() {
         <SectionFrame variant='tinted'>
           <SectionHeader
             index='02'
-            label='provider leaderboard · 24h ambient'
+            label='provider leaderboard'
             title='how providers performed across all routes'
             rightSlot={<Label className={META_LABEL_CLASS}>pulled from each provider&rsquo;s public history api</Label>}
           />

--- a/apps/benchmark/test/formatters.spec.ts
+++ b/apps/benchmark/test/formatters.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { formatSampleWindow } from '~/components/leaderboard/formatters';
+
+describe('formatSampleWindow', () => {
+  it('renders a placeholder for null or negative input', () => {
+    expect(formatSampleWindow(null)).toBe('—');
+    expect(formatSampleWindow(-5)).toBe('—');
+  });
+
+  it('reports a zero / sub-minute span in seconds, not a rounded-up minute', () => {
+    expect(formatSampleWindow(0)).toBe('0s');
+    expect(formatSampleWindow(45)).toBe('45s');
+  });
+
+  it('rolls a near-boundary value into the next unit instead of an out-of-range count', () => {
+    expect(formatSampleWindow(3599)).toBe('1h'); // not 60m
+    expect(formatSampleWindow(86_399)).toBe('1.0d'); // not 24h
+  });
+
+  it('formats whole units', () => {
+    expect(formatSampleWindow(8 * 3600)).toBe('8h');
+    expect(formatSampleWindow(2.7 * 86_400)).toBe('2.7d');
+    expect(formatSampleWindow(33 * 86_400)).toBe('33d'); // no decimal past 10d
+  });
+});

--- a/apps/benchmark/test/formatters.spec.ts
+++ b/apps/benchmark/test/formatters.spec.ts
@@ -15,11 +15,13 @@ describe('formatSampleWindow', () => {
   it('rolls a near-boundary value into the next unit instead of an out-of-range count', () => {
     expect(formatSampleWindow(3599)).toBe('1h'); // not 60m
     expect(formatSampleWindow(86_399)).toBe('1.0d'); // not 24h
+    expect(formatSampleWindow(9.97 * 86_400)).toBe('10d'); // not 10.0d
   });
 
   it('formats whole units', () => {
     expect(formatSampleWindow(8 * 3600)).toBe('8h');
     expect(formatSampleWindow(2.7 * 86_400)).toBe('2.7d');
+    expect(formatSampleWindow(9.94 * 86_400)).toBe('9.9d'); // one decimal under 10d
     expect(formatSampleWindow(33 * 86_400)).toBe('33d'); // no decimal past 10d
   });
 });

--- a/apps/benchmark/test/providerMetrics.spec.ts
+++ b/apps/benchmark/test/providerMetrics.spec.ts
@@ -36,6 +36,18 @@ function result(id: ProviderId, samples: HistorySample[]): HistoryResult {
   return { providerId: id, samples };
 }
 
+// A single success fill at a given timestamp (ms), for sample-window assertions.
+function at(timestamp: number): HistorySample {
+  return {
+    providerId: ProviderId.Across,
+    timestamp,
+    status: 'success',
+    amountUsd: 100,
+    feeUsd: 2,
+    fillTimeSeconds: 12,
+  };
+}
+
 type RouteHandler = (query: HistoryQuery, callIndex: number) => HistoryResult;
 
 function fakeService(handler: RouteHandler): { service: HistoryService; calls: HistoryQuery[] } {
@@ -107,6 +119,27 @@ describe('aggregateProviderRoutes', () => {
 
     expect(metrics.fillCount).toBe(0); // the provider answered, just with nothing
     expect(metrics.successRate).toBeNull(); // no resolved samples to rate
+    expect(metrics.sampleWindowSeconds).toBeNull(); // no fills, no span
+  });
+
+  it('reports the sample window as the span from oldest to newest fill across routes', async () => {
+    const { service } = fakeService((_q, i) =>
+      result(ACROSS, i === 0 ? [at(0), at(3_600_000)] : [at(7_200_000), at(10_800_000)]),
+    );
+
+    const metrics = await aggregateProviderRoutes(ACROSS, service, routes(2), NEVER);
+
+    expect(metrics.fillCount).toBe(4);
+    expect(metrics.sampleWindowSeconds).toBe(10_800); // 0 → 3h, pooled across both routes
+  });
+
+  it('has no window when the pool holds a single fill', async () => {
+    const { service } = fakeService((_q, i) => result(ACROSS, i === 0 ? [at(0)] : []));
+
+    const metrics = await aggregateProviderRoutes(ACROSS, service, routes(2), NEVER);
+
+    expect(metrics.fillCount).toBe(1);
+    expect(metrics.sampleWindowSeconds).toBeNull();
   });
 
   it('launches no waves when the budget is already spent', async () => {


### PR DESCRIPTION
Stacked on #394 (multi-route aggregation) — review/merge that first.

## Why

The leaderboard was labelled "24h ambient" with a "FILLS 24H" column, but the history services never send a time filter. The data is each provider's most recent fills per route (capped at 100/route, pooled across the 12 routes), not a 24h window — the claim was false.

It can't honestly be a fixed 24h window either: Across (~9.6k fills/24h) and Relay (~18k/24h) would need 20-100+ pages per route to cover a full day, well past the per-regeneration budget. So each provider's capped sample covers a different span (Across ~2-3d, Relay ~1.5d, LiFi's quiet routes tens of days). Rather than hide that behind a fake "24h", surface the real span as context.

## What

- Add `sampleWindowSeconds` to `ProviderMetrics`, computed in `aggregateProviderSamples` (newest − oldest timestamp across the pooled sample; null below two fills).
- Drop the standalone `FILLS 24H` column. Fold fill count and window into a secondary sublabel under each provider name (`1,200 fills · 2.7d`) — sample context, not a KPI next to success rate / fill time / fee.
- No-feed placeholder (Bungee) keeps the reason in that slot.
- Remove `· 24h ambient` from the section label; each row now states its real period.
- Head-to-head (section 03) is untouched: it keeps the plain `ProviderCell` and its own `FILLS` column, so the leaderboard variant lives in a separate `LeaderboardProviderCell`.
- Unit tests for the window: span across routes, single-fill → null, zero-fill → null.

Closes EFI-1014
