### PR TITLE
fix(benchmark): unify table header and status label casing

### DIFF
--- a/apps/benchmark/app/components/leaderboard/constants.tsx
+++ b/apps/benchmark/app/components/leaderboard/constants.tsx
@@ -16,7 +16,7 @@ export type LeaderboardColumn = MetricsColumn<LeaderboardRowContext>;
 export const LEADERBOARD_COLUMNS: readonly LeaderboardColumn[] = [
   {
     key: 'rank',
-    label: '#',
+    label: 'RANK',
     className: 'w-10 md:w-12',
     tdClass: METRICS_CELL_STACK,
     render: (_metrics, ctx) => <RankCell {...ctx} />,

--- a/apps/benchmark/app/components/race-table/constants.ts
+++ b/apps/benchmark/app/components/race-table/constants.ts
@@ -6,15 +6,15 @@ export const RACE_PROVIDER_IDS = [ProviderId.Across, ProviderId.Relay, ProviderI
 export const RACE_PROVIDERS = RACE_PROVIDER_IDS.map((providerId) => PROVIDERS[providerId]);
 
 export const RACE_TABLE_COLUMNS: readonly BenchmarkColumn[] = [
-  { key: 'rank', label: 'rank', className: 'w-10 md:w-12' },
-  { key: 'provider', label: 'provider', className: 'md:w-60' },
-  { key: 'latency', label: 'latency', className: 'hidden md:table-cell' },
+  { key: 'rank', label: 'RANK', className: 'w-10 md:w-12' },
+  { key: 'provider', label: 'PROVIDER', className: 'md:w-60' },
+  { key: 'latency', label: 'LATENCY', className: 'hidden md:table-cell' },
   {
     key: 'output',
-    label: 'output',
+    label: 'OUTPUT',
     className: 'text-right md:w-[200px]',
     tooltip: 'The winner is the provider that returns the most output.',
   },
-  { key: 'eta', label: 'eta', className: 'hidden md:table-cell md:w-[100px] text-right' },
-  { key: 'status', label: 'status', className: 'hidden md:table-cell md:w-[160px] text-right' },
+  { key: 'eta', label: 'ETA', className: 'hidden md:table-cell md:w-[100px] text-right' },
+  { key: 'status', label: 'STATUS', className: 'hidden md:table-cell md:w-[160px] text-right' },
 ];

--- a/apps/benchmark/app/lib/providers.ts
+++ b/apps/benchmark/app/lib/providers.ts
@@ -42,7 +42,7 @@ export const PROVIDERS: Record<ProviderId, ProviderMeta> = {
     colorClass: 'bg-provider-bungee',
     iconUrl: '/icons/providers/bungee.webp',
     hasGlobalFeed: false,
-    noFeedReason: 'no global feed',
+    noFeedReason: 'NO GLOBAL FEED',
   },
 };
 

--- a/apps/benchmark/tests/headtohead.spec.ts
+++ b/apps/benchmark/tests/headtohead.spec.ts
@@ -28,7 +28,7 @@ test('every row shows either a BEST AT badge or the no-activity footer', async (
 test('bungee row shows em-dashes and no global feed', async ({ page }) => {
   const table = page.getByRole('region', { name: 'head-to-head comparison' });
   const bungeeRow = table.locator('tbody tr').filter({ hasText: 'bungee' });
-  await expect(bungeeRow).toContainText('no global feed');
+  await expect(bungeeRow).toContainText('NO GLOBAL FEED');
   // BEST AT cell should render the em-dash (no badges for placeholder).
   const bestAtCell = bungeeRow.locator('td').last();
   await expect(bestAtCell).toContainText('—');

--- a/apps/benchmark/tests/leaderboard.spec.ts
+++ b/apps/benchmark/tests/leaderboard.spec.ts
@@ -22,7 +22,7 @@ test('top row shows a real success rate value, not an em-dash', async ({ page })
 test('renders the bungee placeholder row with no global feed', async ({ page }) => {
   const table = page.getByRole('region', { name: 'provider leaderboard' });
   const bungeeRow = table.locator('tbody tr').filter({ hasText: 'bungee' });
-  await expect(bungeeRow).toContainText('no global feed');
+  await expect(bungeeRow).toContainText('NO GLOBAL FEED');
   // Every numeric column (cells 2 through 6: fills, success, p50, p99, fee)
   // must render the em-dash. Asserting `toContainText('—')` alone would pass
   // if any single cell had it, missing a regression that fills another column.


### PR DESCRIPTION
## Why

QA flagged three casing inconsistencies across the benchmark tables:

- In the live quote race table the OUTPUT header rendered lowercase while the rest were uppercase. The header row uppercases labels via CSS, but the OUTPUT label sits inside the `InfoTooltip` button, and browsers reset `text-transform` on buttons, so the raw lowercase string showed through.
- The first column header was "RANK" in the race table but "#" in the leaderboard.
- The Bungee status read "no global feed" in the leaderboard but "NO GLOBAL FEED" in head-to-head.

## What

- Uppercase the `RACE_TABLE_COLUMNS` label strings (`RANK`, `PROVIDER`, `LATENCY`, `OUTPUT`, `ETA`, `STATUS`), the convention the leaderboard and head-to-head tables already use. No style changes needed.
- Rename the leaderboard first column from `#` to `RANK`.
- Set `noFeedReason` to `NO GLOBAL FEED` in `providers.ts` so both tables show the same text.
- Update the two Playwright assertions that matched the lowercase status text.

Closes EFI-1016