### PR TITLE
feat(benchmark): show fee normalized by intent size as a median percentage

### DIFF
--- a/apps/benchmark/app/components/headtohead/constants.tsx
+++ b/apps/benchmark/app/components/headtohead/constants.tsx
@@ -1,5 +1,5 @@
 import { ProviderCell } from '../leaderboard/ProviderCell';
-import { formatAvgFee, formatFillCount, formatFillSeconds, formatSuccessRate } from '../leaderboard/formatters';
+import { formatFeePercent, formatFillCount, formatFillSeconds, formatSuccessRate } from '../leaderboard/formatters';
 import { METRICS_CELL_NUM, METRICS_CELL_NUM_HIDDEN, METRICS_CELL_STACK, type MetricsColumn } from '../metricsTable';
 import type { BestAtBadge } from '~/lib/headToHeadBadges';
 import type { ProviderMeta } from '~/lib/providers';
@@ -44,10 +44,11 @@ export const HEAD_TO_HEAD_COLUMNS: readonly HeadToHeadColumn[] = [
   },
   {
     key: 'fee',
-    label: 'AVG FEE',
+    label: 'FEE %',
     className: 'text-right md:w-24',
     tdClass: `${METRICS_CELL_NUM} text-text-primary`,
-    render: (metrics) => formatAvgFee(metrics.avgFeeUsd),
+    tooltip: 'Typical fee as a % of the amount moved.',
+    render: (metrics) => formatFeePercent(metrics.feePercent),
   },
   {
     key: 'bestAt',

--- a/apps/benchmark/app/components/leaderboard/constants.tsx
+++ b/apps/benchmark/app/components/leaderboard/constants.tsx
@@ -1,6 +1,6 @@
 import { METRICS_CELL_NUM, METRICS_CELL_NUM_HIDDEN, METRICS_CELL_STACK, type MetricsColumn } from '../metricsTable';
 import { LeaderboardProviderCell } from './LeaderboardProviderCell';
-import { formatAvgFee, formatFillSeconds, formatSuccessRate } from './formatters';
+import { formatFeePercent, formatFillSeconds, formatSuccessRate } from './formatters';
 import type { ProviderMeta } from '~/lib/providers';
 import { cn } from '~/lib/cn';
 
@@ -58,10 +58,11 @@ export const LEADERBOARD_COLUMNS: readonly LeaderboardColumn[] = [
   },
   {
     key: 'fee',
-    label: 'AVG FEE',
+    label: 'FEE %',
     className: 'text-right md:w-28',
     tdClass: `${METRICS_CELL_NUM} text-text-primary`,
-    render: (metrics) => formatAvgFee(metrics.avgFeeUsd),
+    tooltip: 'Typical fee as a % of the amount moved.',
+    render: (metrics) => formatFeePercent(metrics.feePercent),
   },
 ];
 

--- a/apps/benchmark/app/components/leaderboard/formatters.ts
+++ b/apps/benchmark/app/components/leaderboard/formatters.ts
@@ -53,7 +53,11 @@ export function formatFillSeconds(value: number | null): string {
   return remainderSeconds === 0 ? `${minutes}m` : `${minutes}m ${remainderSeconds}s`;
 }
 
-export function formatAvgFee(value: number | null): string {
+// Fee as a percentage of the amount moved: `0.04%`. Anything that rounds to
+// `0.00%` is a real, non-zero fee that's just below the displayed precision, so
+// show `<0.01%` rather than implying it's free.
+export function formatFeePercent(value: number | null): string {
   if (!isUsableNumber(value) || value < 0) return PLACEHOLDER;
-  return `$${value.toFixed(2)}`;
+  if (value > 0 && value < 0.005) return '<0.01%';
+  return `${value.toFixed(2)}%`;
 }

--- a/apps/benchmark/app/lib/headToHeadBadges.ts
+++ b/apps/benchmark/app/lib/headToHeadBadges.ts
@@ -13,7 +13,7 @@ interface BadgeRule {
 
 const RULES: readonly BadgeRule[] = [
   { badge: 'FASTEST', select: (m) => m.p50FillSeconds, direction: 'min' },
-  { badge: 'CHEAPEST', select: (m) => m.avgFeeUsd, direction: 'min' },
+  { badge: 'CHEAPEST', select: (m) => m.feePercent, direction: 'min' },
   { badge: 'MOST ACTIVE', select: (m) => m.fillCount, direction: 'max' },
 ];
 

--- a/apps/benchmark/app/lib/historyAggregation.ts
+++ b/apps/benchmark/app/lib/historyAggregation.ts
@@ -30,7 +30,13 @@ export function aggregateProviderSamples(providerId: ProviderId, samples: readon
   const successRate = resolved.length === 0 ? null : filled / resolved.length;
 
   const fillTimes = owned.map((s) => s.fillTimeSeconds).filter((v): v is number => v !== null);
-  const fees = owned.map((s) => s.feeUsd).filter((v): v is number => v !== null);
+  // Size-normalized fee: per-sample fee as a % of the intent amount. Skip samples
+  // missing either side, and drop negatives (Across swap-surplus can report a
+  // negative feeUsd, which is not a fee). Median rather than mean so outliers and
+  // any remaining noise don't drag the typical value around.
+  const feePercents = owned
+    .filter((s) => s.feeUsd !== null && s.amountUsd !== null && s.amountUsd > 0 && s.feeUsd >= 0)
+    .map((s) => ((s.feeUsd as number) / (s.amountUsd as number)) * 100);
   const volumes = owned.map((s) => s.amountUsd).filter((v): v is number => v !== null);
 
   return {
@@ -40,7 +46,7 @@ export function aggregateProviderSamples(providerId: ProviderId, samples: readon
     successRate,
     p50FillSeconds: percentile(fillTimes, 50),
     p99FillSeconds: percentile(fillTimes, 99),
-    avgFeeUsd: fees.length === 0 ? null : fees.reduce((a, b) => a + b, 0) / fees.length,
+    feePercent: percentile(feePercents, 50),
     volumeUsd: volumes.length === 0 ? null : volumes.reduce((a, b) => a + b, 0),
   };
 }

--- a/apps/benchmark/app/lib/services/providerMetrics.ts
+++ b/apps/benchmark/app/lib/services/providerMetrics.ts
@@ -31,7 +31,7 @@ function nullMetricsFor(providerId: ProviderId): ProviderMetrics {
     successRate: null,
     p50FillSeconds: null,
     p99FillSeconds: null,
-    avgFeeUsd: null,
+    feePercent: null,
     volumeUsd: null,
   };
 }

--- a/apps/benchmark/app/lib/types/historyMetrics.ts
+++ b/apps/benchmark/app/lib/types/historyMetrics.ts
@@ -34,6 +34,8 @@ export interface ProviderMetrics {
   successRate: number | null;
   p50FillSeconds: number | null;
   p99FillSeconds: number | null;
-  avgFeeUsd: number | null;
+  // Typical fee as a percentage of intent size: the median of per-sample
+  // feeUsd/amountUsd. Size-normalized so it's comparable across providers.
+  feePercent: number | null;
   volumeUsd: number | null;
 }

--- a/apps/benchmark/test/providerMetrics.spec.ts
+++ b/apps/benchmark/test/providerMetrics.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { aggregateProviderSamples } from '~/lib/historyAggregation';
 import { ProviderId } from '~/lib/providers';
 import {
   aggregateProviderRoutes,
@@ -72,6 +73,52 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+describe('aggregateProviderSamples feePercent', () => {
+  function sample(over: Partial<HistorySample>): HistorySample {
+    return {
+      providerId: ACROSS,
+      timestamp: 0,
+      status: 'success',
+      amountUsd: 100,
+      feeUsd: 2,
+      fillTimeSeconds: 12,
+      ...over,
+    };
+  }
+
+  it('takes the median of per-sample fee percents', () => {
+    // 1%, 2%, 6% → median 2%
+    const samples = [
+      sample({ feeUsd: 1, amountUsd: 100 }),
+      sample({ feeUsd: 2, amountUsd: 100 }),
+      sample({ feeUsd: 6, amountUsd: 100 }),
+    ];
+
+    expect(aggregateProviderSamples(ACROSS, samples).feePercent).toBe(2);
+  });
+
+  it('drops negative-fee samples (Across swap-surplus) from the median', () => {
+    // The -5 sample would pull a mean negative; dropped, the median is 2%.
+    const samples = [
+      sample({ feeUsd: -5, amountUsd: 100 }),
+      sample({ feeUsd: 1, amountUsd: 100 }),
+      sample({ feeUsd: 3, amountUsd: 100 }),
+    ];
+
+    expect(aggregateProviderSamples(ACROSS, samples).feePercent).toBe(2);
+  });
+
+  it('is null when no sample has both a fee and a size', () => {
+    const samples = [
+      sample({ feeUsd: null, amountUsd: 100 }),
+      sample({ feeUsd: 2, amountUsd: null }),
+      sample({ feeUsd: 2, amountUsd: 0 }),
+    ];
+
+    expect(aggregateProviderSamples(ACROSS, samples).feePercent).toBeNull();
+  });
+});
+
 describe('aggregateProviderRoutes', () => {
   it('pools samples across every route and aggregates the combined pool once', async () => {
     // Routes return 1, 2, 3 fills: a per-route aggregate would never see 6.
@@ -84,7 +131,7 @@ describe('aggregateProviderRoutes', () => {
     expect(metrics.successRate).toBe(1);
     expect(metrics.p50FillSeconds).toBe(12);
     expect(metrics.p99FillSeconds).toBe(12);
-    expect(metrics.avgFeeUsd).toBe(2);
+    expect(metrics.feePercent).toBe(2); // feeUsd 2 / amountUsd 100 = 2%
     expect(metrics.volumeUsd).toBe(600);
   });
 


### PR DESCRIPTION
The leaderboard (section 02) and head-to-head (section 03) tables showed AVG FEE as an absolute USD mean, which isn't comparable across providers: a provider that mostly sees large intents looks expensive next to one that sees small ones, even at the same rate. This replaces it with a size-normalized FEE %, computed per sample as `feeUsd / amountUsd * 100` and reported as the median across a provider's samples.

Using the median instead of a mean also fixes a real bug. Across reports swap-surplus as a negative `feeUsd`, and the old mean let those negatives drag the displayed fee below zero. We now drop negative-fee samples before taking the median, so the typical fee is what shows.

The metric lives in the shared aggregation layer (`aggregateProviderSamples`), so the same FEE % feeds both tables and the head-to-head CHEAPEST badge. LiFi and Bungee have no fee/size data, so their FEE % is null and renders as '—', same as before.

Closes EFI-1023