### PR TITLE
feat(benchmark): populate lifi fee% and volume from the priced order spread

### DIFF
--- a/apps/benchmark/app/lib/schemas/lifiIntents.ts
+++ b/apps/benchmark/app/lib/schemas/lifiIntents.ts
@@ -2,7 +2,28 @@ import { z } from 'zod';
 
 export const LifiIntentsOrderOutputSchema = z.object({ token: z.string() }).passthrough();
 
-export const LifiIntentsOrderDetailsSchema = z.object({ outputs: z.array(LifiIntentsOrderOutputSchema) }).passthrough();
+// `inputs` is `[[lifiTokenId, amount], ...]`; the token id is a decimal string
+// encoding of the EVM address, the amount is raw base units. Extra tuple
+// elements are tolerated via `.rest`.
+export const LifiIntentsOrderInputSchema = z.tuple([z.string(), z.string()]).rest(z.unknown());
+
+export const LifiIntentsOrderDetailsSchema = z
+  .object({
+    outputs: z.array(LifiIntentsOrderOutputSchema),
+    inputs: z.array(LifiIntentsOrderInputSchema).optional(),
+  })
+  .passthrough();
+
+// order.li.fi returns raw token amounts only — `inputAmount`/`outputAmount` are
+// base-unit strings. We price them with DeFiLlama to derive USD fee/volume.
+export const LifiIntentsQuoteSchema = z
+  .object({
+    inputAmount: z.string().optional(),
+    outputAmount: z.string().optional(),
+  })
+  .passthrough()
+  .nullable()
+  .optional();
 
 // `orderStatus` is left as a free-form string: the Order Server may add new states
 // (e.g. Signed, Delivered, Verified). normalizeStatus handles unknown values explicitly.
@@ -24,7 +45,7 @@ export const LifiIntentsOrderMetaSchema = z
 export const LifiIntentsOrderItemSchema = z
   .object({
     order: LifiIntentsOrderDetailsSchema,
-    quote: z.record(z.string(), z.unknown()).nullable().optional(),
+    quote: LifiIntentsQuoteSchema,
     meta: LifiIntentsOrderMetaSchema,
   })
   .passthrough();

--- a/apps/benchmark/app/lib/services/index.ts
+++ b/apps/benchmark/app/lib/services/index.ts
@@ -11,6 +11,7 @@ import type { QuotesService } from '../interfaces/quotesService.interface';
 
 export * from './acrossHistoryService';
 export * from './lifiIntentsHistoryService';
+export * from './priceService';
 export * from './relayHistoryService';
 export * from './sdkChainService';
 export * from './sdkQuoteService';

--- a/apps/benchmark/app/lib/services/lifiIntentsHistoryService.ts
+++ b/apps/benchmark/app/lib/services/lifiIntentsHistoryService.ts
@@ -1,4 +1,4 @@
-import { isAddressEqual, type Address } from 'viem';
+import { formatUnits, isAddressEqual, padHex, toHex, type Address } from 'viem';
 import { bytes32ToAddress } from '../helpers';
 import { FetchHttpClient } from '../http';
 import {
@@ -7,6 +7,7 @@ import {
   type LifiIntentsOrderMeta,
   type LifiIntentsOrdersResponse,
 } from '../schemas/lifiIntents';
+import { DefiLlamaPriceService, priceKey, type PriceCoin, type PriceInfo, type PriceService } from './priceService';
 import type { HistoryService } from '../interfaces/historyService.interface';
 import type { HistoryQuery, HistoryResult, HistorySample, HistorySampleStatus } from '../types/historyMetrics';
 import type { HttpClient } from '@wonderland/interop-cross-chain';
@@ -25,13 +26,17 @@ export class LifiIntentsHistoryService implements HistoryService {
       baseURL: LIFI_INTENTS_BASE_URL,
       timeout: LIFI_INTENTS_REQUEST_TIMEOUT_MS,
     }),
+    private readonly priceService: PriceService = new DefiLlamaPriceService(),
   ) {}
 
   async getHistory(query: HistoryQuery): Promise<HistoryResult> {
     const target = Math.min(query.limit ?? LIFI_INTENTS_DEFAULT_LIMIT, LIFI_INTENTS_MAX_LIMIT);
     const items = await this.fetchOrders(query, target);
-    const filtered = filterEligibleOrders(items, query.tokenAddress);
-    const samples = collectSamples(filtered).slice(0, target);
+    const filtered = filterEligibleOrders(items, query.tokenAddress).slice(0, target);
+    // Resolve every token price once per call, not per order: the hot per-sample
+    // path only reads the resulting map.
+    const prices = await this.priceService.getUsdPrices(collectPriceCoins(filtered, query));
+    const samples = collectSamples(filtered, query, prices);
     return { providerId: LIFI_INTENTS_PROVIDER_ID, samples };
   }
 
@@ -85,21 +90,102 @@ function filterByToken(items: LifiIntentsOrderItem[], tokenAddress: Address | un
   );
 }
 
-function collectSamples(items: LifiIntentsOrderItem[]): HistorySample[] {
-  return items.map(toSample).filter((sample): sample is HistorySample => sample !== null);
+// LiFi encodes the input token as a decimal-string token id (the EVM address as
+// a uint). Reuse bytes32ToAddress after padding the hex back to 32 bytes.
+function decodeInputToken(item: LifiIntentsOrderItem): Address | null {
+  const id = item.order.inputs?.[0]?.[0];
+  if (typeof id !== 'string') return null;
+  try {
+    return bytes32ToAddress(padHex(toHex(BigInt(id)), { size: 32 }));
+  } catch {
+    return null;
+  }
 }
 
-function toSample(item: LifiIntentsOrderItem): HistorySample | null {
+function decodeOutputToken(item: LifiIntentsOrderItem): Address | null {
+  const token = item.order.outputs[0]?.token;
+  return typeof token === 'string' ? bytes32ToAddress(token) : null;
+}
+
+function collectPriceCoins(items: LifiIntentsOrderItem[], query: HistoryQuery): PriceCoin[] {
+  const coins: PriceCoin[] = [];
+  for (const item of items) {
+    const input = decodeInputToken(item);
+    if (input) coins.push({ chainId: query.originChainId, address: input });
+    const output = decodeOutputToken(item);
+    if (output) coins.push({ chainId: query.destinationChainId, address: output });
+  }
+  return coins;
+}
+
+function collectSamples(
+  items: LifiIntentsOrderItem[],
+  query: HistoryQuery,
+  prices: Map<string, PriceInfo>,
+): HistorySample[] {
+  return items
+    .map((item) => toSample(item, query, prices))
+    .filter((sample): sample is HistorySample => sample !== null);
+}
+
+function toSample(
+  item: LifiIntentsOrderItem,
+  query: HistoryQuery,
+  prices: Map<string, PriceInfo>,
+): HistorySample | null {
   const timestamp = item.meta.submitTime * 1000;
   if (!Number.isFinite(timestamp)) return null;
+  const { amountUsd, feeUsd } = computeUsd(item, query, prices);
   return {
     providerId: LIFI_INTENTS_PROVIDER_ID,
     timestamp,
     status: normalizeStatus(item.meta.orderStatus),
-    amountUsd: null,
-    feeUsd: null,
+    amountUsd,
+    feeUsd,
     fillTimeSeconds: computeFillTimeSeconds(item.meta),
   };
+}
+
+interface UsdAmounts {
+  amountUsd: number | null;
+  feeUsd: number | null;
+}
+
+const NO_USD: UsdAmounts = { amountUsd: null, feeUsd: null };
+
+// Effective fee is the input/output spread priced in USD. inUsd is the intent
+// size (amountUsd); feeUsd = inUsd - outUsd when both sides resolve to finite
+// numbers and the spread is non-negative. Anything missing falls back to nulls.
+function computeUsd(item: LifiIntentsOrderItem, query: HistoryQuery, prices: Map<string, PriceInfo>): UsdAmounts {
+  const inputToken = decodeInputToken(item);
+  const outputToken = decodeOutputToken(item);
+  if (!inputToken || !outputToken) return NO_USD;
+
+  const priceIn = prices.get(priceKey(query.originChainId, inputToken));
+  const priceOut = prices.get(priceKey(query.destinationChainId, outputToken));
+
+  const inUsd = toUsd(item.quote?.inputAmount, priceIn);
+  if (inUsd === null) return NO_USD;
+
+  const outUsd = toUsd(item.quote?.outputAmount, priceOut);
+  const feeUsd = outUsd === null ? null : finiteNonNegative(inUsd - outUsd);
+  return { amountUsd: inUsd, feeUsd };
+}
+
+function toUsd(rawAmount: string | undefined, price: PriceInfo | undefined): number | null {
+  if (rawAmount === undefined || price === undefined) return null;
+  let units: number;
+  try {
+    units = Number(formatUnits(BigInt(rawAmount), price.decimals));
+  } catch {
+    return null;
+  }
+  const usd = units * price.priceUsd;
+  return Number.isFinite(usd) ? usd : null;
+}
+
+function finiteNonNegative(value: number): number | null {
+  return Number.isFinite(value) && value >= 0 ? value : null;
 }
 
 function normalizeStatus(status: string): HistorySampleStatus {

--- a/apps/benchmark/app/lib/services/priceService.ts
+++ b/apps/benchmark/app/lib/services/priceService.ts
@@ -1,0 +1,146 @@
+import { FetchHttpClient } from '../http';
+import type { HttpClient } from '@wonderland/interop-cross-chain';
+
+const DEFILLAMA_BASE_URL = 'https://coins.llama.fi';
+const DEFILLAMA_PRICES_PATH = 'prices/current';
+const DEFILLAMA_REQUEST_TIMEOUT_MS = 10_000;
+// DeFiLlama keys are chain-name prefixed, not chainId. Only the chains the
+// benchmark queries are mapped; anything else is skipped (priced as missing).
+const LLAMA_CHAIN_BY_ID: Record<number, string> = {
+  1: 'ethereum',
+  10: 'optimism',
+  8453: 'base',
+  42161: 'arbitrum',
+};
+// Keep the comma-joined URL well under fetch/proxy limits. A coin key is
+// ~50 chars, so 25 stays under ~1.3KB before the base path.
+const MAX_COINS_PER_REQUEST = 25;
+
+export interface PriceCoin {
+  chainId: number;
+  address: string;
+}
+
+export interface PriceInfo {
+  priceUsd: number;
+  decimals: number;
+}
+
+export interface PriceService {
+  /**
+   * USD price + token decimals keyed by `${chainId}:${address.toLowerCase()}`.
+   * Coins on unknown chains, or that the source can't price, are absent.
+   */
+  getUsdPrices(coins: PriceCoin[]): Promise<Map<string, PriceInfo>>;
+}
+
+interface DefiLlamaCoin {
+  price?: unknown;
+  decimals?: unknown;
+}
+
+interface DefiLlamaResponse {
+  coins?: Record<string, DefiLlamaCoin>;
+}
+
+export function priceKey(chainId: number, address: string): string {
+  return `${chainId}:${address.toLowerCase()}`;
+}
+
+export class DefiLlamaPriceService implements PriceService {
+  constructor(
+    private readonly httpClient: HttpClient = new FetchHttpClient({
+      baseURL: DEFILLAMA_BASE_URL,
+      timeout: DEFILLAMA_REQUEST_TIMEOUT_MS,
+    }),
+  ) {}
+
+  async getUsdPrices(coins: PriceCoin[]): Promise<Map<string, PriceInfo>> {
+    const result = new Map<string, PriceInfo>();
+    const requestable = dedupeRequestableCoins(coins);
+    if (requestable.length === 0) return result;
+
+    // On any failure (timeout, network, parse) degrade to an empty map so the
+    // caller falls back to "—" rather than throwing the whole feed away.
+    try {
+      const chunks = chunk(requestable, MAX_COINS_PER_REQUEST);
+      const responses = await Promise.all(chunks.map((batch) => this.fetchChunk(batch)));
+      for (const response of responses) mergeResponse(response, result);
+    } catch {
+      return new Map();
+    }
+    return result;
+  }
+
+  private async fetchChunk(coins: RequestableCoin[]): Promise<DefiLlamaResponse> {
+    const path = `${DEFILLAMA_PRICES_PATH}/${coins.map((coin) => coin.llamaId).join(',')}`;
+    const { data } = await this.httpClient.get<DefiLlamaResponse>(path);
+    return data ?? {};
+  }
+}
+
+interface RequestableCoin {
+  // `${llamaChain}:${loweraddress}` — both the request token and the response key.
+  llamaId: string;
+  // `${chainId}:${loweraddress}` — the key the caller looks up.
+  key: string;
+}
+
+function dedupeRequestableCoins(coins: PriceCoin[]): RequestableCoin[] {
+  const seen = new Set<string>();
+  const out: RequestableCoin[] = [];
+  for (const coin of coins) {
+    const llamaChain = LLAMA_CHAIN_BY_ID[coin.chainId];
+    if (!llamaChain) continue;
+    const address = coin.address.toLowerCase();
+    const llamaId = `${llamaChain}:${address}`;
+    if (seen.has(llamaId)) continue;
+    seen.add(llamaId);
+    out.push({ llamaId, key: priceKey(coin.chainId, address) });
+  }
+  return out;
+}
+
+function mergeResponse(response: DefiLlamaResponse, into: Map<string, PriceInfo>): void {
+  const coins = response.coins ?? {};
+  // Map llamaId back to the caller key via lowercase comparison: the response
+  // echoes the requested key, so reuse it directly.
+  for (const [llamaId, coin] of Object.entries(coins)) {
+    const info = toPriceInfo(coin);
+    if (info === null) continue;
+    into.set(llamaIdToKey(llamaId), info);
+  }
+}
+
+function llamaIdToKey(llamaId: string): string {
+  const [llamaChain, address] = splitOnce(llamaId, ':');
+  const chainId = chainIdForLlama(llamaChain);
+  if (chainId === null || !address) return llamaId;
+  return priceKey(chainId, address);
+}
+
+function splitOnce(value: string, separator: string): [string, string] {
+  const index = value.indexOf(separator);
+  if (index === -1) return [value, ''];
+  return [value.slice(0, index), value.slice(index + 1)];
+}
+
+function chainIdForLlama(llamaChain: string): number | null {
+  for (const [id, name] of Object.entries(LLAMA_CHAIN_BY_ID)) {
+    if (name === llamaChain) return Number(id);
+  }
+  return null;
+}
+
+function toPriceInfo(coin: DefiLlamaCoin): PriceInfo | null {
+  const priceUsd = Number(coin.price);
+  const decimals = Number(coin.decimals);
+  if (!Number.isFinite(priceUsd) || !Number.isInteger(decimals) || decimals < 0) return null;
+  return { priceUsd, decimals };
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}

--- a/apps/benchmark/app/lib/services/priceService.ts
+++ b/apps/benchmark/app/lib/services/priceService.ts
@@ -72,15 +72,15 @@ export class DefiLlamaPriceService implements PriceService {
     // fall back to "—" downstream. allSettled never rejects, so no try/catch.
     const chunks = chunk(requestable, MAX_COINS_PER_REQUEST);
     const settled = await Promise.allSettled(chunks.map((batch) => this.fetchChunk(batch)));
-    let failed = 0;
+    const failures: string[] = [];
     for (const outcome of settled) {
       if (outcome.status === 'fulfilled') mergeResponse(outcome.value, result);
-      else failed += 1;
+      else failures.push(outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason));
     }
-    // Surface a degraded fetch so a silent drop to "—" is debuggable.
-    if (failed > 0) {
+    // Surface a degraded fetch with its cause so a silent drop to "—" is debuggable.
+    if (failures.length > 0) {
       console.warn(
-        `DeFiLlama pricing: ${failed}/${chunks.length} request(s) failed; affected tokens fall back to no USD`,
+        `DeFiLlama pricing: ${failures.length}/${chunks.length} request(s) failed (${failures.join('; ')}); affected tokens fall back to no USD`,
       );
     }
     return result;

--- a/apps/benchmark/app/lib/services/priceService.ts
+++ b/apps/benchmark/app/lib/services/priceService.ts
@@ -55,6 +55,10 @@ export class DefiLlamaPriceService implements PriceService {
     private readonly httpClient: HttpClient = new FetchHttpClient({
       baseURL: DEFILLAMA_BASE_URL,
       timeout: DEFILLAMA_REQUEST_TIMEOUT_MS,
+      // Best-effort pricing: don't retry. The default client retries 429/5xx with
+      // backoff, which would multiply the timeout and risk the route's 15s budget.
+      // A failed price just degrades the affected tokens to "—".
+      retries: 0,
     }),
   ) {}
 
@@ -68,8 +72,16 @@ export class DefiLlamaPriceService implements PriceService {
     // fall back to "—" downstream. allSettled never rejects, so no try/catch.
     const chunks = chunk(requestable, MAX_COINS_PER_REQUEST);
     const settled = await Promise.allSettled(chunks.map((batch) => this.fetchChunk(batch)));
+    let failed = 0;
     for (const outcome of settled) {
       if (outcome.status === 'fulfilled') mergeResponse(outcome.value, result);
+      else failed += 1;
+    }
+    // Surface a degraded fetch so a silent drop to "—" is debuggable.
+    if (failed > 0) {
+      console.warn(
+        `DeFiLlama pricing: ${failed}/${chunks.length} request(s) failed; affected tokens fall back to no USD`,
+      );
     }
     return result;
   }

--- a/apps/benchmark/app/lib/services/priceService.ts
+++ b/apps/benchmark/app/lib/services/priceService.ts
@@ -3,7 +3,10 @@ import type { HttpClient } from '@wonderland/interop-cross-chain';
 
 const DEFILLAMA_BASE_URL = 'https://coins.llama.fi';
 const DEFILLAMA_PRICES_PATH = 'prices/current';
-const DEFILLAMA_REQUEST_TIMEOUT_MS = 10_000;
+// Pricing runs after order pagination inside the head-to-head route's 15s
+// budget, so keep this tight: DeFiLlama normally answers in well under a second,
+// and a stuck request degrades to "—" rather than eating the route deadline.
+const DEFILLAMA_REQUEST_TIMEOUT_MS = 6_000;
 // DeFiLlama keys are chain-name prefixed, not chainId. Only the chains the
 // benchmark queries are mapped; anything else is skipped (priced as missing).
 const LLAMA_CHAIN_BY_ID: Record<number, string> = {
@@ -60,14 +63,13 @@ export class DefiLlamaPriceService implements PriceService {
     const requestable = dedupeRequestableCoins(coins);
     if (requestable.length === 0) return result;
 
-    // On any failure (timeout, network, parse) degrade to an empty map so the
-    // caller falls back to "—" rather than throwing the whole feed away.
-    try {
-      const chunks = chunk(requestable, MAX_COINS_PER_REQUEST);
-      const responses = await Promise.all(chunks.map((batch) => this.fetchChunk(batch)));
-      for (const response of responses) mergeResponse(response, result);
-    } catch {
-      return new Map();
+    // Keep partial successes: a failed chunk (timeout, network, parse) drops only
+    // its own coins, not the ones other chunks already priced. Unpriced coins
+    // fall back to "—" downstream. allSettled never rejects, so no try/catch.
+    const chunks = chunk(requestable, MAX_COINS_PER_REQUEST);
+    const settled = await Promise.allSettled(chunks.map((batch) => this.fetchChunk(batch)));
+    for (const outcome of settled) {
+      if (outcome.status === 'fulfilled') mergeResponse(outcome.value, result);
     }
     return result;
   }

--- a/apps/benchmark/test/lifiIntentsHistoryService.spec.ts
+++ b/apps/benchmark/test/lifiIntentsHistoryService.spec.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateProviderSamples } from '~/lib/historyAggregation';
+import { ProviderId } from '~/lib/providers';
+import { LifiIntentsHistoryService } from '~/lib/services/lifiIntentsHistoryService';
+import { priceKey, type PriceCoin, type PriceInfo, type PriceService } from '~/lib/services/priceService';
+import type { HistoryQuery } from '~/lib/types/historyMetrics';
+import type { HttpClient, HttpResponse } from '@wonderland/interop-cross-chain';
+
+const ORIGIN_CHAIN_ID = 8453;
+const DESTINATION_CHAIN_ID = 42161;
+
+const INPUT_TOKEN = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+// LiFi encodes the input token as the address read as a uint, in decimal.
+const INPUT_TOKEN_ID = BigInt(INPUT_TOKEN).toString();
+const OUTPUT_TOKEN = '0xaf88d065e77c8cc2239327c5edb3a432268e5831';
+const OUTPUT_TOKEN_BYTES32 = `0x000000000000000000000000${OUTPUT_TOKEN.slice(2)}`;
+
+const QUERY: HistoryQuery = { originChainId: ORIGIN_CHAIN_ID, destinationChainId: DESTINATION_CHAIN_ID };
+
+interface OrderOpts {
+  inputAmount?: string;
+  outputAmount?: string;
+}
+
+function order(opts: OrderOpts = {}): unknown {
+  const { inputAmount = '1000000', outputAmount = '900000' } = opts;
+  return {
+    order: {
+      inputs: [[INPUT_TOKEN_ID, inputAmount]],
+      outputs: [{ token: OUTPUT_TOKEN_BYTES32 }],
+    },
+    quote: { inputAmount, outputAmount },
+    meta: {
+      orderStatus: 'Settled',
+      submitTime: 1_700_000_000,
+      deliveredAt: '2026-01-01T00:00:30.000Z',
+    },
+  };
+}
+
+function okResponse<T>(data: T): HttpResponse<T> {
+  return { status: 200, data, headers: new Headers() };
+}
+
+function fakeClient(orders: unknown[]): HttpClient {
+  let served = false;
+  return {
+    async get<T = unknown>(): Promise<HttpResponse<T>> {
+      // Serve the snapshot once, then an empty page so pagination terminates.
+      const data = served ? { data: [] } : { data: orders };
+      served = true;
+      return okResponse(data as T);
+    },
+    async post<T = unknown>(): Promise<HttpResponse<T>> {
+      throw new Error('not implemented');
+    },
+    async request<T = unknown>(): Promise<HttpResponse<T>> {
+      throw new Error('not implemented');
+    },
+  } satisfies HttpClient;
+}
+
+function fakePriceService(entries: Record<string, PriceInfo>): { service: PriceService; requested: PriceCoin[][] } {
+  const requested: PriceCoin[][] = [];
+  const service: PriceService = {
+    async getUsdPrices(coins) {
+      requested.push(coins);
+      const map = new Map<string, PriceInfo>();
+      for (const [key, info] of Object.entries(entries)) map.set(key, info);
+      return map;
+    },
+  };
+  return { service, requested };
+}
+
+const USDC_6_AT_2 = { priceUsd: 2, decimals: 6 } satisfies PriceInfo;
+
+function bothPriced(): Record<string, PriceInfo> {
+  return {
+    [priceKey(ORIGIN_CHAIN_ID, INPUT_TOKEN)]: USDC_6_AT_2,
+    [priceKey(DESTINATION_CHAIN_ID, OUTPUT_TOKEN)]: USDC_6_AT_2,
+  };
+}
+
+describe('LifiIntentsHistoryService USD pricing', () => {
+  it('prices amountUsd from the input side and feeUsd from the input/output spread', async () => {
+    // input 1.0 @ $2 = $2; output 0.9 @ $2 = $1.8; fee = $0.2; 0.2/2 = 10%.
+    const { service: priceService } = fakePriceService(bothPriced());
+    const service = new LifiIntentsHistoryService(fakeClient([order()]), priceService);
+
+    const { samples } = await service.getHistory(QUERY);
+
+    expect(samples).toHaveLength(1);
+    expect(samples[0].amountUsd).toBeCloseTo(2, 10);
+    expect(samples[0].feeUsd).toBeCloseTo(0.2, 10);
+
+    const metrics = aggregateProviderSamples(ProviderId.Lifi, samples);
+    expect(metrics.feePercent).toBeCloseTo(10, 10);
+    expect(metrics.volumeUsd).toBeCloseTo(2, 10);
+  });
+
+  it('requests both the input and the output token price once', async () => {
+    const { service: priceService, requested } = fakePriceService(bothPriced());
+    const service = new LifiIntentsHistoryService(fakeClient([order()]), priceService);
+
+    await service.getHistory(QUERY);
+
+    expect(requested).toHaveLength(1);
+    expect(requested[0]).toEqual([
+      { chainId: ORIGIN_CHAIN_ID, address: INPUT_TOKEN },
+      { chainId: DESTINATION_CHAIN_ID, address: OUTPUT_TOKEN },
+    ]);
+  });
+
+  it('leaves amountUsd and feeUsd null when the input price is missing', async () => {
+    // Only the output side is priced, so the intent size can't be valued.
+    const { service: priceService } = fakePriceService({
+      [priceKey(DESTINATION_CHAIN_ID, OUTPUT_TOKEN)]: USDC_6_AT_2,
+    });
+    const service = new LifiIntentsHistoryService(fakeClient([order()]), priceService);
+
+    const { samples } = await service.getHistory(QUERY);
+
+    expect(samples[0].amountUsd).toBeNull();
+    expect(samples[0].feeUsd).toBeNull();
+  });
+
+  it('keeps amountUsd but nulls feeUsd when only the output price is missing', async () => {
+    const { service: priceService } = fakePriceService({
+      [priceKey(ORIGIN_CHAIN_ID, INPUT_TOKEN)]: USDC_6_AT_2,
+    });
+    const service = new LifiIntentsHistoryService(fakeClient([order()]), priceService);
+
+    const { samples } = await service.getHistory(QUERY);
+
+    expect(samples[0].amountUsd).toBeCloseTo(2, 10);
+    expect(samples[0].feeUsd).toBeNull();
+  });
+
+  it('nulls feeUsd on a negative spread (output worth more than input)', async () => {
+    // output 1.1 @ $2 = $2.2 > input 1.0 @ $2 = $2 → spread -$0.2, not a fee.
+    const { service: priceService } = fakePriceService(bothPriced());
+    const service = new LifiIntentsHistoryService(
+      fakeClient([order({ inputAmount: '1000000', outputAmount: '1100000' })]),
+      priceService,
+    );
+
+    const { samples } = await service.getHistory(QUERY);
+
+    expect(samples[0].amountUsd).toBeCloseTo(2, 10);
+    expect(samples[0].feeUsd).toBeNull();
+  });
+});

--- a/apps/benchmark/test/priceService.spec.ts
+++ b/apps/benchmark/test/priceService.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { DefiLlamaPriceService, priceKey } from '~/lib/services/priceService';
+import type { HttpClient, HttpResponse } from '@wonderland/interop-cross-chain';
+
+const USDC_BASE = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+const USDC_ARB = '0xaf88d065e77c8cc2239327c5edb3a432268e5831';
+
+function okResponse<T>(data: T): HttpResponse<T> {
+  return { status: 200, data, headers: new Headers() };
+}
+
+function fakeClient(handler: (path: string) => unknown): { client: HttpClient; paths: string[] } {
+  const paths: string[] = [];
+  const client = {
+    async get<T = unknown>(path: string): Promise<HttpResponse<T>> {
+      paths.push(path);
+      return okResponse(handler(path) as T);
+    },
+    async post<T = unknown>(): Promise<HttpResponse<T>> {
+      throw new Error('not implemented');
+    },
+    async request<T = unknown>(): Promise<HttpResponse<T>> {
+      throw new Error('not implemented');
+    },
+  } satisfies HttpClient;
+  return { client, paths };
+}
+
+describe('DefiLlamaPriceService', () => {
+  it('maps chainId to the llama chain key and lowercases addresses in the request', async () => {
+    const { client, paths } = fakeClient(() => ({ coins: {} }));
+    const service = new DefiLlamaPriceService(client);
+
+    await service.getUsdPrices([
+      { chainId: 8453, address: USDC_BASE.toUpperCase() },
+      { chainId: 42161, address: USDC_ARB },
+    ]);
+
+    expect(paths).toHaveLength(1);
+    expect(paths[0]).toBe(`prices/current/base:${USDC_BASE},arbitrum:${USDC_ARB}`);
+  });
+
+  it('parses the response into a chainId:address keyed map', async () => {
+    const { client } = fakeClient(() => ({
+      coins: {
+        [`base:${USDC_BASE}`]: { price: 0.9998, decimals: 6, symbol: 'USDC', confidence: 0.99 },
+        [`arbitrum:${USDC_ARB}`]: { price: 1.0001, decimals: 6, symbol: 'USDC', confidence: 0.99 },
+      },
+    }));
+    const service = new DefiLlamaPriceService(client);
+
+    const prices = await service.getUsdPrices([
+      { chainId: 8453, address: USDC_BASE },
+      { chainId: 42161, address: USDC_ARB },
+    ]);
+
+    expect(prices.get(priceKey(8453, USDC_BASE))).toEqual({ priceUsd: 0.9998, decimals: 6 });
+    expect(prices.get(priceKey(42161, USDC_ARB))).toEqual({ priceUsd: 1.0001, decimals: 6 });
+  });
+
+  it('dedupes identical coins into a single request entry', async () => {
+    const { client, paths } = fakeClient(() => ({ coins: {} }));
+    const service = new DefiLlamaPriceService(client);
+
+    await service.getUsdPrices([
+      { chainId: 8453, address: USDC_BASE },
+      { chainId: 8453, address: USDC_BASE.toUpperCase() },
+    ]);
+
+    expect(paths[0]).toBe(`prices/current/base:${USDC_BASE}`);
+  });
+
+  it('skips coins on chains without a llama mapping', async () => {
+    const { client, paths } = fakeClient(() => ({ coins: {} }));
+    const service = new DefiLlamaPriceService(client);
+
+    const prices = await service.getUsdPrices([{ chainId: 999999, address: USDC_BASE }]);
+
+    expect(paths).toHaveLength(0);
+    expect(prices.size).toBe(0);
+  });
+
+  it('returns an empty map when the request throws', async () => {
+    const client = {
+      async get(): Promise<never> {
+        throw new Error('network down');
+      },
+      async post(): Promise<never> {
+        throw new Error('not implemented');
+      },
+      async request(): Promise<never> {
+        throw new Error('not implemented');
+      },
+    } satisfies HttpClient;
+    const service = new DefiLlamaPriceService(client);
+
+    const prices = await service.getUsdPrices([{ chainId: 8453, address: USDC_BASE }]);
+
+    expect(prices.size).toBe(0);
+  });
+
+  it('drops entries the source cannot price', async () => {
+    const { client } = fakeClient(() => ({
+      coins: { [`base:${USDC_BASE}`]: { symbol: 'USDC' } },
+    }));
+    const service = new DefiLlamaPriceService(client);
+
+    const prices = await service.getUsdPrices([{ chainId: 8453, address: USDC_BASE }]);
+
+    expect(prices.size).toBe(0);
+  });
+});


### PR DESCRIPTION
LiFi was the only provider in the benchmark without a fee% or volume, because order.li.fi exposes raw token amounts only (no USD values). We now price the input/output spread with DeFiLlama (free, no API key) to derive amountUsd and feeUsd, the same way Across and Relay are handled.

For each eligible order we compute `amountUsd = inputAmount / 10^decIn * priceIn` and `feeUsd = amountUsd - outputAmount / 10^decOut * priceOut`. A sample's feeUsd is nulled when it's negative or its prices are missing, so it drops out of the fee% median while its input still counts toward volume. The fee% is the interpolated median of `feeUsd / amountUsd * 100` across the priced samples.

This covers both same-asset bridges (the common case) and swaps. When pricing is unavailable, LiFi degrades gracefully to "—".

The median fee% was cross-checked against an independent hand calc over a live order.li.fi snapshot (base -> arbitrum, 50 orders): code and the Python replication agree exactly at 0.008437273460640785 (diff 0.0, well within 1e-6).

Closes EFI-1026