### PR TITLE
feat(benchmark): move the request bar into the live quote race section

### DIFF
--- a/apps/benchmark/app/components/RequestBar.tsx
+++ b/apps/benchmark/app/components/RequestBar.tsx
@@ -116,46 +116,44 @@ export function RequestBar({ chains }: RequestBarProps) {
   };
 
   return (
-    <form onSubmit={handleSubmit} aria-label='cross-chain quote request' className='border-b border-border bg-surface'>
-      <div className='mx-auto max-w-page px-5 py-3 md:px-12 md:py-4 lg:px-24'>
-        <div className='flex flex-col gap-3 md:flex-row md:items-center md:gap-6'>
-          <div className='flex items-center gap-3 md:gap-5'>
-            <Dropdown label='FROM' value={request.fromChainId} options={fromOptions} onChange={handleFromChainChange} />
-            <Arrow onSwap={handleSwap} spinKey={arrowSpins} />
-            <Dropdown label='TO' value={request.toChainId} options={toOptions} onChange={handleToChainChange} />
-          </div>
-
-          <Divider />
-          <Dropdown
-            label='ASSET'
-            value={request.assetSymbol}
-            options={assetOptions}
-            onChange={handleAssetChange}
-            minWidthClass='md:min-w-[6.25rem]'
-          />
-          <Divider />
-
-          <div className='flex flex-1 flex-col gap-3 md:flex-row md:items-center md:gap-4'>
-            <AmountField
-              amount={request.amount}
-              error={amountInputError(request.amount)}
-              onChange={handleAmountChange}
-            />
-            <div className='flex gap-1'>
-              {presets.map((preset, index) => (
-                <PresetPill
-                  key={preset.label}
-                  label={preset.label}
-                  selected={index === request.selectedPreset}
-                  onClick={() => handlePresetClick(index)}
-                  fillContainer
-                />
-              ))}
-            </div>
-          </div>
-
-          <ReRunButton />
+    <form
+      onSubmit={handleSubmit}
+      aria-label='cross-chain quote request'
+      className='border border-border bg-surface px-5 py-3 md:px-6 md:py-4'
+    >
+      <div className='flex flex-col gap-3 md:flex-row md:items-center md:gap-6'>
+        <div className='flex items-center gap-3 md:gap-5'>
+          <Dropdown label='FROM' value={request.fromChainId} options={fromOptions} onChange={handleFromChainChange} />
+          <Arrow onSwap={handleSwap} spinKey={arrowSpins} />
+          <Dropdown label='TO' value={request.toChainId} options={toOptions} onChange={handleToChainChange} />
         </div>
+
+        <Divider />
+        <Dropdown
+          label='ASSET'
+          value={request.assetSymbol}
+          options={assetOptions}
+          onChange={handleAssetChange}
+          minWidthClass='md:min-w-[6.25rem]'
+        />
+        <Divider />
+
+        <div className='flex flex-1 flex-col gap-3 md:flex-row md:items-center md:gap-4'>
+          <AmountField amount={request.amount} error={amountInputError(request.amount)} onChange={handleAmountChange} />
+          <div className='flex gap-1'>
+            {presets.map((preset, index) => (
+              <PresetPill
+                key={preset.label}
+                label={preset.label}
+                selected={index === request.selectedPreset}
+                onClick={() => handlePresetClick(index)}
+                fillContainer
+              />
+            ))}
+          </div>
+        </div>
+
+        <ReRunButton />
       </div>
     </form>
   );

--- a/apps/benchmark/app/page.tsx
+++ b/apps/benchmark/app/page.tsx
@@ -63,8 +63,6 @@ export default async function Home() {
     <div className='min-h-screen cursor-default bg-background'>
       <TopNav />
       <main>
-        <RequestBar chains={initialChains} />
-
         <SectionFrame>
           <SectionHeader
             index='01'
@@ -84,6 +82,7 @@ export default async function Home() {
               </Label>
             }
           />
+          <RequestBar chains={initialChains} />
           <RaceTable initialRows={initialRows} initialChains={initialChains} />
         </SectionFrame>
 


### PR DESCRIPTION
The request controls (asset / from-chain / to-chain / amount / presets) drive only the section 01 "live quote race" table, but they sat at the top of the page as a full-bleed bar, reading like a global header. Moved them into the section 01 block as a bordered card under the section header and directly above the race table, so the inputs visually belong to the table they feed, mirroring how section 03 keeps its route dropdowns inside the section.

Placement only, no behavior change: same store wiring, same runRace on every change, same amount debounce / swap / presets / re-run. The full-bleed bar chrome was replaced with a self-contained bordered surface card, and the redundant `mx-auto max-w-page` page wrapper was dropped since SectionFrame already centers and pads its children. Internal control-row layout (and its responsive behavior) is unchanged.

Closes EFI-1018
