### PR TITLE
fix(benchmark): validate amount input and show placeholder

### DIFF
--- a/apps/benchmark/app/components/RequestBar.tsx
+++ b/apps/benchmark/app/components/RequestBar.tsx
@@ -7,6 +7,7 @@ import { Dropdown, type DropdownOption } from './Dropdown';
 import { Label } from './Label';
 import { useRunRace } from './race-table/useRunRace';
 import type { NetworkAssets } from '@wonderland/interop-cross-chain';
+import { amountInputError, isWellFormedAmount, sanitizeAmountInput } from '~/lib/amountInput';
 import { ASSET_SYMBOLS, ASSETS, AssetSymbol } from '~/lib/assets';
 import { CHAIN_IDS, CHAINS, ChainId } from '~/lib/chains';
 import { cn } from '~/lib/cn';
@@ -84,8 +85,10 @@ export function RequestBar({ chains }: RequestBarProps) {
   };
 
   const handleAmountChange = (value: string) => {
-    setAmount({ amount: value, selectedPreset: null });
+    const sanitized = sanitizeAmountInput(value);
+    setAmount({ amount: sanitized, selectedPreset: null });
     clearPendingAmountRun();
+    if (!isWellFormedAmount(sanitized)) return;
     debounceTimer.current = window.setTimeout(() => {
       debounceTimer.current = null;
       void runRace();
@@ -125,7 +128,11 @@ export function RequestBar({ chains }: RequestBarProps) {
           <Divider />
 
           <div className='flex flex-1 flex-col gap-3 md:flex-row md:items-center md:gap-4'>
-            <AmountField amount={request.amount} onChange={handleAmountChange} />
+            <AmountField
+              amount={request.amount}
+              error={amountInputError(request.amount)}
+              onChange={handleAmountChange}
+            />
             <div className='flex gap-1'>
               {presets.map((preset, index) => (
                 <PresetPill
@@ -148,10 +155,11 @@ export function RequestBar({ chains }: RequestBarProps) {
 
 interface AmountFieldProps {
   amount: string;
+  error: string | null;
   onChange: (value: string) => void;
 }
 
-function AmountField({ amount, onChange }: AmountFieldProps) {
+function AmountField({ amount, error, onChange }: AmountFieldProps) {
   return (
     <label className='flex flex-1 cursor-text flex-col gap-1.5'>
       <Label className='font-mono text-caption uppercase tracking-widest text-text-muted'>AMOUNT</Label>
@@ -159,9 +167,17 @@ function AmountField({ amount, onChange }: AmountFieldProps) {
         type='text'
         inputMode='decimal'
         value={amount}
+        placeholder='0.00'
+        aria-invalid={error !== null}
+        aria-describedby={error === null ? undefined : 'amount-error'}
         onChange={(event) => onChange(event.target.value)}
-        className='w-full bg-transparent font-sans text-lg font-medium tracking-tight text-text-primary outline-none md:text-xl'
+        className='w-full bg-transparent font-sans text-lg font-medium tracking-tight text-text-primary outline-none placeholder:text-text-muted md:text-xl'
       />
+      {error !== null && (
+        <span id='amount-error' role='alert' className='font-mono text-caption text-error'>
+          {error}
+        </span>
+      )}
     </label>
   );
 }

--- a/apps/benchmark/app/components/RequestBar.tsx
+++ b/apps/benchmark/app/components/RequestBar.tsx
@@ -5,6 +5,7 @@ import { Arrow } from './Arrow';
 import { Divider } from './Divider';
 import { Dropdown, type DropdownOption } from './Dropdown';
 import { Label } from './Label';
+import { createRows, orderRaceRows } from './race-table/raceRows';
 import { useRunRace } from './race-table/useRunRace';
 import type { NetworkAssets } from '@wonderland/interop-cross-chain';
 import { amountInputError, isWellFormedAmount, sanitizeAmountInput } from '~/lib/amountInput';
@@ -41,6 +42,7 @@ export function RequestBar({ chains }: RequestBarProps) {
   const setAmount = useRequestBarStore((state) => state.setAmount);
   const setPreset = useRequestBarStore((state) => state.setPreset);
   const swapChains = useRequestBarStore((state) => state.swapChains);
+  const setRows = useRequestBarStore((state) => state.setRows);
   const runRace = useRunRace(chains);
   const [arrowSpins, setArrowSpins] = useState(0);
   const debounceTimer = useRef<number | null>(null);
@@ -88,11 +90,15 @@ export function RequestBar({ chains }: RequestBarProps) {
     const sanitized = sanitizeAmountInput(value);
     setAmount({ amount: sanitized, selectedPreset: null });
     clearPendingAmountRun();
-    if (!isWellFormedAmount(sanitized)) return;
-    debounceTimer.current = window.setTimeout(() => {
-      debounceTimer.current = null;
-      void runRace();
-    }, 200);
+    if (isWellFormedAmount(sanitized)) {
+      debounceTimer.current = window.setTimeout(() => {
+        debounceTimer.current = null;
+        void runRace();
+      }, 200);
+      return;
+    }
+    const error = amountInputError(sanitized);
+    if (error !== null) setRows(orderRaceRows(createRows('errored', error)));
   };
 
   const handlePresetClick = (presetIndex: number) => {

--- a/apps/benchmark/app/components/RequestBar.tsx
+++ b/apps/benchmark/app/components/RequestBar.tsx
@@ -43,7 +43,7 @@ export function RequestBar({ chains }: RequestBarProps) {
   const setPreset = useRequestBarStore((state) => state.setPreset);
   const swapChains = useRequestBarStore((state) => state.swapChains);
   const setRows = useRequestBarStore((state) => state.setRows);
-  const runRace = useRunRace(chains);
+  const { runRace, cancelRace } = useRunRace(chains);
   const [arrowSpins, setArrowSpins] = useState(0);
   const debounceTimer = useRef<number | null>(null);
 
@@ -98,7 +98,9 @@ export function RequestBar({ chains }: RequestBarProps) {
       return;
     }
     const error = amountInputError(sanitized);
-    if (error !== null) setRows(orderRaceRows(createRows('errored', error)));
+    if (error === null) return;
+    cancelRace();
+    setRows(orderRaceRows(createRows('errored', error)));
   };
 
   const handlePresetClick = (presetIndex: number) => {

--- a/apps/benchmark/app/components/race-table/raceRows.ts
+++ b/apps/benchmark/app/components/race-table/raceRows.ts
@@ -3,6 +3,7 @@ import { RACE_PROVIDER_IDS } from './constants';
 import type { AssetLookup, RaceRow, RowStatus } from './types';
 import type { NetworkAssets, QuoteRequest } from '@wonderland/interop-cross-chain';
 import type { ProviderQuoteError, ProviderQuoteResult } from '~/lib/types';
+import { isWellFormedAmount } from '~/lib/amountInput';
 import { AssetSymbol } from '~/lib/assets';
 import { ChainId } from '~/lib/chains';
 import { PROVIDERS, ProviderId } from '~/lib/providers';
@@ -130,35 +131,10 @@ function compareByOutputDesc(left: RaceRow, right: RaceRow): number {
   return a < b ? 1 : a > b ? -1 : 0;
 }
 
-const DECIMAL_AMOUNT_RE = /^\d+(\.\d+)?$/;
-
 function parseAmount(value: string, decimals: number): string {
   const trimmed = value.trim();
-  if (!trimmed) throw new Error('Enter a valid amount');
-
-  if (trimmed.includes(',') && !hasValidThousandSeparators(trimmed)) {
-    throw new Error('Enter a valid amount');
-  }
-
-  const normalized = trimmed.replace(/,/g, '');
-  if (!DECIMAL_AMOUNT_RE.test(normalized)) {
-    throw new Error('Enter a valid amount');
-  }
-
-  return parseUnits(normalized, decimals).toString();
-}
-
-function hasValidThousandSeparators(value: string): boolean {
-  const [integerPart, ...rest] = value.split('.');
-  if (rest.length > 1) return false;
-  if (rest[0]?.includes(',')) return false;
-  if (!integerPart || integerPart.includes(',,')) return false;
-
-  const digitsOnly = integerPart.replace(/,/g, '');
-  if (!/^\d+$/.test(digitsOnly)) return false;
-
-  const reformatted = digitsOnly.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-  return reformatted === integerPart;
+  if (!isWellFormedAmount(trimmed)) throw new Error('Enter a valid amount');
+  return parseUnits(trimmed.replace(/,/g, ''), decimals).toString();
 }
 
 function normalizeProviderId(providerId: string): ProviderId | undefined {

--- a/apps/benchmark/app/components/race-table/useRunRace.ts
+++ b/apps/benchmark/app/components/race-table/useRunRace.ts
@@ -14,7 +14,11 @@ export function useRunRace(chains: NetworkAssets[]) {
   const setRows = useRequestBarStore((state) => state.setRows);
   const latestRunId = useRef(0);
 
-  return useCallback(async () => {
+  const cancelRace = useCallback(() => {
+    latestRunId.current += 1;
+  }, []);
+
+  const runRace = useCallback(async () => {
     if (chains.length === 0) {
       setRows(orderRaceRows(createRows('errored', 'CHAIN DISCOVERY FAILED')));
       return;
@@ -36,6 +40,8 @@ export function useRunRace(chains: NetworkAssets[]) {
       setRows(orderRaceRows(createRows('errored', message)));
     }
   }, [chains, setRows]);
+
+  return { runRace, cancelRace };
 }
 
 function toQueryingRows(previous: RaceRow[]): RaceRow[] {

--- a/apps/benchmark/app/lib/amountInput.ts
+++ b/apps/benchmark/app/lib/amountInput.ts
@@ -11,9 +11,9 @@ export function isWellFormedAmount(value: string): boolean {
 }
 
 export function amountInputError(value: string): string | null {
-  if (!value || isWellFormedAmount(value)) return null;
+  if (isWellFormedAmount(value)) return null;
   // A trailing separator is an amount still being typed, not a malformed one.
-  if (isWellFormedAmount(value.replace(/[.,]$/, ''))) return null;
+  if (value && isWellFormedAmount(value.replace(/[.,]$/, ''))) return null;
   return 'Enter a valid amount';
 }
 

--- a/apps/benchmark/app/lib/amountInput.ts
+++ b/apps/benchmark/app/lib/amountInput.ts
@@ -1,0 +1,31 @@
+const DECIMAL_AMOUNT_RE = /^\d+(\.\d+)?$/;
+
+export function sanitizeAmountInput(value: string): string {
+  return value.replace(/[^\d.,]/g, '');
+}
+
+export function isWellFormedAmount(value: string): boolean {
+  if (!value) return false;
+  if (value.includes(',') && !hasValidThousandSeparators(value)) return false;
+  return DECIMAL_AMOUNT_RE.test(value.replace(/,/g, ''));
+}
+
+export function amountInputError(value: string): string | null {
+  if (!value || isWellFormedAmount(value)) return null;
+  // A trailing separator is an amount still being typed, not a malformed one.
+  if (isWellFormedAmount(value.replace(/[.,]$/, ''))) return null;
+  return 'Enter a valid amount';
+}
+
+function hasValidThousandSeparators(value: string): boolean {
+  const [integerPart, ...rest] = value.split('.');
+  if (rest.length > 1) return false;
+  if (rest[0]?.includes(',')) return false;
+  if (!integerPart || integerPart.includes(',,')) return false;
+
+  const digitsOnly = integerPart.replace(/,/g, '');
+  if (!/^\d+$/.test(digitsOnly)) return false;
+
+  const reformatted = digitsOnly.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return reformatted === integerPart;
+}


### PR DESCRIPTION
# 🤖 Linear

Closes EFI-1017

## Description

The AMOUNT field accepted any text: letters, special characters and malformed numbers like `1.2.3`. It also showed nothing when empty and never surfaced a validation error.

- `app/lib/amountInput.ts`: new module with the amount input rules. `sanitizeAmountInput` strips everything that is not a digit, decimal point or comma, `isWellFormedAmount` checks the number shape (including thousand separators) and `amountInputError` returns the inline message, tolerating a trailing separator while the user is still typing.
- `components/RequestBar.tsx`: the field sanitizes on change, shows a `0.00` placeholder when empty, renders an "Enter a valid amount" message linked to the input with `aria-describedby`/`aria-invalid`, and skips the debounced quote race while the value is not a well-formed number.
- `components/race-table/raceRows.ts`: `parseAmount` reuses `isWellFormedAmount` instead of keeping its own copy of the rules.

## Checklist before requesting a review

- [ ] I have conducted a self-review of my code.
- [ ] I have conducted a QA.
- [ ] If it is a core feature, I have included comprehensive tests.