### PR TITLE
feat(benchmark): add /lifi-debug page to investigate LiFi success rate

### DIFF
--- a/apps/benchmark/app/lib/lifiDebugAggregation.ts
+++ b/apps/benchmark/app/lib/lifiDebugAggregation.ts
@@ -1,0 +1,183 @@
+import type { LifiDebugOrderItem, LifiDebugRouteOrders } from './services/lifiDebugService';
+import type { HistorySampleStatus } from './types/historyMetrics';
+
+/**
+ * Mirrors LifiIntentsHistoryService's normalizeStatus so the debug view counts
+ * exactly like the leaderboard: Settled/Delivered succeed, Expired/Refunded/
+ * Failed fail, anything else (Signed, in-flight states) is pending and excluded
+ * from the success-rate denominator.
+ */
+export function normalizeLifiOrderStatus(status: string): HistorySampleStatus {
+  switch (status) {
+    case 'Settled':
+    case 'Delivered':
+      return 'success';
+    case 'Expired':
+    case 'Refunded':
+    case 'Failed':
+      return 'failed';
+    default:
+      return 'pending';
+  }
+}
+
+export interface StatusTally {
+  success: number;
+  failed: number;
+  pending: number;
+  /** success / (success + failed); null when nothing resolved. */
+  successRate: number | null;
+}
+
+export interface LifiDebugRouteStats extends StatusTally {
+  originChainId: number;
+  destinationChainId: number;
+  /** Days between oldest and newest sampled order; null with <2 orders or a dead route. */
+  windowDays: number | null;
+  /** True when every page request for the route failed. */
+  unavailable: boolean;
+}
+
+export interface LifiDebugWalletStats {
+  user: string;
+  failed: number;
+  total: number;
+}
+
+export interface LifiDebugFailedOrder {
+  originChainId: number;
+  destinationChainId: number;
+  rawStatus: string;
+  submitTimeMs: number;
+  user: string;
+  hasSolverQuote: boolean;
+  initiatedOnChain: boolean;
+}
+
+export interface LifiDebugReport {
+  totalOrders: number;
+  rawStatusCounts: Record<string, number>;
+  overall: StatusTally;
+  routes: LifiDebugRouteStats[];
+  topFailedWallets: LifiDebugWalletStats[];
+  /** Overall tally with the single worst-failing wallet's orders removed. */
+  excludingTopWallet: StatusTally | null;
+  /** Orders where a solver actually quoted before submission. */
+  quotedOnly: StatusTally;
+  /** Orders submitted without any solver quote attached. */
+  unquotedOnly: StatusTally;
+  /** Failed orders, newest first. */
+  failedOrders: LifiDebugFailedOrder[];
+}
+
+const MS_PER_DAY = 86_400_000;
+const TOP_WALLET_LIMIT = 8;
+
+function tally(items: readonly LifiDebugOrderItem[]): StatusTally {
+  let success = 0;
+  let failed = 0;
+  let pending = 0;
+  for (const item of items) {
+    const status = normalizeLifiOrderStatus(item.meta.orderStatus);
+    if (status === 'success') success += 1;
+    else if (status === 'failed') failed += 1;
+    else pending += 1;
+  }
+  const resolved = success + failed;
+  return { success, failed, pending, successRate: resolved === 0 ? null : success / resolved };
+}
+
+function dedupeKey(item: LifiDebugOrderItem): string {
+  return (
+    item.meta.onChainOrderId ??
+    item.meta.orderIdentifier ??
+    `${item.order.user}-${item.meta.submitTime}-${item.meta.orderStatus}`
+  );
+}
+
+/**
+ * Builds the full debug report from the raw per-route order pages: per-route
+ * and overall tallies using the leaderboard's exact status mapping, plus the
+ * failure attributions (wallet concentration, quoted-vs-unquoted) that the
+ * leaderboard number hides.
+ */
+export function buildLifiDebugReport(routeOrders: readonly LifiDebugRouteOrders[]): LifiDebugReport {
+  const seen = new Set<string>();
+  const unique: { route: LifiDebugRouteOrders; item: LifiDebugOrderItem }[] = [];
+
+  const routes: LifiDebugRouteStats[] = routeOrders.map((route) => {
+    const orders = route.orders ?? [];
+    const fresh: LifiDebugOrderItem[] = [];
+    for (const item of orders) {
+      const key = dedupeKey(item);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      fresh.push(item);
+      unique.push({ route, item });
+    }
+    const timestamps = fresh.map((item) => item.meta.submitTime * 1000).filter((t) => Number.isFinite(t));
+    const windowDays = timestamps.length < 2 ? null : (Math.max(...timestamps) - Math.min(...timestamps)) / MS_PER_DAY;
+    return {
+      originChainId: route.originChainId,
+      destinationChainId: route.destinationChainId,
+      ...tally(fresh),
+      windowDays,
+      unavailable: route.orders === null,
+    };
+  });
+
+  const allItems = unique.map(({ item }) => item);
+  const overall = tally(allItems);
+
+  const rawStatusCounts: Record<string, number> = {};
+  for (const item of allItems) {
+    rawStatusCounts[item.meta.orderStatus] = (rawStatusCounts[item.meta.orderStatus] ?? 0) + 1;
+  }
+
+  const byWallet = new Map<string, { failed: number; total: number }>();
+  for (const item of allItems) {
+    const user = item.order.user.toLowerCase();
+    const entry = byWallet.get(user) ?? { failed: 0, total: 0 };
+    entry.total += 1;
+    if (normalizeLifiOrderStatus(item.meta.orderStatus) === 'failed') entry.failed += 1;
+    byWallet.set(user, entry);
+  }
+  const topFailedWallets = [...byWallet.entries()]
+    .map(([user, counts]) => ({ user, ...counts }))
+    .filter((wallet) => wallet.failed > 0)
+    .sort((a, b) => b.failed - a.failed)
+    .slice(0, TOP_WALLET_LIMIT);
+
+  const topWallet = topFailedWallets[0];
+  const excludingTopWallet = topWallet
+    ? tally(allItems.filter((item) => item.order.user.toLowerCase() !== topWallet.user))
+    : null;
+
+  const quoted = allItems.filter((item) => item.quote != null);
+  const unquoted = allItems.filter((item) => item.quote == null);
+
+  const failedOrders = unique
+    .filter(({ item }) => normalizeLifiOrderStatus(item.meta.orderStatus) === 'failed')
+    .map(({ route, item }) => ({
+      originChainId: route.originChainId,
+      destinationChainId: route.destinationChainId,
+      rawStatus: item.meta.orderStatus,
+      submitTimeMs: item.meta.submitTime * 1000,
+      user: item.order.user.toLowerCase(),
+      hasSolverQuote: item.quote != null,
+      initiatedOnChain: Boolean(item.meta.orderInitiatedTxHash),
+    }))
+    .sort((a, b) => b.submitTimeMs - a.submitTimeMs);
+
+  return {
+    totalOrders: allItems.length,
+    rawStatusCounts,
+    overall,
+    routes,
+    topFailedWallets,
+    excludingTopWallet,
+    quotedOnly: tally(quoted),
+    unquotedOnly: tally(unquoted),
+    failedOrders,
+  };
+}

--- a/apps/benchmark/app/lib/services/lifiDebugService.ts
+++ b/apps/benchmark/app/lib/services/lifiDebugService.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+import { FetchHttpClient } from '../http';
+import { LifiIntentsOrderMetaSchema } from '../schemas/lifiIntents';
+import type { HttpClient } from '@wonderland/interop-cross-chain';
+
+const LIFI_INTENTS_BASE_URL = 'https://order.li.fi';
+const LIFI_INTENTS_ORDERS_PATH = 'orders';
+const LIFI_INTENTS_PAGE_SIZE = 50;
+const LIFI_INTENTS_REQUEST_TIMEOUT_MS = 15_000;
+// Mirrors LifiIntentsHistoryService's default limit so the debug view samples
+// the same population the leaderboard aggregates.
+const ORDERS_PER_ROUTE = 100;
+
+// Superset of the fields the leaderboard pipeline reads: keeps `user` and the
+// solver `quote` so failures can be attributed to wallets and to
+// quoted-vs-unquoted submissions.
+const LifiDebugOrderItemSchema = z
+  .object({
+    order: z.object({ user: z.string() }).passthrough(),
+    quote: z.unknown().nullable().optional(),
+    meta: LifiIntentsOrderMetaSchema.extend({
+      onChainOrderId: z.string().nullable().optional(),
+      orderIdentifier: z.string().nullable().optional(),
+    }),
+  })
+  .passthrough();
+
+const LifiDebugOrdersResponseSchema = z.object({
+  data: z.array(LifiDebugOrderItemSchema),
+});
+
+export type LifiDebugOrderItem = z.infer<typeof LifiDebugOrderItemSchema>;
+
+export interface LifiDebugRouteOrders {
+  originChainId: number;
+  destinationChainId: number;
+  /** Null when every page request for the route failed. */
+  orders: LifiDebugOrderItem[] | null;
+}
+
+/**
+ * Fetches the raw order pages the leaderboard's LiFi history service consumes,
+ * without collapsing them to HistorySamples, so the debug page can inspect the
+ * fields (user, solver quote, tx hashes) that aggregation discards.
+ */
+export class LifiDebugService {
+  constructor(
+    private readonly httpClient: HttpClient = new FetchHttpClient({
+      baseURL: LIFI_INTENTS_BASE_URL,
+      timeout: LIFI_INTENTS_REQUEST_TIMEOUT_MS,
+    }),
+  ) {}
+
+  async getRouteOrders(originChainId: number, destinationChainId: number): Promise<LifiDebugRouteOrders> {
+    try {
+      const orders: LifiDebugOrderItem[] = [];
+      let offset = 0;
+      while (orders.length < ORDERS_PER_ROUTE) {
+        const page = await this.fetchPage(originChainId, destinationChainId, offset);
+        orders.push(...page);
+        offset += page.length;
+        if (page.length < LIFI_INTENTS_PAGE_SIZE) break;
+      }
+      return { originChainId, destinationChainId, orders };
+    } catch {
+      // A dead route should degrade to "no data" in the report, not sink the page.
+      return { originChainId, destinationChainId, orders: null };
+    }
+  }
+
+  private async fetchPage(
+    originChainId: number,
+    destinationChainId: number,
+    offset: number,
+  ): Promise<LifiDebugOrderItem[]> {
+    const { data } = await this.httpClient.get(LIFI_INTENTS_ORDERS_PATH, {
+      params: { originChainId, destinationChainId, limit: LIFI_INTENTS_PAGE_SIZE, offset },
+    });
+    return LifiDebugOrdersResponseSchema.parse(data).data;
+  }
+}

--- a/apps/benchmark/app/lifi-debug/page.tsx
+++ b/apps/benchmark/app/lifi-debug/page.tsx
@@ -1,0 +1,206 @@
+import { CHAIN_IDS, CHAINS, type ChainId } from '../lib/chains';
+import { truncateAddress } from '../lib/formatters';
+import { buildLifiDebugReport, type StatusTally } from '../lib/lifiDebugAggregation';
+import { LifiDebugService } from '../lib/services/lifiDebugService';
+
+// Investigation page: always fetch fresh so the numbers match order.li.fi right now.
+export const dynamic = 'force-dynamic';
+
+const lifiDebugService = new LifiDebugService();
+
+const CARD_CLASS = 'border border-border bg-surface-elevated p-4';
+const HEADING_CLASS = 'font-mono text-label uppercase text-text-muted';
+const TABLE_CLASS = 'w-full font-mono text-sm';
+const HEADER_CELL_CLASS = 'px-3 py-2 text-left text-label uppercase text-text-muted';
+const CELL_CLASS = 'px-3 py-2 text-text-primary';
+const ROW_CLASS = 'border-t border-border';
+
+function formatRate(rate: number | null): string {
+  return rate === null ? '—' : `${(rate * 100).toFixed(1)}%`;
+}
+
+function formatChain(chainId: number): string {
+  return CHAINS[chainId as ChainId]?.displayName ?? `Chain ${chainId}`;
+}
+
+function formatDate(ms: number): string {
+  return new Date(ms).toISOString().replace('T', ' ').slice(0, 16);
+}
+
+interface RateBarProps {
+  rate: number | null;
+}
+
+function RateBar({ rate }: RateBarProps) {
+  if (rate === null) return null;
+  const pct = Math.round(rate * 100);
+  return (
+    <div className='h-2 w-32 overflow-hidden rounded-sm bg-border' role='presentation'>
+      {/* Width is data-driven; no static utility class can express it. */}
+      <div
+        className={`h-full ${pct >= 95 ? 'bg-green-500' : pct >= 80 ? 'bg-yellow-500' : 'bg-red-500'}`}
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}
+
+interface TallyLineProps {
+  label: string;
+  tally: StatusTally;
+}
+
+function TallyLine({ label, tally }: TallyLineProps) {
+  return (
+    <div className='flex items-center justify-between gap-4 py-1'>
+      <span className='text-text-muted'>{label}</span>
+      <span className='font-mono text-text-primary'>
+        {tally.success} ok / {tally.failed} failed / {tally.pending} pending → {formatRate(tally.successRate)}
+      </span>
+    </div>
+  );
+}
+
+export default async function LifiDebugPage() {
+  const routeOrders = await Promise.all(
+    CHAIN_IDS.flatMap((originChainId) =>
+      CHAIN_IDS.filter((destinationChainId) => destinationChainId !== originChainId).map((destinationChainId) =>
+        lifiDebugService.getRouteOrders(originChainId, destinationChainId),
+      ),
+    ),
+  );
+  const report = buildLifiDebugReport(routeOrders);
+
+  return (
+    <main className='min-h-screen bg-background px-6 py-10'>
+      <div className='mx-auto flex max-w-5xl flex-col gap-6'>
+        <header>
+          <h1 className='text-xl font-semibold text-text-primary'>LiFi success-rate investigation</h1>
+          <p className='mt-1 text-sm text-text-muted'>
+            Raw orders from order.li.fi for the 12 leaderboard routes, counted with the exact status mapping the
+            leaderboard uses (Settled/Delivered = success, Expired/Refunded/Failed = failure, rest excluded).
+          </p>
+        </header>
+
+        <section className={CARD_CLASS} aria-label='overall tallies'>
+          <h2 className={HEADING_CLASS}>Overall</h2>
+          <div className='mt-2 text-sm'>
+            <TallyLine label={`All ${report.totalOrders} sampled orders (leaderboard number)`} tally={report.overall} />
+            <TallyLine label='Only orders with a solver quote' tally={report.quotedOnly} />
+            <TallyLine label='Orders submitted without a solver quote' tally={report.unquotedOnly} />
+            {report.excludingTopWallet && report.topFailedWallets[0] && (
+              <TallyLine
+                label={`Excluding top failing wallet ${truncateAddress(report.topFailedWallets[0].user)}`}
+                tally={report.excludingTopWallet}
+              />
+            )}
+          </div>
+          <p className='mt-3 text-sm text-text-muted'>
+            Raw statuses:{' '}
+            {Object.entries(report.rawStatusCounts)
+              .sort(([, a], [, b]) => b - a)
+              .map(([status, count]) => `${status} ${count}`)
+              .join(' · ')}
+          </p>
+        </section>
+
+        <section className={CARD_CLASS} aria-label='per-route success rates'>
+          <h2 className={HEADING_CLASS}>Per route</h2>
+          <table className={TABLE_CLASS}>
+            <thead>
+              <tr>
+                <th className={HEADER_CELL_CLASS}>Route</th>
+                <th className={HEADER_CELL_CLASS}>OK</th>
+                <th className={HEADER_CELL_CLASS}>Failed</th>
+                <th className={HEADER_CELL_CLASS}>Pending</th>
+                <th className={HEADER_CELL_CLASS}>Window</th>
+                <th className={HEADER_CELL_CLASS}>Success</th>
+                <th className={HEADER_CELL_CLASS}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {report.routes.map((route) => (
+                <tr key={`${route.originChainId}-${route.destinationChainId}`} className={ROW_CLASS}>
+                  <td className={CELL_CLASS}>
+                    {formatChain(route.originChainId)} → {formatChain(route.destinationChainId)}
+                    {route.unavailable && <span className='ml-2 text-text-muted'>(fetch failed)</span>}
+                  </td>
+                  <td className={CELL_CLASS}>{route.success}</td>
+                  <td className={CELL_CLASS}>{route.failed}</td>
+                  <td className={CELL_CLASS}>{route.pending}</td>
+                  <td className={CELL_CLASS}>{route.windowDays === null ? '—' : `${route.windowDays.toFixed(1)}d`}</td>
+                  <td className={CELL_CLASS}>{formatRate(route.successRate)}</td>
+                  <td className={CELL_CLASS}>
+                    <RateBar rate={route.successRate} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className='mt-2 text-sm text-text-muted'>
+            Window = age span of the ≤100 most-recent orders the API returns per route. A short window means the sample
+            is dominated by a recent burst of activity.
+          </p>
+        </section>
+
+        <section className={CARD_CLASS} aria-label='failures by wallet'>
+          <h2 className={HEADING_CLASS}>Failures by wallet</h2>
+          <table className={TABLE_CLASS}>
+            <thead>
+              <tr>
+                <th className={HEADER_CELL_CLASS}>Wallet</th>
+                <th className={HEADER_CELL_CLASS}>Failed</th>
+                <th className={HEADER_CELL_CLASS}>Total orders</th>
+                <th className={HEADER_CELL_CLASS}>Share of all failures</th>
+              </tr>
+            </thead>
+            <tbody>
+              {report.topFailedWallets.map((wallet) => (
+                <tr key={wallet.user} className={ROW_CLASS}>
+                  <td className={CELL_CLASS}>{wallet.user}</td>
+                  <td className={CELL_CLASS}>{wallet.failed}</td>
+                  <td className={CELL_CLASS}>{wallet.total}</td>
+                  <td className={CELL_CLASS}>
+                    {report.overall.failed === 0
+                      ? '—'
+                      : `${((wallet.failed / report.overall.failed) * 100).toFixed(0)}%`}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+
+        <section className={CARD_CLASS} aria-label='failed orders'>
+          <h2 className={HEADING_CLASS}>Failed orders (newest first)</h2>
+          <table className={TABLE_CLASS}>
+            <thead>
+              <tr>
+                <th className={HEADER_CELL_CLASS}>Submitted (UTC)</th>
+                <th className={HEADER_CELL_CLASS}>Route</th>
+                <th className={HEADER_CELL_CLASS}>Status</th>
+                <th className={HEADER_CELL_CLASS}>Wallet</th>
+                <th className={HEADER_CELL_CLASS}>Solver quote</th>
+                <th className={HEADER_CELL_CLASS}>On-chain</th>
+              </tr>
+            </thead>
+            <tbody>
+              {report.failedOrders.map((order) => (
+                <tr key={`${order.user}-${order.submitTimeMs}`} className={ROW_CLASS}>
+                  <td className={CELL_CLASS}>{formatDate(order.submitTimeMs)}</td>
+                  <td className={CELL_CLASS}>
+                    {formatChain(order.originChainId)} → {formatChain(order.destinationChainId)}
+                  </td>
+                  <td className={CELL_CLASS}>{order.rawStatus}</td>
+                  <td className={CELL_CLASS}>{truncateAddress(order.user)}</td>
+                  <td className={CELL_CLASS}>{order.hasSolverQuote ? 'yes' : 'no'}</td>
+                  <td className={CELL_CLASS}>{order.initiatedOnChain ? 'yes' : 'no'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Local investigation page for the LiFi leaderboard success rate (~92%). Renders per-route tallies, failures by wallet, and quoted-vs-unquoted splits from raw order.li.fi data at `/lifi-debug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)