### PR TITLE
feat(benchmark): capitalize chain, provider, and section title labels

### DIFF
--- a/apps/benchmark/app/lib/chains.ts
+++ b/apps/benchmark/app/lib/chains.ts
@@ -15,25 +15,25 @@ export interface ChainMeta {
 export const CHAINS: Record<ChainId, ChainMeta> = {
   [ChainId.Ethereum]: {
     id: ChainId.Ethereum,
-    displayName: 'ethereum',
+    displayName: 'Ethereum',
     colorClass: 'bg-text-muted',
     iconUrl: '/icons/chains/ethereum.svg',
   },
   [ChainId.Optimism]: {
     id: ChainId.Optimism,
-    displayName: 'optimism',
+    displayName: 'Optimism',
     colorClass: 'bg-chain-optimism',
     iconUrl: '/icons/chains/optimism.svg',
   },
   [ChainId.Base]: {
     id: ChainId.Base,
-    displayName: 'base',
+    displayName: 'Base',
     colorClass: 'bg-chain-base',
     iconUrl: '/icons/chains/base.svg',
   },
   [ChainId.Arbitrum]: {
     id: ChainId.Arbitrum,
-    displayName: 'arbitrum',
+    displayName: 'Arbitrum',
     colorClass: 'bg-chain-arbitrum',
     iconUrl: '/icons/chains/arbitrum.svg',
   },

--- a/apps/benchmark/app/lib/providers.ts
+++ b/apps/benchmark/app/lib/providers.ts
@@ -17,28 +17,28 @@ export interface ProviderMeta {
 export const PROVIDERS: Record<ProviderId, ProviderMeta> = {
   [ProviderId.Across]: {
     id: ProviderId.Across,
-    displayName: 'across',
+    displayName: 'Across',
     colorClass: 'bg-provider-across',
     iconUrl: '/icons/providers/across.svg',
     hasGlobalFeed: true,
   },
   [ProviderId.Relay]: {
     id: ProviderId.Relay,
-    displayName: 'relay',
+    displayName: 'Relay',
     colorClass: 'bg-provider-relay',
     iconUrl: '/icons/providers/relay.svg',
     hasGlobalFeed: true,
   },
   [ProviderId.Lifi]: {
     id: ProviderId.Lifi,
-    displayName: 'lifi-intents',
+    displayName: 'LI.FI',
     colorClass: 'bg-provider-lifi',
     iconUrl: '/icons/providers/lifi.svg',
     hasGlobalFeed: true,
   },
   [ProviderId.Bungee]: {
     id: ProviderId.Bungee,
-    displayName: 'bungee',
+    displayName: 'Bungee',
     colorClass: 'bg-provider-bungee',
     iconUrl: '/icons/providers/bungee.webp',
     hasGlobalFeed: false,

--- a/apps/benchmark/app/page.tsx
+++ b/apps/benchmark/app/page.tsx
@@ -69,7 +69,7 @@ export default async function Home() {
           <SectionHeader
             index='01'
             label='live quote race'
-            title='ask every provider the same question'
+            title='Ask every provider the same question'
             rightSlot={
               <Label className={META_LABEL_CLASS}>
                 powered by{' '}
@@ -91,7 +91,7 @@ export default async function Home() {
           <SectionHeader
             index='02'
             label='provider leaderboard'
-            title='how providers performed across all routes'
+            title='How providers performed across all routes'
             rightSlot={<Label className={META_LABEL_CLASS}>pulled from each provider&rsquo;s public history api</Label>}
           />
           <Leaderboard metrics={leaderboardMetrics} />
@@ -101,7 +101,7 @@ export default async function Home() {
           <SectionHeader
             index='03'
             label='head-to-head · by route'
-            title='compare providers on a specific chain pair'
+            title='Compare providers on a specific chain pair'
             rightSlot={<RouteSelector />}
           />
           <HeadToHeadClient


### PR DESCRIPTION
Capitalize chain, provider, and section title labels for a more polished look.

The UI used all-lowercase chain names, provider names, and section titles, which clashed with the already-uppercase asset labels (USDC, WETH). This capitalizes the display strings:
- Chains: Ethereum, Optimism, Base, Arbitrum.
- Providers: Across, Relay, Bungee, and `lifi-intents` → `LI.FI` (brand styling; the provider id enum is untouched).
- Section titles to sentence case.

Source-string changes only (labels render verbatim). Reverses an intentional lowercase aesthetic, so it's a deliberate visual change.

The EFI-1016 table casing fixes (output header, rank label, no-feed status) are handled separately in #403.

Closes EFI-1019
