### PR TITLE
fix(benchmark): exclude unquoted lifi orders from success rate

### DIFF
--- a/apps/benchmark/app/lib/schemas/lifiIntents.ts
+++ b/apps/benchmark/app/lib/schemas/lifiIntents.ts
@@ -24,6 +24,7 @@ export const LifiIntentsOrderMetaSchema = z
 export const LifiIntentsOrderItemSchema = z
   .object({
     order: LifiIntentsOrderDetailsSchema,
+    quote: z.unknown().nullable().optional(),
     meta: LifiIntentsOrderMetaSchema,
   })
   .passthrough();

--- a/apps/benchmark/app/lib/schemas/lifiIntents.ts
+++ b/apps/benchmark/app/lib/schemas/lifiIntents.ts
@@ -24,7 +24,7 @@ export const LifiIntentsOrderMetaSchema = z
 export const LifiIntentsOrderItemSchema = z
   .object({
     order: LifiIntentsOrderDetailsSchema,
-    quote: z.unknown().nullable().optional(),
+    quote: z.record(z.string(), z.unknown()).nullable().optional(),
     meta: LifiIntentsOrderMetaSchema,
   })
   .passthrough();

--- a/apps/benchmark/app/lib/schemas/relay.ts
+++ b/apps/benchmark/app/lib/schemas/relay.ts
@@ -266,6 +266,9 @@ const RelayHistoryFeesUsdSchema = RelayFeesUsdSchema.passthrough();
 export const RelayHistoryRequestDataSchema = z
   .object({
     subsidizedRequest: z.boolean().optional(),
+    // Kept as a free-form string instead of RelayFailReasonSchema: live data carries
+    // values missing from that enum (e.g. DEPOSIT_CONFIRMATION_TIMEOUT) and new ones may appear.
+    failReason: z.string().optional(),
     inTxs: z.array(RelayHistoryTxSchema).optional(),
     outTxs: z.array(RelayHistoryTxSchema).optional(),
     metadata: RelayHistoryMetadataSchema.optional(),

--- a/apps/benchmark/app/lib/services/lifiIntentsHistoryService.ts
+++ b/apps/benchmark/app/lib/services/lifiIntentsHistoryService.ts
@@ -69,7 +69,8 @@ function filterEligibleOrders(
   items: LifiIntentsOrderItem[],
   tokenAddress: Address | undefined,
 ): LifiIntentsOrderItem[] {
-  return filterByToken(items, tokenAddress).filter((item) => item.quote != null);
+  const quoted = items.filter((item) => item.quote != null);
+  return filterByToken(quoted, tokenAddress);
 }
 
 // The Order Server doesn't accept a token filter and `order.inputs` is encoded as LiFi token ids

--- a/apps/benchmark/app/lib/services/lifiIntentsHistoryService.ts
+++ b/apps/benchmark/app/lib/services/lifiIntentsHistoryService.ts
@@ -30,7 +30,7 @@ export class LifiIntentsHistoryService implements HistoryService {
   async getHistory(query: HistoryQuery): Promise<HistoryResult> {
     const target = Math.min(query.limit ?? LIFI_INTENTS_DEFAULT_LIMIT, LIFI_INTENTS_MAX_LIMIT);
     const items = await this.fetchOrders(query, target);
-    const filtered = filterByToken(items, query.tokenAddress);
+    const filtered = filterEligibleOrders(items, query.tokenAddress);
     const samples = collectSamples(filtered).slice(0, target);
     return { providerId: LIFI_INTENTS_PROVIDER_ID, samples };
   }
@@ -43,7 +43,7 @@ export class LifiIntentsHistoryService implements HistoryService {
       const page = await this.fetchPage(query, offset);
       if (page.data.length === 0) break;
       collected.push(...page.data);
-      filteredCount += filterByToken(page.data, query.tokenAddress).length;
+      filteredCount += filterEligibleOrders(page.data, query.tokenAddress).length;
       offset += page.data.length;
       if (page.data.length < LIFI_INTENTS_PAGE_SIZE) break;
     }
@@ -61,6 +61,15 @@ export class LifiIntentsHistoryService implements HistoryService {
     });
     return LifiIntentsOrdersResponseSchema.parse(data);
   }
+}
+
+// Orders submitted without a solver quote don't go through the quote -> submit flow the SDK
+// integrates, and they fail at ~30% (vs ~0.5% for quoted ones), so they're excluded from the sample.
+function filterEligibleOrders(
+  items: LifiIntentsOrderItem[],
+  tokenAddress: Address | undefined,
+): LifiIntentsOrderItem[] {
+  return filterByToken(items, tokenAddress).filter((item) => item.quote != null);
 }
 
 // The Order Server doesn't accept a token filter and `order.inputs` is encoded as LiFi token ids

--- a/apps/benchmark/app/lib/services/relayHistoryService.ts
+++ b/apps/benchmark/app/lib/services/relayHistoryService.ts
@@ -30,7 +30,7 @@ export class RelayHistoryService implements HistoryService {
   async getHistory(query: HistoryQuery): Promise<HistoryResult> {
     const target = Math.min(query.limit ?? RELAY_DEFAULT_LIMIT, RELAY_MAX_LIMIT);
     const requests = await this.fetchRequests(query, target);
-    const filtered = filterByToken(requests, query.tokenAddress);
+    const filtered = filterEligibleRequests(requests, query.tokenAddress);
     const samples = collectSamples(filtered).slice(0, target);
     return { providerId: RELAY_PROVIDER_ID, samples };
   }
@@ -45,7 +45,7 @@ export class RelayHistoryService implements HistoryService {
       // Count samples that survive both the token filter and the sample
       // construction step; otherwise dropped requests (subsidized, missing
       // timestamps) leave us under-filling the requested limit.
-      usableCount += collectSamples(filterByToken(page.requests, query.tokenAddress)).length;
+      usableCount += collectSamples(filterEligibleRequests(page.requests, query.tokenAddress)).length;
       // Short page or missing continuation both indicate end of data — stop
       // before issuing a redundant request.
       if (!page.continuation || page.requests.length < RELAY_PAGE_SIZE) break;
@@ -65,6 +65,16 @@ export class RelayHistoryService implements HistoryService {
     });
     return RelayHistoryResponseSchema.parse(data);
   }
+}
+
+// Requests no solver quoted (failReason NO_QUOTES) never enter the quote -> submit flow the SDK
+// integrates, so they're excluded from the sample — same rule as unquoted orders in the LiFi service.
+function filterEligibleRequests(
+  requests: RelayHistoryRequest[],
+  tokenAddress: Address | undefined,
+): RelayHistoryRequest[] {
+  const quoted = requests.filter((request) => request.data.failReason !== 'NO_QUOTES');
+  return filterByToken(quoted, tokenAddress);
 }
 
 function filterByToken(requests: RelayHistoryRequest[], tokenAddress: Address | undefined): RelayHistoryRequest[] {


### PR DESCRIPTION
## Description

The LiFi leaderboard success rate (~92%) was dragged down by orders submitted on-chain without a solver quote. Raw order.li.fi data shows those fail around 30% of the time (mostly repeated refunds from a couple of wallets), while quoted orders fail around 0.5%. The SDK always goes through the quote -> submit flow, so unquoted orders don't reflect what the leaderboard measures. Investigation data is in #409.

- `lifiIntents.ts`: declare the `quote` field on `LifiIntentsOrderItemSchema`. The Order Server returns a quote object when a solver quoted the order and `null` otherwise.
- `lifiIntentsHistoryService.ts`: add `filterEligibleOrders`, which applies the existing token filter and drops orders without a solver quote. It runs both when building samples and in the pagination count, so the service keeps fetching pages until it has enough eligible orders.

QA: replayed the new filter against live order.li.fi data on Arbitrum -> Ethereum, the worst route. The sampled success rate moves from 53.1% (52 ok / 46 failed) to 100% (33 ok / 0 failed).

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [ ] If it is a core feature, I have included comprehensive tests.