### PR TITLE
feat(benchmark): add median intent size column to the leaderboard

### DIFF
--- a/apps/benchmark/app/components/leaderboard/constants.tsx
+++ b/apps/benchmark/app/components/leaderboard/constants.tsx
@@ -1,6 +1,6 @@
 import { METRICS_CELL_NUM, METRICS_CELL_NUM_HIDDEN, METRICS_CELL_STACK, type MetricsColumn } from '../metricsTable';
 import { LeaderboardProviderCell } from './LeaderboardProviderCell';
-import { formatFeePercent, formatFillSeconds, formatSuccessRate } from './formatters';
+import { formatFeePercent, formatFillSeconds, formatSize, formatSuccessRate } from './formatters';
 import type { ProviderMeta } from '~/lib/providers';
 import { cn } from '~/lib/cn';
 
@@ -55,6 +55,14 @@ export const LEADERBOARD_COLUMNS: readonly LeaderboardColumn[] = [
     tdClass: `${METRICS_CELL_NUM_HIDDEN} text-text-secondary`,
     tooltip: 'Worst-case fill time. Only 1 in 100 fills is slower than this.',
     render: (metrics) => formatFillSeconds(metrics.p99FillSeconds),
+  },
+  {
+    key: 'size',
+    label: 'SIZE',
+    className: 'hidden text-right md:table-cell md:w-28',
+    tdClass: `${METRICS_CELL_NUM_HIDDEN} text-text-secondary`,
+    tooltip: 'Median intent size in USD: the typical amount moved per fill.',
+    render: (metrics) => formatSize(metrics.medianSizeUsd),
   },
   {
     key: 'fee',

--- a/apps/benchmark/app/components/leaderboard/constants.tsx
+++ b/apps/benchmark/app/components/leaderboard/constants.tsx
@@ -58,8 +58,8 @@ export const LEADERBOARD_COLUMNS: readonly LeaderboardColumn[] = [
   },
   {
     key: 'size',
-    label: 'SIZE',
-    className: 'hidden text-right md:table-cell md:w-28',
+    label: 'MEDIAN SIZE',
+    className: 'hidden text-right md:table-cell md:w-32',
     tdClass: `${METRICS_CELL_NUM_HIDDEN} text-text-secondary`,
     tooltip: 'Median intent size in USD: the typical amount moved per fill.',
     render: (metrics) => formatSize(metrics.medianSizeUsd),

--- a/apps/benchmark/app/components/leaderboard/formatters.ts
+++ b/apps/benchmark/app/components/leaderboard/formatters.ts
@@ -11,17 +11,21 @@ export function formatFillCount(value: number | null): string {
 
 // Compact USD intent size: `<$1`, `$20`, `$1.2k`, `$3.4m`. Whole dollars under
 // 1k (sizes that small don't need cents); k/m suffix above with one decimal.
+// Each unit is rounded before the threshold check so a value just under the next
+// boundary promotes (999,960 -> `$1m`) instead of rendering `$1000k`.
 export function formatSize(value: number | null): string {
   if (!isUsableNumber(value) || value < 0) return PLACEHOLDER;
   if (value < 1) return '<$1';
-  if (value < 1_000) return `$${Math.round(value)}`;
-  if (value < 1_000_000) return `$${trimDecimal(value / 1_000)}k`;
-  return `$${trimDecimal(value / 1_000_000)}m`;
+  if (Math.round(value) < 1_000) return `$${Math.round(value)}`;
+  const k = roundTenth(value / 1_000);
+  if (k < 1_000) return `$${k}k`;
+  return `$${roundTenth(value / 1_000_000)}m`;
 }
 
-// One decimal, but drop a trailing `.0` so `$1.0k` reads `$1k`.
-function trimDecimal(value: number): string {
-  return (Math.round(value * 10) / 10).toString();
+// Round to one decimal; the numeric result drops a trailing `.0` on its own
+// (so `1` renders `$1k`, `1.2` renders `$1.2k`).
+function roundTenth(value: number): number {
+  return Math.round(value * 10) / 10;
 }
 
 // Compact span the sample covers: `0s`, `45s`, `8h`, `2.7d`. Round into each

--- a/apps/benchmark/app/components/leaderboard/formatters.ts
+++ b/apps/benchmark/app/components/leaderboard/formatters.ts
@@ -9,6 +9,21 @@ export function formatFillCount(value: number | null): string {
   return Math.trunc(value).toLocaleString('en-US');
 }
 
+// Compact USD intent size: `<$1`, `$20`, `$1.2k`, `$3.4m`. Whole dollars under
+// 1k (sizes that small don't need cents); k/m suffix above with one decimal.
+export function formatSize(value: number | null): string {
+  if (!isUsableNumber(value) || value < 0) return PLACEHOLDER;
+  if (value < 1) return '<$1';
+  if (value < 1_000) return `$${Math.round(value)}`;
+  if (value < 1_000_000) return `$${trimDecimal(value / 1_000)}k`;
+  return `$${trimDecimal(value / 1_000_000)}m`;
+}
+
+// One decimal, but drop a trailing `.0` so `$1.0k` reads `$1k`.
+function trimDecimal(value: number): string {
+  return (Math.round(value * 10) / 10).toString();
+}
+
 // Compact span the sample covers: `0s`, `45s`, `8h`, `2.7d`. Round into each
 // unit before the threshold check so a near-boundary value rolls over (3599s →
 // `1h`, not `60m`) instead of rendering an out-of-range count. Days keep one

--- a/apps/benchmark/app/lib/historyAggregation.ts
+++ b/apps/benchmark/app/lib/historyAggregation.ts
@@ -47,6 +47,7 @@ export function aggregateProviderSamples(providerId: ProviderId, samples: readon
     p50FillSeconds: percentile(fillTimes, 50),
     p99FillSeconds: percentile(fillTimes, 99),
     feePercent: percentile(feePercents, 50),
+    medianSizeUsd: percentile(volumes, 50),
     volumeUsd: volumes.length === 0 ? null : volumes.reduce((a, b) => a + b, 0),
   };
 }

--- a/apps/benchmark/app/lib/services/providerMetrics.ts
+++ b/apps/benchmark/app/lib/services/providerMetrics.ts
@@ -32,6 +32,7 @@ function nullMetricsFor(providerId: ProviderId): ProviderMetrics {
     p50FillSeconds: null,
     p99FillSeconds: null,
     feePercent: null,
+    medianSizeUsd: null,
     volumeUsd: null,
   };
 }

--- a/apps/benchmark/app/lib/types/historyMetrics.ts
+++ b/apps/benchmark/app/lib/types/historyMetrics.ts
@@ -37,5 +37,8 @@ export interface ProviderMetrics {
   // Typical fee as a percentage of intent size: the median of per-sample
   // feeUsd/amountUsd. Size-normalized so it's comparable across providers.
   feePercent: number | null;
+  // Median intent size in USD: the typical amount moved per fill. Median, not
+  // mean, so a single whale intent doesn't skew it.
+  medianSizeUsd: number | null;
   volumeUsd: number | null;
 }

--- a/apps/benchmark/test/formatters.spec.ts
+++ b/apps/benchmark/test/formatters.spec.ts
@@ -1,5 +1,125 @@
 import { describe, expect, it } from 'vitest';
-import { formatSampleWindow } from '~/components/leaderboard/formatters';
+import {
+  formatFeePercent,
+  formatFillCount,
+  formatFillSeconds,
+  formatSampleWindow,
+  formatSize,
+  formatSuccessRate,
+} from '~/components/leaderboard/formatters';
+
+describe('formatFillCount', () => {
+  it('renders a placeholder for null or negative input', () => {
+    expect(formatFillCount(null)).toBe('—');
+    expect(formatFillCount(-1)).toBe('—');
+  });
+
+  it('groups thousands and truncates fractions', () => {
+    expect(formatFillCount(0)).toBe('0');
+    expect(formatFillCount(42)).toBe('42');
+    expect(formatFillCount(1200)).toBe('1,200');
+    expect(formatFillCount(1200.9)).toBe('1,200'); // truncated, not rounded
+    expect(formatFillCount(1_000_000)).toBe('1,000,000');
+  });
+});
+
+describe('formatSize', () => {
+  it('renders a placeholder for null or negative input', () => {
+    expect(formatSize(null)).toBe('—');
+    expect(formatSize(-5)).toBe('—');
+  });
+
+  it('shows sub-dollar sizes as <$1 rather than $0', () => {
+    expect(formatSize(0)).toBe('<$1');
+    expect(formatSize(0.4)).toBe('<$1');
+  });
+
+  it('shows whole dollars under 1k', () => {
+    expect(formatSize(1)).toBe('$1');
+    expect(formatSize(20)).toBe('$20');
+    expect(formatSize(156.7)).toBe('$157'); // rounded to whole dollars
+    expect(formatSize(999)).toBe('$999');
+  });
+
+  it('uses a k suffix with one decimal in the thousands', () => {
+    expect(formatSize(1000)).toBe('$1k'); // trailing .0 dropped
+    expect(formatSize(1234)).toBe('$1.2k');
+    expect(formatSize(1500)).toBe('$1.5k');
+    expect(formatSize(20_640)).toBe('$20.6k');
+  });
+
+  it('uses an m suffix in the millions', () => {
+    expect(formatSize(1_000_000)).toBe('$1m');
+    expect(formatSize(3_400_000)).toBe('$3.4m');
+  });
+});
+
+describe('formatSuccessRate', () => {
+  it('renders a placeholder for null input', () => {
+    expect(formatSuccessRate(null)).toBe('—');
+  });
+
+  it('renders a fraction as a one-decimal percentage', () => {
+    expect(formatSuccessRate(0)).toBe('0.0%');
+    expect(formatSuccessRate(0.998)).toBe('99.8%');
+    expect(formatSuccessRate(1)).toBe('100.0%');
+  });
+
+  it('clamps upstream rounding noise into [0, 100]', () => {
+    expect(formatSuccessRate(1.0001)).toBe('100.0%');
+    expect(formatSuccessRate(-0.0001)).toBe('0.0%');
+  });
+});
+
+describe('formatFillSeconds', () => {
+  it('renders a placeholder for null or negative input', () => {
+    expect(formatFillSeconds(null)).toBe('—');
+    expect(formatFillSeconds(-1)).toBe('—');
+  });
+
+  it('shows sub-second times in milliseconds', () => {
+    expect(formatFillSeconds(0.012)).toBe('12ms');
+    expect(formatFillSeconds(0.5)).toBe('500ms');
+  });
+
+  it('shows one decimal for seconds under a minute', () => {
+    expect(formatFillSeconds(3)).toBe('3.0s');
+    expect(formatFillSeconds(12.54)).toBe('12.5s');
+  });
+
+  it('rolls a near-minute value into minutes instead of 60.0s', () => {
+    expect(formatFillSeconds(59.96)).toBe('1m'); // not 60.0s
+  });
+
+  it('formats minutes with a seconds remainder, dropping a zero remainder', () => {
+    expect(formatFillSeconds(60)).toBe('1m');
+    expect(formatFillSeconds(65)).toBe('1m 5s');
+    expect(formatFillSeconds(120)).toBe('2m');
+    expect(formatFillSeconds(266)).toBe('4m 26s');
+  });
+});
+
+describe('formatFeePercent', () => {
+  it('renders a placeholder for null or negative input', () => {
+    expect(formatFeePercent(null)).toBe('—');
+    expect(formatFeePercent(-0.1)).toBe('—');
+  });
+
+  it('renders two decimals', () => {
+    expect(formatFeePercent(0.06)).toBe('0.06%');
+    expect(formatFeePercent(0.228)).toBe('0.23%');
+    expect(formatFeePercent(1.5)).toBe('1.50%');
+  });
+
+  it('shows a real zero as 0.00%', () => {
+    expect(formatFeePercent(0)).toBe('0.00%');
+  });
+
+  it('shows a non-zero fee below display precision as <0.01%, not 0.00%', () => {
+    expect(formatFeePercent(0.002)).toBe('<0.01%');
+    expect(formatFeePercent(0.0049)).toBe('<0.01%');
+  });
+});
 
 describe('formatSampleWindow', () => {
   it('renders a placeholder for null or negative input', () => {

--- a/apps/benchmark/test/formatters.spec.ts
+++ b/apps/benchmark/test/formatters.spec.ts
@@ -52,6 +52,10 @@ describe('formatSize', () => {
     expect(formatSize(1_000_000)).toBe('$1m');
     expect(formatSize(3_400_000)).toBe('$3.4m');
   });
+
+  it('promotes to m at the 1M boundary instead of rendering 1000k', () => {
+    expect(formatSize(999_960)).toBe('$1m'); // not $1000k
+  });
 });
 
 describe('formatSuccessRate', () => {

--- a/apps/benchmark/test/providerMetrics.spec.ts
+++ b/apps/benchmark/test/providerMetrics.spec.ts
@@ -119,6 +119,39 @@ describe('aggregateProviderSamples feePercent', () => {
   });
 });
 
+describe('aggregateProviderSamples medianSizeUsd', () => {
+  function sample(over: Partial<HistorySample>): HistorySample {
+    return {
+      providerId: ACROSS,
+      timestamp: 0,
+      status: 'success',
+      amountUsd: 100,
+      feeUsd: 2,
+      fillTimeSeconds: 12,
+      ...over,
+    };
+  }
+
+  it('takes the median of the per-sample intent sizes', () => {
+    // 10, 20, 990 → median 20, not the whale-skewed mean of ~340.
+    const samples = [sample({ amountUsd: 10 }), sample({ amountUsd: 20 }), sample({ amountUsd: 990 })];
+
+    expect(aggregateProviderSamples(ACROSS, samples).medianSizeUsd).toBe(20);
+  });
+
+  it('ignores samples without a size', () => {
+    const samples = [sample({ amountUsd: null }), sample({ amountUsd: 40 }), sample({ amountUsd: 60 })];
+
+    expect(aggregateProviderSamples(ACROSS, samples).medianSizeUsd).toBe(50);
+  });
+
+  it('is null when no sample has a size', () => {
+    const samples = [sample({ amountUsd: null }), sample({ amountUsd: null })];
+
+    expect(aggregateProviderSamples(ACROSS, samples).medianSizeUsd).toBeNull();
+  });
+});
+
 describe('aggregateProviderRoutes', () => {
   it('pools samples across every route and aggregates the combined pool once', async () => {
     // Routes return 1, 2, 3 fills: a per-route aggregate would never see 6.


### PR DESCRIPTION
Adds a SIZE column to the leaderboard (section 02) = median intent size in USD, so the FEE % is easier to read in context.

Median, not average: a single whale intent skews the mean badly (real data: Across mean ~$986 vs median ~$20), and median is consistent with the already-median FEE % and P50 FILL columns. The aggregation already builds the per-sample `volumes` array for volumeUsd, so this is `medianSizeUsd = percentile(volumes, 50)` plus the column.

- New column between P99 and FEE %, right-aligned, hidden on mobile like P50/P99, tooltip "Median intent size in USD".
- Compact format: `<$1`, `$20`, `$1.2k`, `$3.4m`; Bungee has no feed so it renders "—".
- Also backfills unit tests for the leaderboard formatters (only formatSampleWindow had coverage before): formatFillCount, formatSize, formatSuccessRate, formatFillSeconds, formatFeePercent, plus the medianSizeUsd aggregation.

Context: Across and Relay medians are only ~$5 apart and FEE % is already size-normalized, so size doesn't drive the fee gap — the column makes that visible rather than leaving it to intuition.

Closes EFI-1028
