### PR TITLE
fix(ci): skip changeset check on changeset-release branches

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -9,6 +9,7 @@ on:
 jobs:
     check-changeset:
         name: Require changeset for package changes
+        if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
         runs-on: ubuntu-latest
         steps:
             - name: Check out github repository


### PR DESCRIPTION
## Description

The `Check Changeset` workflow fails on the bot's `chore: version packages` PR (#374). That PR bumps the `package.json` of the published packages, which matches the check's path filter, and it deletes the pending `.changeset/*.md` files instead of adding one, so the check can never pass on it.

This went unnoticed until now because the changesets action pushes with the default `GITHUB_TOKEN` and GitHub does not trigger `pull_request` workflows for those pushes. The check never ran on previous release PRs; today the queued runs on #374 were re-run manually and it failed.

The fix adds a job-level `if` that skips the check when the head branch is `changeset-release/*`. Every other PR keeps the requirement.

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [ ] I have conducted a QA.
- [ ] If it is a core feature, I have included comprehensive tests.