### PR TITLE
fix(benchmark): pass token decimals so Across computes USD amount

### DIFF
--- a/apps/benchmark/app/api/head-to-head-metrics/route.ts
+++ b/apps/benchmark/app/api/head-to-head-metrics/route.ts
@@ -7,6 +7,7 @@ import { allProvidersFailed, fetchProviderMetrics } from '~/lib/services/provide
 import { buildTokenDecimals } from '~/lib/tokenDecimals';
 
 const FETCH_TIMEOUT_MS = 15_000;
+const CHAINS_TIMEOUT_MS = 5_000;
 const CACHE_TTL_SECONDS = 60;
 
 // Per (origin, destination) cached function. `unstable_cache` keys on the args
@@ -17,9 +18,16 @@ const CACHE_TTL_SECONDS = 60;
 const cachedFetch = unstable_cache(
   async (fromChainId: ChainId, toChainId: ChainId) => {
     // Across converts inputAmount to USD with the token's decimals, so thread a
-    // decimals map built from the chains data. If discovery throws, let it
-    // propagate to the route's 502 path instead of caching a degraded result.
-    const tokenDecimals = buildTokenDecimals(await chainService.getChains());
+    // decimals map built from the chains data. Decimals only enhance Across USD;
+    // if discovery is slow or fails, degrade to no decimals (Across amountUsd
+    // stays null) rather than failing the whole metrics request.
+    let tokenDecimals: Record<string, number> = {};
+    try {
+      const chains = await withTimeout(chainService.getChains(), CHAINS_TIMEOUT_MS, 'H2H_CHAINS_TIMEOUT');
+      tokenDecimals = buildTokenDecimals(chains);
+    } catch {
+      // keep the empty map
+    }
     const metrics = await fetchProviderMetrics({
       originChainId: fromChainId,
       destinationChainId: toChainId,

--- a/apps/benchmark/app/api/head-to-head-metrics/route.ts
+++ b/apps/benchmark/app/api/head-to-head-metrics/route.ts
@@ -7,32 +7,19 @@ import { allProvidersFailed, fetchProviderMetrics } from '~/lib/services/provide
 import { buildTokenDecimals } from '~/lib/tokenDecimals';
 
 const FETCH_TIMEOUT_MS = 15_000;
-const CHAINS_TIMEOUT_MS = 5_000;
 const CACHE_TTL_SECONDS = 60;
 
-// Token decimals are the same for every route pair and rarely change, so cache
-// them once (shared across pairs) instead of refetching inside each pair's
-// cache. Only successful results are cached: this throws on failure so a
-// transient discovery error isn't cached as an empty map for the whole TTL
-// (which would globally degrade Across USD). The caller handles the throw.
-const getTokenDecimals = unstable_cache(
-  async (): Promise<Record<string, number>> => {
-    const chains = await withTimeout(chainService.getChains(), CHAINS_TIMEOUT_MS, 'H2H_CHAINS_TIMEOUT');
-    return buildTokenDecimals(chains);
-  },
-  ['head-to-head-token-decimals'],
-  { revalidate: CACHE_TTL_SECONDS },
-);
-
-// Per (origin, destination, decimals) cached function. `unstable_cache` keys on
-// the args so identical pairs share the cached response across the fleet for one
-// minute. `tokenDecimals` is part of the key on purpose: a degraded ({}) and a
-// full map cache as separate entries, so a transient decimals failure can't pin
-// degraded Across USD onto the pair's good entry. A route-handler-level
-// `export const revalidate` is ignored when the handler reads `searchParams`
-// (Next treats it as dynamic), so we cache at this layer instead.
+// Per (origin, destination) cached function. `unstable_cache` keys on the args
+// so identical pairs share the cached response across the fleet for one minute.
+// A route-handler-level `export const revalidate` is ignored when the handler
+// reads `searchParams` (Next treats it as dynamic), so we cache at this layer.
 const cachedFetch = unstable_cache(
-  async (fromChainId: ChainId, toChainId: ChainId, tokenDecimals: Record<string, number>) => {
+  async (fromChainId: ChainId, toChainId: ChainId) => {
+    // Across needs token decimals to convert inputAmount into USD. They come
+    // from chains discovery, the same source the rest of the app relies on; if
+    // it fails the request throws and retries (not cached), like the
+    // all-providers-failed guard below.
+    const tokenDecimals = buildTokenDecimals(await chainService.getChains());
     const metrics = await fetchProviderMetrics({
       originChainId: fromChainId,
       destinationChainId: toChainId,
@@ -68,20 +55,9 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'origin and destination must differ' }, { status: 400 });
   }
 
-  // Decimals only enhance Across USD amounts, so a discovery failure degrades to
-  // no decimals (Across amountUsd stays null) instead of failing the request.
-  // Resolved outside cachedFetch so the (possibly empty) map is part of its cache
-  // key, keeping degraded and full results in separate entries.
-  let tokenDecimals: Record<string, number> = {};
-  try {
-    tokenDecimals = await getTokenDecimals();
-  } catch (error) {
-    console.warn('head-to-head-metrics: token decimals unavailable, Across USD degraded:', error);
-  }
-
   try {
     const metrics = await withTimeout(
-      cachedFetch(fromChainId, toChainId, tokenDecimals),
+      cachedFetch(fromChainId, toChainId),
       FETCH_TIMEOUT_MS,
       'HEAD_TO_HEAD_API_TIMEOUT',
     );

--- a/apps/benchmark/app/api/head-to-head-metrics/route.ts
+++ b/apps/benchmark/app/api/head-to-head-metrics/route.ts
@@ -10,6 +10,25 @@ const FETCH_TIMEOUT_MS = 15_000;
 const CHAINS_TIMEOUT_MS = 5_000;
 const CACHE_TTL_SECONDS = 60;
 
+// Token decimals are the same for every route pair and rarely change, so cache
+// them once (shared across pairs) instead of refetching inside each pair's
+// cache. Decimals only enhance Across USD amounts; if discovery is slow or
+// fails, log it and degrade to no decimals (Across amountUsd stays null) rather
+// than failing the metrics request.
+const getTokenDecimals = unstable_cache(
+  async (): Promise<Record<string, number>> => {
+    try {
+      const chains = await withTimeout(chainService.getChains(), CHAINS_TIMEOUT_MS, 'H2H_CHAINS_TIMEOUT');
+      return buildTokenDecimals(chains);
+    } catch (error) {
+      console.warn('head-to-head-metrics: token decimals unavailable, Across USD degraded:', error);
+      return {};
+    }
+  },
+  ['head-to-head-token-decimals'],
+  { revalidate: CACHE_TTL_SECONDS },
+);
+
 // Per (origin, destination) cached function. `unstable_cache` keys on the args
 // so identical pairs share the cached response across the fleet for one
 // minute. A route-handler-level `export const revalidate` is ignored when the
@@ -17,17 +36,7 @@ const CACHE_TTL_SECONDS = 60;
 // this layer instead.
 const cachedFetch = unstable_cache(
   async (fromChainId: ChainId, toChainId: ChainId) => {
-    // Across converts inputAmount to USD with the token's decimals, so thread a
-    // decimals map built from the chains data. Decimals only enhance Across USD;
-    // if discovery is slow or fails, degrade to no decimals (Across amountUsd
-    // stays null) rather than failing the whole metrics request.
-    let tokenDecimals: Record<string, number> = {};
-    try {
-      const chains = await withTimeout(chainService.getChains(), CHAINS_TIMEOUT_MS, 'H2H_CHAINS_TIMEOUT');
-      tokenDecimals = buildTokenDecimals(chains);
-    } catch {
-      // keep the empty map
-    }
+    const tokenDecimals = await getTokenDecimals();
     const metrics = await fetchProviderMetrics({
       originChainId: fromChainId,
       destinationChainId: toChainId,

--- a/apps/benchmark/app/api/head-to-head-metrics/route.ts
+++ b/apps/benchmark/app/api/head-to-head-metrics/route.ts
@@ -2,7 +2,9 @@ import { unstable_cache } from 'next/cache';
 import { NextResponse } from 'next/server';
 import { CHAIN_IDS, type ChainId } from '~/lib/chains';
 import { withTimeout } from '~/lib/helpers';
+import { chainService } from '~/lib/services';
 import { allProvidersFailed, fetchProviderMetrics } from '~/lib/services/providerMetrics';
+import { buildTokenDecimals } from '~/lib/tokenDecimals';
 
 const FETCH_TIMEOUT_MS = 15_000;
 const CACHE_TTL_SECONDS = 60;
@@ -14,9 +16,14 @@ const CACHE_TTL_SECONDS = 60;
 // this layer instead.
 const cachedFetch = unstable_cache(
   async (fromChainId: ChainId, toChainId: ChainId) => {
+    // Across converts inputAmount to USD with the token's decimals, so thread a
+    // decimals map built from the chains data. If discovery throws, let it
+    // propagate to the route's 502 path instead of caching a degraded result.
+    const tokenDecimals = buildTokenDecimals(await chainService.getChains());
     const metrics = await fetchProviderMetrics({
       originChainId: fromChainId,
       destinationChainId: toChainId,
+      tokenDecimals,
     });
     // `fetchProviderMetrics` resolves with null-filled rows when providers
     // fail, so a transient total outage would otherwise be cached for the

--- a/apps/benchmark/app/api/head-to-head-metrics/route.ts
+++ b/apps/benchmark/app/api/head-to-head-metrics/route.ts
@@ -12,18 +12,13 @@ const CACHE_TTL_SECONDS = 60;
 
 // Token decimals are the same for every route pair and rarely change, so cache
 // them once (shared across pairs) instead of refetching inside each pair's
-// cache. Decimals only enhance Across USD amounts; if discovery is slow or
-// fails, log it and degrade to no decimals (Across amountUsd stays null) rather
-// than failing the metrics request.
+// cache. Only successful results are cached: this throws on failure so a
+// transient discovery error isn't cached as an empty map for the whole TTL
+// (which would globally degrade Across USD). The caller handles the throw.
 const getTokenDecimals = unstable_cache(
   async (): Promise<Record<string, number>> => {
-    try {
-      const chains = await withTimeout(chainService.getChains(), CHAINS_TIMEOUT_MS, 'H2H_CHAINS_TIMEOUT');
-      return buildTokenDecimals(chains);
-    } catch (error) {
-      console.warn('head-to-head-metrics: token decimals unavailable, Across USD degraded:', error);
-      return {};
-    }
+    const chains = await withTimeout(chainService.getChains(), CHAINS_TIMEOUT_MS, 'H2H_CHAINS_TIMEOUT');
+    return buildTokenDecimals(chains);
   },
   ['head-to-head-token-decimals'],
   { revalidate: CACHE_TTL_SECONDS },
@@ -36,7 +31,15 @@ const getTokenDecimals = unstable_cache(
 // this layer instead.
 const cachedFetch = unstable_cache(
   async (fromChainId: ChainId, toChainId: ChainId) => {
-    const tokenDecimals = await getTokenDecimals();
+    // Decimals only enhance Across USD amounts, so a discovery failure degrades
+    // this one request to no decimals (Across amountUsd stays null) instead of
+    // failing it. The throw is not cached, so the next request retries.
+    let tokenDecimals: Record<string, number> = {};
+    try {
+      tokenDecimals = await getTokenDecimals();
+    } catch (error) {
+      console.warn('head-to-head-metrics: token decimals unavailable, Across USD degraded:', error);
+    }
     const metrics = await fetchProviderMetrics({
       originChainId: fromChainId,
       destinationChainId: toChainId,

--- a/apps/benchmark/app/api/head-to-head-metrics/route.ts
+++ b/apps/benchmark/app/api/head-to-head-metrics/route.ts
@@ -24,22 +24,15 @@ const getTokenDecimals = unstable_cache(
   { revalidate: CACHE_TTL_SECONDS },
 );
 
-// Per (origin, destination) cached function. `unstable_cache` keys on the args
-// so identical pairs share the cached response across the fleet for one
-// minute. A route-handler-level `export const revalidate` is ignored when the
-// handler reads `searchParams` (Next treats it as dynamic), so we cache at
-// this layer instead.
+// Per (origin, destination, decimals) cached function. `unstable_cache` keys on
+// the args so identical pairs share the cached response across the fleet for one
+// minute. `tokenDecimals` is part of the key on purpose: a degraded ({}) and a
+// full map cache as separate entries, so a transient decimals failure can't pin
+// degraded Across USD onto the pair's good entry. A route-handler-level
+// `export const revalidate` is ignored when the handler reads `searchParams`
+// (Next treats it as dynamic), so we cache at this layer instead.
 const cachedFetch = unstable_cache(
-  async (fromChainId: ChainId, toChainId: ChainId) => {
-    // Decimals only enhance Across USD amounts, so a discovery failure degrades
-    // this one request to no decimals (Across amountUsd stays null) instead of
-    // failing it. The throw is not cached, so the next request retries.
-    let tokenDecimals: Record<string, number> = {};
-    try {
-      tokenDecimals = await getTokenDecimals();
-    } catch (error) {
-      console.warn('head-to-head-metrics: token decimals unavailable, Across USD degraded:', error);
-    }
+  async (fromChainId: ChainId, toChainId: ChainId, tokenDecimals: Record<string, number>) => {
     const metrics = await fetchProviderMetrics({
       originChainId: fromChainId,
       destinationChainId: toChainId,
@@ -75,9 +68,20 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'origin and destination must differ' }, { status: 400 });
   }
 
+  // Decimals only enhance Across USD amounts, so a discovery failure degrades to
+  // no decimals (Across amountUsd stays null) instead of failing the request.
+  // Resolved outside cachedFetch so the (possibly empty) map is part of its cache
+  // key, keeping degraded and full results in separate entries.
+  let tokenDecimals: Record<string, number> = {};
+  try {
+    tokenDecimals = await getTokenDecimals();
+  } catch (error) {
+    console.warn('head-to-head-metrics: token decimals unavailable, Across USD degraded:', error);
+  }
+
   try {
     const metrics = await withTimeout(
-      cachedFetch(fromChainId, toChainId),
+      cachedFetch(fromChainId, toChainId, tokenDecimals),
       FETCH_TIMEOUT_MS,
       'HEAD_TO_HEAD_API_TIMEOUT',
     );

--- a/apps/benchmark/app/lib/tokenDecimals.ts
+++ b/apps/benchmark/app/lib/tokenDecimals.ts
@@ -1,0 +1,18 @@
+import type { NetworkAssets } from '@wonderland/interop-cross-chain';
+
+/**
+ * Flattens the discovered chains into a `chainId:loweraddress -> decimals` map.
+ *
+ * The Across history service keys its decimals lookup on
+ * `${chainId}:${tokenAddress.toLowerCase()}`, so the address must be
+ * lowercased here to match (asset addresses come back checksummed).
+ */
+export function buildTokenDecimals(chains: NetworkAssets[]): Record<string, number> {
+  const map: Record<string, number> = {};
+  for (const network of chains) {
+    for (const asset of network.assets) {
+      map[`${network.chainId}:${asset.address.toLowerCase()}`] = asset.decimals;
+    }
+  }
+  return map;
+}

--- a/apps/benchmark/app/page.tsx
+++ b/apps/benchmark/app/page.tsx
@@ -25,6 +25,7 @@ import {
   fetchAggregatedProviderMetrics,
   fetchProviderMetrics,
 } from './lib/services/providerMetrics';
+import { buildTokenDecimals } from './lib/tokenDecimals';
 import type { RaceRow } from './components/race-table/types';
 import type { HistoryQuery, ProviderMetrics } from './lib/types/historyMetrics';
 import type { NetworkAssets } from '@wonderland/interop-cross-chain';
@@ -49,8 +50,8 @@ export default async function Home() {
   const initialChains = await loadInitialChains();
   const [initialRows, leaderboardMetrics, headToHeadSeed] = await Promise.all([
     loadInitialRace(initialChains),
-    loadLeaderboardMetrics(),
-    loadHeadToHeadSeed(),
+    loadLeaderboardMetrics(initialChains),
+    loadHeadToHeadSeed(initialChains),
   ]);
 
   // First paint uses the canonical-route seed. If that fetch failed entirely,
@@ -127,14 +128,16 @@ async function loadInitialChains(): Promise<NetworkAssets[]> {
   }
 }
 
-async function loadLeaderboardMetrics(): Promise<ProviderMetrics[]> {
+async function loadLeaderboardMetrics(chains: NetworkAssets[]): Promise<ProviderMetrics[]> {
   // Leaderboard pools provider activity across every network route (no token
   // filter, so the sample reflects every asset), for a network-wide view that
   // is distinct from the per-route head-to-head section. No outer deadline: each
   // request is already bounded by the service's client timeout, so the aggregate
   // returns partial results (per-provider null on total failure) instead of an
   // all-or-nothing wrapper that would drop the providers that did finish.
-  const metrics = await fetchAggregatedProviderMetrics(NETWORK_ROUTES);
+  // Thread the decimals map so Across can convert inputAmount to USD.
+  const tokenDecimals = buildTokenDecimals(chains);
+  const metrics = await fetchAggregatedProviderMetrics(NETWORK_ROUTES.map((route) => ({ ...route, tokenDecimals })));
   if (allProvidersFailed(metrics)) {
     // The aggregate resolves null rows instead of throwing when every provider
     // fails, so a try/catch never fires here. Opt this render out of ISR so a
@@ -144,14 +147,16 @@ async function loadLeaderboardMetrics(): Promise<ProviderMetrics[]> {
   return metrics;
 }
 
-async function loadHeadToHeadSeed(): Promise<ProviderMetrics[]> {
+async function loadHeadToHeadSeed(chains: NetworkAssets[]): Promise<ProviderMetrics[]> {
   // First paint of the head-to-head section: the canonical route only, so it
   // matches the route the client hook starts on and can skip the mount fetch.
+  const tokenDecimals = buildTokenDecimals(chains);
   try {
     const seed = await withTimeout(
       fetchProviderMetrics({
         originChainId: INITIAL_FROM_CHAIN_ID,
         destinationChainId: INITIAL_TO_CHAIN_ID,
+        tokenDecimals,
       }),
       HEAD_TO_HEAD_SEED_TIMEOUT_MS,
       'HEAD_TO_HEAD_SEED_TIMEOUT',

--- a/apps/benchmark/test/tokenDecimals.spec.ts
+++ b/apps/benchmark/test/tokenDecimals.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { buildTokenDecimals } from '~/lib/tokenDecimals';
+import type { NetworkAssets } from '@wonderland/interop-cross-chain';
+
+function network(chainId: number, assets: NetworkAssets['assets']): NetworkAssets {
+  return { chainId, assets };
+}
+
+function asset(address: string, decimals: number, symbol = 'TKN'): NetworkAssets['assets'][number] {
+  return { address, symbol, decimals };
+}
+
+describe('buildTokenDecimals', () => {
+  it('maps every asset to a chainId:loweraddress key with its decimals', () => {
+    const chains = [
+      network(1, [asset('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 6, 'USDC')]),
+      network(8453, [asset('0x4200000000000000000000000000000000000006', 18, 'WETH')]),
+    ];
+
+    expect(buildTokenDecimals(chains)).toEqual({
+      '1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': 6,
+      '8453:0x4200000000000000000000000000000000000006': 18,
+    });
+  });
+
+  it('lowercases the checksummed address so it matches the across service key', () => {
+    const chains = [network(1, [asset('0xAbCdEf0000000000000000000000000000000001', 9)])];
+
+    expect(buildTokenDecimals(chains)).toEqual({
+      '1:0xabcdef0000000000000000000000000000000001': 9,
+    });
+  });
+
+  it('returns an empty map when there are no chains', () => {
+    expect(buildTokenDecimals([])).toEqual({});
+  });
+
+  it('keeps the same address on different chains as separate keys', () => {
+    const address = '0x0000000000000000000000000000000000000abc';
+    const chains = [network(1, [asset(address, 6)]), network(10, [asset(address, 18)])];
+
+    expect(buildTokenDecimals(chains)).toEqual({
+      '1:0x0000000000000000000000000000000000000abc': 6,
+      '10:0x0000000000000000000000000000000000000abc': 18,
+    });
+  });
+});


### PR DESCRIPTION
Across's `amountUsd` came back null in the leaderboard and head-to-head tables, so its volume column was empty and the new fee % rendered "—".

The Across history service computes USD from `inputAmount` (raw base units) x `inputPriceUsd`, which needs the token's decimals. It reads them from `HistoryQuery.tokenDecimals` keyed by `${chainId}:${tokenAddress.toLowerCase()}`, but the queries never passed that field, so the lookup missed and `amountUsd` stayed null.

This builds a decimals map from the chains data (already fetched server-side) and threads it as `tokenDecimals` into the queries: the leaderboard aggregate, the head-to-head seed, and the head-to-head API route. The map lowercases each asset's checksummed address to match the service's key format.

No change to the across/relay/lifi services or the aggregation. Relay returns `amountUsd` directly so it's unaffected; LiFi has no fee/amount data and still shows "—". Covers the supported tokens (USDC/WETH); exotic tokens not in the chains data stay "—" as before.

Closes EFI-1025
