### PR TITLE
feat(benchmark): render the 3 tables as cards on mobile

### DIFF
--- a/apps/benchmark/app/components/InfoTooltip.tsx
+++ b/apps/benchmark/app/components/InfoTooltip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useId } from 'react';
+import { useCallback, useId, useRef, useState, type ReactNode } from 'react';
 import { cn } from '~/lib/cn';
 
 interface InfoTooltipProps {
@@ -10,33 +10,67 @@ interface InfoTooltipProps {
   text: string;
   /** Extra classes for the trigger (e.g. to inherit a cell's label styling). */
   className?: string;
-  /**
-   * Which edge the popover anchors to. Headers use 'right' (the default) so it
-   * stays inside the table's overflow box. Mobile stat cells pass 'left' for
-   * left-aligned cells so the popover opens toward the card's free space.
-   */
-  side?: 'left' | 'right';
 }
 
-// Dropped below the trigger; anchored to one edge so it doesn't overflow its
-// container (the table's overflow box on desktop, the card on mobile).
+// Gap kept between the popover and whatever clips it (the viewport edge on
+// mobile cards, the table's horizontal scroll box on desktop).
+const EDGE_GAP = 8;
+
+// Centered under the trigger; the inline transform nudges it horizontally so it
+// never crosses its clipping box. Width is capped so long copy wraps instead of
+// pushing the popover off-screen.
 const TOOLTIP_CLASS =
-  'pointer-events-none absolute top-full z-20 mt-2 w-max max-w-[15rem] whitespace-normal border ' +
+  'pointer-events-none absolute left-1/2 top-full z-20 mt-2 w-max max-w-[15rem] whitespace-normal border ' +
   'border-border bg-surface-elevated px-2.5 py-1.5 text-left font-sans text-mark normal-case leading-snug ' +
   'tracking-normal text-text-secondary opacity-0 shadow-lg transition-opacity duration-150 ' +
   'group-hover:opacity-100 group-focus-within:opacity-100';
 
-export function InfoTooltip({ label, text, className, side = 'right' }: InfoTooltipProps) {
+// Inner edges of the nearest horizontally-clipping ancestor, clamped to the
+// viewport. This is what the popover must stay inside of, wherever it renders.
+function clipEdges(node: HTMLElement): { left: number; right: number } {
+  let left = 0;
+  let right = window.innerWidth;
+  for (let el = node.parentElement; el; el = el.parentElement) {
+    const overflowX = getComputedStyle(el).overflowX;
+    if (overflowX === 'auto' || overflowX === 'hidden' || overflowX === 'scroll') {
+      const rect = el.getBoundingClientRect();
+      left = Math.max(left, rect.left);
+      right = Math.min(right, rect.right);
+    }
+  }
+  return { left, right };
+}
+
+export function InfoTooltip({ label, text, className }: InfoTooltipProps): ReactNode {
   // useId keeps the trigger/tooltip association unique even when several tables
   // render the same column keys on one page.
   const id = useId();
+  const popoverRef = useRef<HTMLSpanElement>(null);
+  const [shift, setShift] = useState(0);
+
+  // On open, measure where the centered popover lands and shift it back inside
+  // its clipping box by exactly the overflow amount (Floating UI's shift idea).
+  // Decided here, not by the caller, so it's correct in any column or table.
+  const reposition = useCallback(() => {
+    const pop = popoverRef.current;
+    if (!pop) return;
+    const rect = pop.getBoundingClientRect();
+    const { left, right } = clipEdges(pop);
+    // Strip the current shift to recover the natural centered edges.
+    const naturalLeft = rect.left - shift;
+    const naturalRight = rect.right - shift;
+    let next = 0;
+    if (naturalRight > right - EDGE_GAP) next = right - EDGE_GAP - naturalRight;
+    if (naturalLeft + next < left + EDGE_GAP) next = left + EDGE_GAP - naturalLeft;
+    setShift(next);
+  }, [shift]);
 
   // The tooltip lives outside the button so the button's accessible name stays
   // the label alone. It's aria-hidden so screen readers skip it while browsing,
   // yet aria-describedby still reads its text on focus: a node referenced
   // directly by describedby contributes to the description even when hidden.
   return (
-    <span className='group relative inline-flex'>
+    <span className='group relative inline-flex' onPointerEnter={reposition} onFocus={reposition}>
       <button
         type='button'
         aria-describedby={id}
@@ -58,7 +92,13 @@ export function InfoTooltip({ label, text, className, side = 'right' }: InfoTool
           <path d='M12 8h.01' />
         </svg>
       </button>
-      <span id={id} aria-hidden='true' className={cn(TOOLTIP_CLASS, side === 'right' ? 'right-0' : 'left-0')}>
+      <span
+        ref={popoverRef}
+        id={id}
+        aria-hidden='true'
+        className={TOOLTIP_CLASS}
+        style={{ transform: `translateX(calc(-50% + ${shift}px))` }}
+      >
         {text}
       </span>
     </span>

--- a/apps/benchmark/app/components/InfoTooltip.tsx
+++ b/apps/benchmark/app/components/InfoTooltip.tsx
@@ -1,23 +1,32 @@
 'use client';
 
 import { useId } from 'react';
+import { cn } from '~/lib/cn';
 
 interface InfoTooltipProps {
   /** Visible column label. */
   label: string;
   /** Plain-language explanation shown on hover or focus. */
   text: string;
+  /** Extra classes for the trigger (e.g. to inherit a cell's label styling). */
+  className?: string;
+  /**
+   * Which edge the popover anchors to. Headers use 'right' (the default) so it
+   * stays inside the table's overflow box. Mobile stat cells pass 'left' for
+   * left-aligned cells so the popover opens toward the card's free space.
+   */
+  side?: 'left' | 'right';
 }
 
-// Anchored to the right edge and dropped below the header so it stays inside the
-// table's overflow container instead of getting clipped above the first row.
+// Dropped below the trigger; anchored to one edge so it doesn't overflow its
+// container (the table's overflow box on desktop, the card on mobile).
 const TOOLTIP_CLASS =
-  'pointer-events-none absolute right-0 top-full z-20 mt-2 w-max max-w-[15rem] whitespace-normal border ' +
+  'pointer-events-none absolute top-full z-20 mt-2 w-max max-w-[15rem] whitespace-normal border ' +
   'border-border bg-surface-elevated px-2.5 py-1.5 text-left font-sans text-mark normal-case leading-snug ' +
   'tracking-normal text-text-secondary opacity-0 shadow-lg transition-opacity duration-150 ' +
   'group-hover:opacity-100 group-focus-within:opacity-100';
 
-export function InfoTooltip({ label, text }: InfoTooltipProps) {
+export function InfoTooltip({ label, text, className, side = 'right' }: InfoTooltipProps) {
   // useId keeps the trigger/tooltip association unique even when several tables
   // render the same column keys on one page.
   const id = useId();
@@ -28,7 +37,11 @@ export function InfoTooltip({ label, text }: InfoTooltipProps) {
   // directly by describedby contributes to the description even when hidden.
   return (
     <span className='group relative inline-flex'>
-      <button type='button' aria-describedby={id} className='inline-flex cursor-default items-center gap-1'>
+      <button
+        type='button'
+        aria-describedby={id}
+        className={cn('inline-flex cursor-default items-center gap-1', className)}
+      >
         {label}
         <svg
           viewBox='0 0 24 24'
@@ -45,7 +58,7 @@ export function InfoTooltip({ label, text }: InfoTooltipProps) {
           <path d='M12 8h.01' />
         </svg>
       </button>
-      <span id={id} aria-hidden='true' className={TOOLTIP_CLASS}>
+      <span id={id} aria-hidden='true' className={cn(TOOLTIP_CLASS, side === 'right' ? 'right-0' : 'left-0')}>
         {text}
       </span>
     </span>

--- a/apps/benchmark/app/components/headtohead/BestAtBadgeChip.tsx
+++ b/apps/benchmark/app/components/headtohead/BestAtBadgeChip.tsx
@@ -3,7 +3,7 @@ import type { BestAtBadge } from '~/lib/headToHeadBadges';
 // Accent chip naming a category a provider leads (FASTEST / CHEAPEST / MOST
 // ACTIVE). Shared by the desktop head-to-head cell and the mobile card so both
 // render the badge identically.
-export function BestAtBadgeChip({ label }: { label: BestAtBadge }) {
+export function BestAtBadgeChip({ label }: { label: BestAtBadge }): React.ReactNode {
   return (
     <span className='inline-flex items-center whitespace-nowrap bg-accent px-2 py-[3px] font-mono text-[9px] font-semibold uppercase tracking-[0.08em] text-on-accent'>
       {label}

--- a/apps/benchmark/app/components/headtohead/BestAtBadgeChip.tsx
+++ b/apps/benchmark/app/components/headtohead/BestAtBadgeChip.tsx
@@ -1,9 +1,10 @@
+import type { ReactNode } from 'react';
 import type { BestAtBadge } from '~/lib/headToHeadBadges';
 
 // Accent chip naming a category a provider leads (FASTEST / CHEAPEST / MOST
 // ACTIVE). Shared by the desktop head-to-head cell and the mobile card so both
 // render the badge identically.
-export function BestAtBadgeChip({ label }: { label: BestAtBadge }): React.ReactNode {
+export function BestAtBadgeChip({ label }: { label: BestAtBadge }): ReactNode {
   return (
     <span className='inline-flex items-center whitespace-nowrap bg-accent px-2 py-[3px] font-mono text-[9px] font-semibold uppercase tracking-[0.08em] text-on-accent'>
       {label}

--- a/apps/benchmark/app/components/headtohead/BestAtBadgeChip.tsx
+++ b/apps/benchmark/app/components/headtohead/BestAtBadgeChip.tsx
@@ -1,0 +1,12 @@
+import type { BestAtBadge } from '~/lib/headToHeadBadges';
+
+// Accent chip naming a category a provider leads (FASTEST / CHEAPEST / MOST
+// ACTIVE). Shared by the desktop head-to-head cell and the mobile card so both
+// render the badge identically.
+export function BestAtBadgeChip({ label }: { label: BestAtBadge }) {
+  return (
+    <span className='inline-flex items-center whitespace-nowrap bg-accent px-2 py-[3px] font-mono text-[9px] font-semibold uppercase tracking-[0.08em] text-on-accent'>
+      {label}
+    </span>
+  );
+}

--- a/apps/benchmark/app/components/headtohead/HeadToHead.tsx
+++ b/apps/benchmark/app/components/headtohead/HeadToHead.tsx
@@ -1,4 +1,5 @@
 import { BenchmarkTable } from '../BenchmarkTable';
+import { HeadToHeadMobileCard } from './HeadToHeadMobileCard';
 import { HeadToHeadRow } from './HeadToHeadRow';
 import { HEAD_TO_HEAD_COLUMNS } from './constants';
 import type { ProviderMetrics } from '~/lib/types/historyMetrics';
@@ -19,14 +20,26 @@ export function HeadToHead({ metrics, isLoading = false }: HeadToHeadProps) {
       aria-label='head-to-head comparison'
       aria-busy={isLoading}
     >
-      <BenchmarkTable
-        columns={HEAD_TO_HEAD_COLUMNS}
-        rows={metrics}
-        getRowKey={(row) => row.providerId}
-        renderRow={(row) => (
-          <HeadToHeadRow metrics={row} badges={badges.get(row.providerId) ?? []} isLoading={isLoading} />
-        )}
-      />
+      <div className='hidden md:block'>
+        <BenchmarkTable
+          columns={HEAD_TO_HEAD_COLUMNS}
+          rows={metrics}
+          getRowKey={(row) => row.providerId}
+          renderRow={(row) => (
+            <HeadToHeadRow metrics={row} badges={badges.get(row.providerId) ?? []} isLoading={isLoading} />
+          )}
+        />
+      </div>
+      <div className='md:hidden'>
+        {metrics.map((row) => (
+          <HeadToHeadMobileCard
+            key={row.providerId}
+            metrics={row}
+            badges={badges.get(row.providerId) ?? []}
+            isLoading={isLoading}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/benchmark/app/components/headtohead/HeadToHeadMobileCard.tsx
+++ b/apps/benchmark/app/components/headtohead/HeadToHeadMobileCard.tsx
@@ -1,0 +1,76 @@
+import { Skeleton } from '../Skeleton';
+import { formatFeePercent, formatFillCount, formatFillSeconds, formatSuccessRate } from '../leaderboard/formatters';
+import { NoFeedChip } from '../mobile/NoFeedChip';
+import { ProviderChip } from '../mobile/ProviderChip';
+import { StatCell } from '../mobile/StatCell';
+import { BestAtBadgeChip } from './BestAtBadgeChip';
+import type { BestAtBadge } from '~/lib/headToHeadBadges';
+import type { ProviderMetrics } from '~/lib/types/historyMetrics';
+import { cn } from '~/lib/cn';
+import { PROVIDERS } from '~/lib/providers';
+
+interface HeadToHeadMobileCardProps {
+  metrics: ProviderMetrics;
+  badges: readonly BestAtBadge[];
+  isLoading?: boolean;
+}
+
+// Mobile head-to-head card: provider header with BEST AT badges on the right,
+// then a FILLS / SUCCESS / P50 / FEE stat strip. A no-feed provider (Bungee) is
+// dimmed and shows a NO FEED chip. While a refetch is in flight the stat values
+// turn into skeletons, mirroring the desktop row.
+export function HeadToHeadMobileCard({ metrics, badges, isLoading = false }: HeadToHeadMobileCardProps) {
+  const provider = PROVIDERS[metrics.providerId];
+  const isPlaceholder = !provider.hasGlobalFeed;
+  const skeletonize = isLoading && !isPlaceholder;
+
+  return (
+    <article
+      className={cn(
+        'flex flex-col gap-3 border-b border-border-subtle p-4 last:border-b-0',
+        isPlaceholder && 'opacity-55',
+      )}
+    >
+      <div className='flex items-center justify-between gap-3'>
+        <ProviderChip provider={provider} />
+        {isPlaceholder ? (
+          <NoFeedChip />
+        ) : badges.length > 0 ? (
+          <div className='flex flex-wrap items-center justify-end gap-1.5'>
+            {badges.map((badge) => (
+              <BestAtBadgeChip key={badge} label={badge} />
+            ))}
+          </div>
+        ) : null}
+      </div>
+      <div className='flex items-start justify-between gap-2'>
+        <Stat label='FILLS' value={formatFillCount(metrics.fillCount)} skeletonize={skeletonize} />
+        <Stat label='SUCCESS' value={formatSuccessRate(metrics.successRate)} skeletonize={skeletonize} />
+        <Stat label='P50' value={formatFillSeconds(metrics.p50FillSeconds)} skeletonize={skeletonize} />
+        <Stat label='FEE' value={formatFeePercent(metrics.feePercent)} skeletonize={skeletonize} align='end' />
+      </div>
+    </article>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  skeletonize,
+  align = 'start',
+}: {
+  label: string;
+  value: string;
+  skeletonize: boolean;
+  align?: 'start' | 'end';
+}) {
+  if (skeletonize) {
+    return (
+      <div className={cn('flex flex-col gap-[3px]', align === 'end' && 'items-end')}>
+        <span className='font-mono text-[9px] uppercase leading-none tracking-[0.04em] text-text-muted'>{label}</span>
+        <Skeleton className='h-[13px] w-10' />
+      </div>
+    );
+  }
+  return <StatCell label={label} value={value} align={align} />;
+}

--- a/apps/benchmark/app/components/headtohead/HeadToHeadMobileCard.tsx
+++ b/apps/benchmark/app/components/headtohead/HeadToHeadMobileCard.tsx
@@ -19,7 +19,11 @@ interface HeadToHeadMobileCardProps {
 // then a FILLS / SUCCESS / P50 / FEE stat strip. A no-feed provider (Bungee) is
 // dimmed and shows a NO FEED chip. While a refetch is in flight the stat values
 // turn into skeletons, mirroring the desktop row.
-export function HeadToHeadMobileCard({ metrics, badges, isLoading = false }: HeadToHeadMobileCardProps) {
+export function HeadToHeadMobileCard({
+  metrics,
+  badges,
+  isLoading = false,
+}: HeadToHeadMobileCardProps): React.ReactNode {
   const provider = PROVIDERS[metrics.providerId];
   const isPlaceholder = !provider.hasGlobalFeed;
   const skeletonize = isLoading && !isPlaceholder;

--- a/apps/benchmark/app/components/headtohead/HeadToHeadMobileCard.tsx
+++ b/apps/benchmark/app/components/headtohead/HeadToHeadMobileCard.tsx
@@ -35,7 +35,7 @@ export function HeadToHeadMobileCard({ metrics, badges, isLoading = false }: Hea
         <ProviderChip provider={provider} />
         {isPlaceholder ? (
           <NoFeedChip />
-        ) : badges.length > 0 ? (
+        ) : !skeletonize && badges.length > 0 ? (
           <div className='flex flex-wrap items-center justify-end gap-1.5'>
             {badges.map((badge) => (
               <BestAtBadgeChip key={badge} label={badge} />
@@ -46,8 +46,19 @@ export function HeadToHeadMobileCard({ metrics, badges, isLoading = false }: Hea
       <div className='flex items-start justify-between gap-2'>
         <Stat label='FILLS' value={formatFillCount(metrics.fillCount)} skeletonize={skeletonize} />
         <Stat label='SUCCESS' value={formatSuccessRate(metrics.successRate)} skeletonize={skeletonize} />
-        <Stat label='P50' value={formatFillSeconds(metrics.p50FillSeconds)} skeletonize={skeletonize} />
-        <Stat label='FEE' value={formatFeePercent(metrics.feePercent)} skeletonize={skeletonize} align='end' />
+        <Stat
+          label='P50'
+          value={formatFillSeconds(metrics.p50FillSeconds)}
+          skeletonize={skeletonize}
+          tooltip='Median fill time. Half of fills finish faster than this, half slower.'
+        />
+        <Stat
+          label='FEE'
+          value={formatFeePercent(metrics.feePercent)}
+          skeletonize={skeletonize}
+          align='end'
+          tooltip='Typical fee as a % of the amount moved.'
+        />
       </div>
     </article>
   );
@@ -58,11 +69,13 @@ function Stat({
   value,
   skeletonize,
   align = 'start',
+  tooltip,
 }: {
   label: string;
   value: string;
   skeletonize: boolean;
   align?: 'start' | 'end';
+  tooltip?: string;
 }) {
   if (skeletonize) {
     return (
@@ -72,5 +85,5 @@ function Stat({
       </div>
     );
   }
-  return <StatCell label={label} value={value} align={align} />;
+  return <StatCell label={label} value={value} align={align} tooltip={tooltip} />;
 }

--- a/apps/benchmark/app/components/headtohead/HeadToHeadMobileCard.tsx
+++ b/apps/benchmark/app/components/headtohead/HeadToHeadMobileCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { Skeleton } from '../Skeleton';
 import { formatFeePercent, formatFillCount, formatFillSeconds, formatSuccessRate } from '../leaderboard/formatters';
 import { NoFeedChip } from '../mobile/NoFeedChip';
@@ -19,11 +20,7 @@ interface HeadToHeadMobileCardProps {
 // then a FILLS / SUCCESS / P50 / FEE stat strip. A no-feed provider (Bungee) is
 // dimmed and shows a NO FEED chip. While a refetch is in flight the stat values
 // turn into skeletons, mirroring the desktop row.
-export function HeadToHeadMobileCard({
-  metrics,
-  badges,
-  isLoading = false,
-}: HeadToHeadMobileCardProps): React.ReactNode {
+export function HeadToHeadMobileCard({ metrics, badges, isLoading = false }: HeadToHeadMobileCardProps): ReactNode {
   const provider = PROVIDERS[metrics.providerId];
   const isPlaceholder = !provider.hasGlobalFeed;
   const skeletonize = isLoading && !isPlaceholder;

--- a/apps/benchmark/app/components/headtohead/constants.tsx
+++ b/apps/benchmark/app/components/headtohead/constants.tsx
@@ -1,9 +1,9 @@
 import { ProviderCell } from '../leaderboard/ProviderCell';
 import { formatFeePercent, formatFillCount, formatFillSeconds, formatSuccessRate } from '../leaderboard/formatters';
 import { METRICS_CELL_NUM, METRICS_CELL_NUM_HIDDEN, METRICS_CELL_STACK, type MetricsColumn } from '../metricsTable';
+import { BestAtBadgeChip } from './BestAtBadgeChip';
 import type { BestAtBadge } from '~/lib/headToHeadBadges';
 import type { ProviderMeta } from '~/lib/providers';
-import { cn } from '~/lib/cn';
 
 export interface HeadToHeadRowContext {
   provider: ProviderMeta;
@@ -69,18 +69,5 @@ function BestAtCell({ badges }: { badges: readonly BestAtBadge[] }) {
         <BestAtBadgeChip key={badge} label={badge} />
       ))}
     </div>
-  );
-}
-
-function BestAtBadgeChip({ label }: { label: BestAtBadge }) {
-  return (
-    <span
-      className={cn(
-        'inline-flex items-center whitespace-nowrap bg-accent px-2 py-[3px]',
-        'font-mono text-[9px] font-semibold uppercase tracking-[0.08em] text-on-accent',
-      )}
-    >
-      {label}
-    </span>
   );
 }

--- a/apps/benchmark/app/components/leaderboard/Leaderboard.tsx
+++ b/apps/benchmark/app/components/leaderboard/Leaderboard.tsx
@@ -1,4 +1,5 @@
 import { BenchmarkTable } from '../BenchmarkTable';
+import { LeaderboardMobileCard } from './LeaderboardMobileCard';
 import { LeaderboardRow } from './LeaderboardRow';
 import { LEADERBOARD_COLUMNS } from './constants';
 import type { ProviderMetrics } from '~/lib/types/historyMetrics';
@@ -22,14 +23,26 @@ export function Leaderboard({ metrics }: LeaderboardProps) {
       role='region'
       aria-label='provider leaderboard'
     >
-      <BenchmarkTable
-        columns={LEADERBOARD_COLUMNS}
-        rows={sorted}
-        getRowKey={(row) => row.providerId}
-        renderRow={(row, index) => (
-          <LeaderboardRow metrics={row} rank={index + 1} isWinner={row.providerId === winnerId} />
-        )}
-      />
+      <div className='hidden md:block'>
+        <BenchmarkTable
+          columns={LEADERBOARD_COLUMNS}
+          rows={sorted}
+          getRowKey={(row) => row.providerId}
+          renderRow={(row, index) => (
+            <LeaderboardRow metrics={row} rank={index + 1} isWinner={row.providerId === winnerId} />
+          )}
+        />
+      </div>
+      <div className='md:hidden'>
+        {sorted.map((row, index) => (
+          <LeaderboardMobileCard
+            key={row.providerId}
+            metrics={row}
+            rank={index + 1}
+            isWinner={row.providerId === winnerId}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/benchmark/app/components/leaderboard/LeaderboardMobileCard.tsx
+++ b/apps/benchmark/app/components/leaderboard/LeaderboardMobileCard.tsx
@@ -62,7 +62,7 @@ export function LeaderboardMobileCard({ metrics, rank, isWinner }: LeaderboardMo
           tooltip='Worst-case fill time. Only 1 in 100 fills is slower than this.'
         />
         <StatCell
-          label='SIZE'
+          label='MED SIZE'
           value={formatSize(metrics.medianSizeUsd)}
           tooltip='Median intent size in USD: the typical amount moved per fill.'
         />

--- a/apps/benchmark/app/components/leaderboard/LeaderboardMobileCard.tsx
+++ b/apps/benchmark/app/components/leaderboard/LeaderboardMobileCard.tsx
@@ -51,10 +51,27 @@ export function LeaderboardMobileCard({ metrics, rank, isWinner }: LeaderboardMo
       {sublabel ? <span className='font-mono text-[10px] tracking-[0.02em] text-text-muted'>{sublabel}</span> : null}
       <div className='flex items-start justify-between gap-2'>
         <StatCell label='SUCCESS' value={formatSuccessRate(metrics.successRate)} />
-        <StatCell label='P50' value={formatFillSeconds(metrics.p50FillSeconds)} />
-        <StatCell label='P99' value={formatFillSeconds(metrics.p99FillSeconds)} />
-        <StatCell label='SIZE' value={formatSize(metrics.medianSizeUsd)} />
-        <StatCell label='FEE' value={formatFeePercent(metrics.feePercent)} align='end' />
+        <StatCell
+          label='P50'
+          value={formatFillSeconds(metrics.p50FillSeconds)}
+          tooltip='Median fill time. Half of fills finish faster than this, half slower.'
+        />
+        <StatCell
+          label='P99'
+          value={formatFillSeconds(metrics.p99FillSeconds)}
+          tooltip='Worst-case fill time. Only 1 in 100 fills is slower than this.'
+        />
+        <StatCell
+          label='SIZE'
+          value={formatSize(metrics.medianSizeUsd)}
+          tooltip='Median intent size in USD: the typical amount moved per fill.'
+        />
+        <StatCell
+          label='FEE'
+          value={formatFeePercent(metrics.feePercent)}
+          align='end'
+          tooltip='Typical fee as a % of the amount moved.'
+        />
       </div>
     </article>
   );

--- a/apps/benchmark/app/components/leaderboard/LeaderboardMobileCard.tsx
+++ b/apps/benchmark/app/components/leaderboard/LeaderboardMobileCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { NoFeedChip } from '../mobile/NoFeedChip';
 import { ProviderChip } from '../mobile/ProviderChip';
 import { StatCell } from '../mobile/StatCell';
@@ -22,7 +23,7 @@ interface LeaderboardMobileCardProps {
 // Mobile leaderboard card: provider header with rank on the right, a sample-size
 // subline, then a stat strip. A no-feed provider (Bungee) is dimmed and swaps
 // the rank for a NO FEED chip with em-dash stats.
-export function LeaderboardMobileCard({ metrics, rank, isWinner }: LeaderboardMobileCardProps): React.ReactNode {
+export function LeaderboardMobileCard({ metrics, rank, isWinner }: LeaderboardMobileCardProps): ReactNode {
   const provider = PROVIDERS[metrics.providerId];
   const isPlaceholder = !provider.hasGlobalFeed;
   const sublabel = buildSublabel(isPlaceholder, metrics);

--- a/apps/benchmark/app/components/leaderboard/LeaderboardMobileCard.tsx
+++ b/apps/benchmark/app/components/leaderboard/LeaderboardMobileCard.tsx
@@ -1,0 +1,72 @@
+import { NoFeedChip } from '../mobile/NoFeedChip';
+import { ProviderChip } from '../mobile/ProviderChip';
+import { StatCell } from '../mobile/StatCell';
+import {
+  formatFeePercent,
+  formatFillCount,
+  formatFillSeconds,
+  formatSampleWindow,
+  formatSize,
+  formatSuccessRate,
+} from './formatters';
+import type { ProviderMetrics } from '~/lib/types/historyMetrics';
+import { cn } from '~/lib/cn';
+import { PROVIDERS } from '~/lib/providers';
+
+interface LeaderboardMobileCardProps {
+  metrics: ProviderMetrics;
+  rank: number;
+  isWinner: boolean;
+}
+
+// Mobile leaderboard card: provider header with rank on the right, a sample-size
+// subline, then a stat strip. A no-feed provider (Bungee) is dimmed and swaps
+// the rank for a NO FEED chip with em-dash stats.
+export function LeaderboardMobileCard({ metrics, rank, isWinner }: LeaderboardMobileCardProps) {
+  const provider = PROVIDERS[metrics.providerId];
+  const isPlaceholder = !provider.hasGlobalFeed;
+  const sublabel = buildSublabel(isPlaceholder, metrics);
+
+  return (
+    <article
+      className={cn(
+        'flex flex-col gap-3 border-b border-border-subtle p-4 last:border-b-0',
+        isWinner && 'bg-accent-soft',
+        isPlaceholder && 'opacity-55',
+      )}
+    >
+      <div className='flex items-center justify-between gap-3'>
+        <ProviderChip provider={provider} />
+        {isPlaceholder ? (
+          <NoFeedChip />
+        ) : (
+          <div className='flex items-center gap-1.5 font-mono text-[11px] tabular-nums'>
+            {isWinner ? (
+              <span className={cn('inline-block size-[5px] rounded-full', provider.colorClass)} aria-hidden='true' />
+            ) : null}
+            <span className={cn('font-medium', isWinner ? 'text-accent' : 'text-text-secondary')}>#{rank}</span>
+          </div>
+        )}
+      </div>
+      {sublabel ? <span className='font-mono text-[10px] tracking-[0.02em] text-text-muted'>{sublabel}</span> : null}
+      <div className='flex items-start justify-between gap-2'>
+        <StatCell label='SUCCESS' value={formatSuccessRate(metrics.successRate)} />
+        <StatCell label='P50' value={formatFillSeconds(metrics.p50FillSeconds)} />
+        <StatCell label='P99' value={formatFillSeconds(metrics.p99FillSeconds)} />
+        <StatCell label='SIZE' value={formatSize(metrics.medianSizeUsd)} />
+        <StatCell label='FEE' value={formatFeePercent(metrics.feePercent)} align='end' />
+      </div>
+    </article>
+  );
+}
+
+function buildSublabel(isPlaceholder: boolean, metrics: ProviderMetrics): string | null {
+  // No public feed (Bungee): say why, not a fill count.
+  if (isPlaceholder) return PROVIDERS[metrics.providerId].noFeedReason?.toLowerCase() ?? 'no global feed';
+  // Has a feed but returned nothing usable (failed or empty window): no sublabel.
+  if (metrics.fillCount === null) return null;
+  const fills = `${formatFillCount(metrics.fillCount)} fills`;
+  // A single-fill sample has no span to show.
+  if (metrics.sampleWindowSeconds === null) return fills;
+  return `${fills} · ${formatSampleWindow(metrics.sampleWindowSeconds)}`;
+}

--- a/apps/benchmark/app/components/leaderboard/LeaderboardMobileCard.tsx
+++ b/apps/benchmark/app/components/leaderboard/LeaderboardMobileCard.tsx
@@ -22,7 +22,7 @@ interface LeaderboardMobileCardProps {
 // Mobile leaderboard card: provider header with rank on the right, a sample-size
 // subline, then a stat strip. A no-feed provider (Bungee) is dimmed and swaps
 // the rank for a NO FEED chip with em-dash stats.
-export function LeaderboardMobileCard({ metrics, rank, isWinner }: LeaderboardMobileCardProps) {
+export function LeaderboardMobileCard({ metrics, rank, isWinner }: LeaderboardMobileCardProps): React.ReactNode {
   const provider = PROVIDERS[metrics.providerId];
   const isPlaceholder = !provider.hasGlobalFeed;
   const sublabel = buildSublabel(isPlaceholder, metrics);

--- a/apps/benchmark/app/components/mobile/NoFeedChip.tsx
+++ b/apps/benchmark/app/components/mobile/NoFeedChip.tsx
@@ -1,6 +1,8 @@
+import type { ReactNode } from 'react';
+
 // Outline chip shown in place of a rank / badges for a provider with no global
 // feed (Bungee). Mirrors the dimmed "NO FEED" pill in the mobile design.
-export function NoFeedChip(): React.ReactNode {
+export function NoFeedChip(): ReactNode {
   return (
     <span className='inline-flex items-center whitespace-nowrap border border-border-subtle px-2 py-[3px] font-mono text-[8px] font-medium uppercase tracking-[0.05em] text-text-muted'>
       no feed

--- a/apps/benchmark/app/components/mobile/NoFeedChip.tsx
+++ b/apps/benchmark/app/components/mobile/NoFeedChip.tsx
@@ -1,0 +1,9 @@
+// Outline chip shown in place of a rank / badges for a provider with no global
+// feed (Bungee). Mirrors the dimmed "NO FEED" pill in the mobile design.
+export function NoFeedChip() {
+  return (
+    <span className='inline-flex items-center whitespace-nowrap border border-border-subtle px-2 py-[3px] font-mono text-[8px] font-medium uppercase tracking-[0.05em] text-text-muted'>
+      no feed
+    </span>
+  );
+}

--- a/apps/benchmark/app/components/mobile/NoFeedChip.tsx
+++ b/apps/benchmark/app/components/mobile/NoFeedChip.tsx
@@ -1,6 +1,6 @@
 // Outline chip shown in place of a rank / badges for a provider with no global
 // feed (Bungee). Mirrors the dimmed "NO FEED" pill in the mobile design.
-export function NoFeedChip() {
+export function NoFeedChip(): React.ReactNode {
   return (
     <span className='inline-flex items-center whitespace-nowrap border border-border-subtle px-2 py-[3px] font-mono text-[8px] font-medium uppercase tracking-[0.05em] text-text-muted'>
       no feed

--- a/apps/benchmark/app/components/mobile/ProviderChip.tsx
+++ b/apps/benchmark/app/components/mobile/ProviderChip.tsx
@@ -1,0 +1,41 @@
+import { cn } from '~/lib/cn';
+import { ProviderId, type ProviderMeta } from '~/lib/providers';
+
+// Two-letter initials shown inside the colored square. Derived from a small map
+// keyed by provider id so LI.FI reads "LI" rather than the first two letters of
+// its display name.
+const PROVIDER_INITIALS: Record<ProviderId, string> = {
+  [ProviderId.Across]: 'AX',
+  [ProviderId.Relay]: 'RL',
+  [ProviderId.Lifi]: 'LI',
+  [ProviderId.Bungee]: 'BG',
+};
+
+interface ProviderChipProps {
+  provider: ProviderMeta;
+  className?: string;
+}
+
+// Shared mobile provider identity: a colored rounded square holding the
+// provider's two-letter initials, followed by its display name. Used across all
+// three mobile card sections so they read as one system. The colored square
+// (not the icon) matches the desktop "Bench / Mobile" design source.
+export function ProviderChip({ provider, className }: ProviderChipProps) {
+  return (
+    <div className={cn('flex items-center gap-2.5', className)}>
+      <span
+        className={cn(
+          'flex size-5 shrink-0 items-center justify-center rounded-[4px]',
+          'font-mono text-[8px] font-semibold leading-none text-on-accent',
+          provider.colorClass,
+        )}
+        aria-hidden='true'
+      >
+        {PROVIDER_INITIALS[provider.id]}
+      </span>
+      <span className='truncate font-sans text-sm font-medium tracking-[-0.0125em] text-text-primary'>
+        {provider.displayName}
+      </span>
+    </div>
+  );
+}

--- a/apps/benchmark/app/components/mobile/ProviderChip.tsx
+++ b/apps/benchmark/app/components/mobile/ProviderChip.tsx
@@ -1,38 +1,19 @@
+import { Icon } from '../Icon';
+import type { ProviderMeta } from '~/lib/providers';
 import { cn } from '~/lib/cn';
-import { ProviderId, type ProviderMeta } from '~/lib/providers';
-
-// Two-letter initials shown inside the colored square. Derived from a small map
-// keyed by provider id so LI.FI reads "LI" rather than the first two letters of
-// its display name.
-const PROVIDER_INITIALS: Record<ProviderId, string> = {
-  [ProviderId.Across]: 'AX',
-  [ProviderId.Relay]: 'RL',
-  [ProviderId.Lifi]: 'LI',
-  [ProviderId.Bungee]: 'BG',
-};
 
 interface ProviderChipProps {
   provider: ProviderMeta;
   className?: string;
 }
 
-// Shared mobile provider identity: a colored rounded square holding the
-// provider's two-letter initials, followed by its display name. Used across all
-// three mobile card sections so they read as one system. The colored square
-// (not the icon) matches the desktop "Bench / Mobile" design source.
+// Shared mobile provider identity: the provider's icon followed by its display
+// name. Used across all three mobile card sections so they read as one system,
+// and matches the icon the desktop tables use.
 export function ProviderChip({ provider, className }: ProviderChipProps) {
   return (
     <div className={cn('flex items-center gap-2.5', className)}>
-      <span
-        className={cn(
-          'flex size-5 shrink-0 items-center justify-center rounded-[4px]',
-          'font-mono text-[8px] font-semibold leading-none text-on-accent',
-          provider.colorClass,
-        )}
-        aria-hidden='true'
-      >
-        {PROVIDER_INITIALS[provider.id]}
-      </span>
+      <Icon src={provider.iconUrl} alt='' size='md' />
       <span className='truncate font-sans text-sm font-medium tracking-[-0.0125em] text-text-primary'>
         {provider.displayName}
       </span>

--- a/apps/benchmark/app/components/mobile/ProviderChip.tsx
+++ b/apps/benchmark/app/components/mobile/ProviderChip.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { Icon } from '../Icon';
 import type { ProviderMeta } from '~/lib/providers';
 import { cn } from '~/lib/cn';
@@ -10,7 +11,7 @@ interface ProviderChipProps {
 // Shared mobile provider identity: the provider's icon followed by its display
 // name. Used across all three mobile card sections so they read as one system,
 // and matches the icon the desktop tables use.
-export function ProviderChip({ provider, className }: ProviderChipProps): React.ReactNode {
+export function ProviderChip({ provider, className }: ProviderChipProps): ReactNode {
   return (
     <div className={cn('flex items-center gap-2.5', className)}>
       <Icon src={provider.iconUrl} alt='' size='md' />

--- a/apps/benchmark/app/components/mobile/ProviderChip.tsx
+++ b/apps/benchmark/app/components/mobile/ProviderChip.tsx
@@ -10,7 +10,7 @@ interface ProviderChipProps {
 // Shared mobile provider identity: the provider's icon followed by its display
 // name. Used across all three mobile card sections so they read as one system,
 // and matches the icon the desktop tables use.
-export function ProviderChip({ provider, className }: ProviderChipProps) {
+export function ProviderChip({ provider, className }: ProviderChipProps): React.ReactNode {
   return (
     <div className={cn('flex items-center gap-2.5', className)}>
       <Icon src={provider.iconUrl} alt='' size='md' />

--- a/apps/benchmark/app/components/mobile/StatCell.tsx
+++ b/apps/benchmark/app/components/mobile/StatCell.tsx
@@ -26,7 +26,7 @@ export function StatCell({ label, value, mono = true, align = 'start', tooltip, 
   return (
     <div className={cn('flex flex-col gap-[3px]', align === 'end' && 'items-end', className)}>
       {tooltip ? (
-        <InfoTooltip label={label} text={tooltip} side={align === 'end' ? 'right' : 'left'} className={LABEL_BASE} />
+        <InfoTooltip label={label} text={tooltip} className={LABEL_BASE} />
       ) : (
         <span className={LABEL_BASE}>{label}</span>
       )}

--- a/apps/benchmark/app/components/mobile/StatCell.tsx
+++ b/apps/benchmark/app/components/mobile/StatCell.tsx
@@ -1,0 +1,26 @@
+import { cn } from '~/lib/cn';
+
+interface StatCellProps {
+  label: string;
+  value: string;
+  // $/% values read better in mono; everything else uses the sans value font.
+  // Defaults to mono since most stat values are numeric.
+  mono?: boolean;
+  // Right-aligns the pair, used for the trailing stat in a justify-between row.
+  align?: 'start' | 'end';
+  className?: string;
+}
+
+const VALUE_BASE = 'text-[13px] font-medium tracking-[-0.0125em] text-text-primary';
+
+// Shared mobile stat: a mono uppercase micro-label stacked over its value.
+// Dropped into a justify-between row to form the stat strip on the leaderboard
+// and head-to-head cards.
+export function StatCell({ label, value, mono = true, align = 'start', className }: StatCellProps) {
+  return (
+    <div className={cn('flex flex-col gap-[3px]', align === 'end' && 'items-end', className)}>
+      <span className='font-mono text-[9px] uppercase leading-none tracking-[0.04em] text-text-muted'>{label}</span>
+      <span className={cn(VALUE_BASE, mono ? 'font-mono tabular-nums' : 'font-sans')}>{value}</span>
+    </div>
+  );
+}

--- a/apps/benchmark/app/components/mobile/StatCell.tsx
+++ b/apps/benchmark/app/components/mobile/StatCell.tsx
@@ -21,7 +21,14 @@ const LABEL_BASE = 'font-mono text-[9px] uppercase leading-none tracking-[0.04em
 // Shared mobile stat: a mono uppercase micro-label stacked over its value.
 // Dropped into a justify-between row to form the stat strip on the leaderboard
 // and head-to-head cards.
-export function StatCell({ label, value, mono = true, align = 'start', tooltip, className }: StatCellProps) {
+export function StatCell({
+  label,
+  value,
+  mono = true,
+  align = 'start',
+  tooltip,
+  className,
+}: StatCellProps): React.ReactNode {
   return (
     <div className={cn('flex flex-col gap-[3px]', align === 'end' && 'items-end', className)}>
       {tooltip ? (

--- a/apps/benchmark/app/components/mobile/StatCell.tsx
+++ b/apps/benchmark/app/components/mobile/StatCell.tsx
@@ -1,3 +1,4 @@
+import { InfoTooltip } from '../InfoTooltip';
 import { cn } from '~/lib/cn';
 
 interface StatCellProps {
@@ -8,18 +9,26 @@ interface StatCellProps {
   mono?: boolean;
   // Right-aligns the pair, used for the trailing stat in a justify-between row.
   align?: 'start' | 'end';
+  // Plain-language explanation. When set, the label gets the info affordance and
+  // reveals the text on tap/focus, preserving the desktop column tooltips.
+  tooltip?: string;
   className?: string;
 }
 
 const VALUE_BASE = 'text-[13px] font-medium tracking-[-0.0125em] text-text-primary';
+const LABEL_BASE = 'font-mono text-[9px] uppercase leading-none tracking-[0.04em] text-text-muted';
 
 // Shared mobile stat: a mono uppercase micro-label stacked over its value.
 // Dropped into a justify-between row to form the stat strip on the leaderboard
 // and head-to-head cards.
-export function StatCell({ label, value, mono = true, align = 'start', className }: StatCellProps) {
+export function StatCell({ label, value, mono = true, align = 'start', tooltip, className }: StatCellProps) {
   return (
     <div className={cn('flex flex-col gap-[3px]', align === 'end' && 'items-end', className)}>
-      <span className='font-mono text-[9px] uppercase leading-none tracking-[0.04em] text-text-muted'>{label}</span>
+      {tooltip ? (
+        <InfoTooltip label={label} text={tooltip} side={align === 'end' ? 'right' : 'left'} className={LABEL_BASE} />
+      ) : (
+        <span className={LABEL_BASE}>{label}</span>
+      )}
       <span className={cn(VALUE_BASE, mono ? 'font-mono tabular-nums' : 'font-sans')}>{value}</span>
     </div>
   );

--- a/apps/benchmark/app/components/mobile/StatCell.tsx
+++ b/apps/benchmark/app/components/mobile/StatCell.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { InfoTooltip } from '../InfoTooltip';
 import { cn } from '~/lib/cn';
 
@@ -21,14 +22,7 @@ const LABEL_BASE = 'font-mono text-[9px] uppercase leading-none tracking-[0.04em
 // Shared mobile stat: a mono uppercase micro-label stacked over its value.
 // Dropped into a justify-between row to form the stat strip on the leaderboard
 // and head-to-head cards.
-export function StatCell({
-  label,
-  value,
-  mono = true,
-  align = 'start',
-  tooltip,
-  className,
-}: StatCellProps): React.ReactNode {
+export function StatCell({ label, value, mono = true, align = 'start', tooltip, className }: StatCellProps): ReactNode {
   return (
     <div className={cn('flex flex-col gap-[3px]', align === 'end' && 'items-end', className)}>
       {tooltip ? (

--- a/apps/benchmark/app/components/race-table/RaceMobileRow.tsx
+++ b/apps/benchmark/app/components/race-table/RaceMobileRow.tsx
@@ -31,7 +31,7 @@ export function RaceMobileRow({
   isFirst,
   assetSymbol,
   reduceMotion,
-}: RaceMobileRowProps) {
+}: RaceMobileRowProps): React.ReactNode {
   const isQuerying = row.status === 'querying';
   const isErrored = row.status === 'errored';
   const isSettled = row.status === 'settled';

--- a/apps/benchmark/app/components/race-table/RaceMobileRow.tsx
+++ b/apps/benchmark/app/components/race-table/RaceMobileRow.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Skeleton } from '../Skeleton';
+import { ProviderChip } from '../mobile/ProviderChip';
+import { RaceStatusPill } from './RaceStatusPill';
+import type { RaceRow } from './types';
+import { AssetSymbol } from '~/lib/assets';
+import { cn } from '~/lib/cn';
+import { formatEta, formatLatency, formatTokenAmount } from '~/lib/formatters';
+
+interface RaceMobileRowProps {
+  row: RaceRow;
+  rank: number | null;
+  outputDecimals: number;
+  isWinner: boolean;
+  isFirst: boolean;
+  assetSymbol: AssetSymbol;
+  reduceMotion: boolean;
+}
+
+// Mobile race row: rank + provider on the left, output amount + status pill on
+// the right, with a mono latency/eta subline under the provider. Compact row,
+// not a stat grid. Winner row is tinted; querying rows mirror the desktop
+// skeleton treatment.
+export function RaceMobileRow({
+  row,
+  rank,
+  outputDecimals,
+  isWinner,
+  isFirst,
+  assetSymbol,
+  reduceMotion,
+}: RaceMobileRowProps) {
+  const isQuerying = row.status === 'querying';
+  const isErrored = row.status === 'errored';
+  const isSettled = row.status === 'settled';
+  const outputToken = row.quote?.outputAmount ? formatTokenAmount(row.quote.outputAmount, outputDecimals) : '—';
+  const subline = buildSubline(row);
+
+  return (
+    <motion.div
+      layout={!reduceMotion}
+      initial={reduceMotion ? false : { opacity: 0, y: 6 }}
+      animate={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+      transition={{ duration: 0.2 }}
+      className={cn(
+        'flex items-center gap-3 border-b border-border-subtle px-4 py-3 last:border-b-0',
+        isWinner && 'bg-accent-soft',
+        isErrored && 'text-text-muted',
+      )}
+    >
+      <span
+        className={cn(
+          'w-3 shrink-0 font-mono text-mark tabular-nums',
+          isWinner ? 'font-medium text-accent' : 'text-text-secondary',
+        )}
+      >
+        {rank ?? '—'}
+      </span>
+      <div className='flex min-w-0 flex-1 flex-col gap-1'>
+        <ProviderChip provider={row.provider} />
+        {subline ? <span className='pl-[30px] font-mono text-[10px] text-text-muted'>{subline}</span> : null}
+      </div>
+      <div className='flex shrink-0 flex-col items-end gap-1.5'>
+        {isQuerying ? (
+          <Skeleton wide reduceMotion={reduceMotion} />
+        ) : isSettled ? (
+          <span className='flex items-baseline gap-1 font-mono tabular-nums'>
+            <span className='text-mark font-medium text-text-primary'>{outputToken}</span>
+            <span className='text-caption text-text-muted'>{assetSymbol}</span>
+          </span>
+        ) : (
+          <span className='font-mono text-label text-text-muted'>—</span>
+        )}
+        <RaceStatusPill
+          status={row.status}
+          isWinner={isWinner}
+          isFirst={isFirst}
+          errorMessage={row.errorMessage}
+          reduceMotion={reduceMotion}
+        />
+      </div>
+    </motion.div>
+  );
+}
+
+// "412ms · 3s" from latency and eta. Only shown for a settled row that carries a
+// quote; querying / errored rows lean on the skeleton or status pill instead.
+function buildSubline(row: RaceRow): string | null {
+  if (row.status !== 'settled' || !row.quote) return null;
+  const latency = row.quote.latencyMs !== undefined ? formatLatency(row.quote.latencyMs) : null;
+  const eta = row.quote.eta !== undefined ? formatEta(Math.round(row.quote.eta)) : null;
+  return [latency, eta].filter(Boolean).join(' · ') || null;
+}

--- a/apps/benchmark/app/components/race-table/RaceMobileRow.tsx
+++ b/apps/benchmark/app/components/race-table/RaceMobileRow.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { motion } from 'framer-motion';
 import { Skeleton } from '../Skeleton';
 import { ProviderChip } from '../mobile/ProviderChip';
@@ -31,7 +32,7 @@ export function RaceMobileRow({
   isFirst,
   assetSymbol,
   reduceMotion,
-}: RaceMobileRowProps): React.ReactNode {
+}: RaceMobileRowProps): ReactNode {
   const isQuerying = row.status === 'querying';
   const isErrored = row.status === 'errored';
   const isSettled = row.status === 'settled';

--- a/apps/benchmark/app/components/race-table/RaceStatusPill.tsx
+++ b/apps/benchmark/app/components/race-table/RaceStatusPill.tsx
@@ -1,0 +1,45 @@
+import { Pill } from '../Pill';
+import type { RowStatus } from './types';
+
+interface RaceStatusPillProps {
+  status: RowStatus;
+  isWinner: boolean;
+  isFirst: boolean;
+  errorMessage?: string;
+  reduceMotion: boolean;
+}
+
+// Status pill for a race row, shared by the desktop table and the mobile card so
+// both render the same WINNER / FIRST / NO ROUTE / querying treatment. Returns
+// null when there is nothing to show (a settled non-winner that wasn't first).
+export function RaceStatusPill({ status, isWinner, isFirst, errorMessage, reduceMotion }: RaceStatusPillProps) {
+  let pills: React.ReactNode = null;
+
+  if (status === 'errored') {
+    pills = (
+      <Pill tone='error' title={errorMessage}>
+        no route
+      </Pill>
+    );
+  } else if (status === 'querying') {
+    pills = (
+      <Pill tone='muted' className={reduceMotion ? undefined : 'animate-pulse'}>
+        querying
+      </Pill>
+    );
+  } else if (status === 'settled' && (isWinner || isFirst)) {
+    pills = (
+      <>
+        {isWinner ? (
+          <Pill tone='accent' icon='★'>
+            winner
+          </Pill>
+        ) : null}
+        {isFirst ? <Pill tone='outline'>first</Pill> : null}
+      </>
+    );
+  }
+
+  if (!pills) return null;
+  return <div className='flex flex-wrap items-center justify-end gap-1.5'>{pills}</div>;
+}

--- a/apps/benchmark/app/components/race-table/RaceStatusPill.tsx
+++ b/apps/benchmark/app/components/race-table/RaceStatusPill.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { Pill } from '../Pill';
 import type { RowStatus } from './types';
 
@@ -18,8 +19,8 @@ export function RaceStatusPill({
   isFirst,
   errorMessage,
   reduceMotion,
-}: RaceStatusPillProps): React.ReactNode {
-  let pills: React.ReactNode = null;
+}: RaceStatusPillProps): ReactNode {
+  let pills: ReactNode = null;
 
   if (status === 'errored') {
     pills = (

--- a/apps/benchmark/app/components/race-table/RaceStatusPill.tsx
+++ b/apps/benchmark/app/components/race-table/RaceStatusPill.tsx
@@ -12,7 +12,13 @@ interface RaceStatusPillProps {
 // Status pill for a race row, shared by the desktop table and the mobile card so
 // both render the same WINNER / FIRST / NO ROUTE / querying treatment. Returns
 // null when there is nothing to show (a settled non-winner that wasn't first).
-export function RaceStatusPill({ status, isWinner, isFirst, errorMessage, reduceMotion }: RaceStatusPillProps) {
+export function RaceStatusPill({
+  status,
+  isWinner,
+  isFirst,
+  errorMessage,
+  reduceMotion,
+}: RaceStatusPillProps): React.ReactNode {
   let pills: React.ReactNode = null;
 
   if (status === 'errored') {

--- a/apps/benchmark/app/components/race-table/RaceTable.tsx
+++ b/apps/benchmark/app/components/race-table/RaceTable.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useReducedMotion } from 'framer-motion';
 import { BenchmarkTable } from '../BenchmarkTable';
+import { RaceMobileRow } from './RaceMobileRow';
 import { RaceTableRow } from './RaceTableRow';
 import { RACE_TABLE_COLUMNS } from './constants';
 import { findBestProvider, orderRaceRows } from './raceRows';
@@ -66,23 +67,39 @@ export function RaceTable({ initialRows, initialChains }: RaceTableProps) {
 
   return (
     <section aria-label='live quote race results' className='overflow-hidden border border-border bg-surface'>
-      <BenchmarkTable
-        columns={RACE_TABLE_COLUMNS}
-        rows={rows}
-        getRowKey={(row) => row.provider.id}
-        renderRow={(row, index) => (
-          <RaceTableRow
+      <div className='hidden md:block'>
+        <BenchmarkTable
+          columns={RACE_TABLE_COLUMNS}
+          rows={rows}
+          getRowKey={(row) => row.provider.id}
+          renderRow={(row, index) => (
+            <RaceTableRow
+              row={row}
+              rank={row.status === 'settled' ? index + 1 : null}
+              outputDecimals={outputDecimals}
+              isWinner={row.provider.id === winnerProviderId}
+              isFirst={row.provider.id === firstProviderId}
+              maxLatencyMs={maxLatencyMs}
+              assetSymbol={request.assetSymbol}
+              reduceMotion={Boolean(reduceMotion)}
+            />
+          )}
+        />
+      </div>
+      <div className='md:hidden'>
+        {rows.map((row, index) => (
+          <RaceMobileRow
+            key={row.provider.id}
             row={row}
             rank={row.status === 'settled' ? index + 1 : null}
             outputDecimals={outputDecimals}
             isWinner={row.provider.id === winnerProviderId}
             isFirst={row.provider.id === firstProviderId}
-            maxLatencyMs={maxLatencyMs}
             assetSymbol={request.assetSymbol}
             reduceMotion={Boolean(reduceMotion)}
           />
-        )}
-      />
+        ))}
+      </div>
     </section>
   );
 }

--- a/apps/benchmark/app/components/race-table/RaceTableRow.tsx
+++ b/apps/benchmark/app/components/race-table/RaceTableRow.tsx
@@ -3,10 +3,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import { Icon } from '../Icon';
-import { Pill } from '../Pill';
 import { Skeleton } from '../Skeleton';
+import { RaceStatusPill } from './RaceStatusPill';
 import { parseOptionalNumber } from './raceRows';
-import type { RaceRow, RowStatus } from './types';
+import type { RaceRow } from './types';
 import { AssetSymbol } from '~/lib/assets';
 import { cn } from '~/lib/cn';
 import { formatEta, formatLatency, formatTokenAmount, formatUsd } from '~/lib/formatters';
@@ -37,7 +37,6 @@ export function RaceTableRow({
   const isSettled = row.status === 'settled';
   const outputUsd = parseOptionalNumber(row.quote?.outputAmountUsd);
   const outputToken = row.quote?.outputAmount ? formatTokenAmount(row.quote.outputAmount, outputDecimals) : '—';
-  const mobileSubtitle = buildMobileSubtitle(row);
 
   return (
     <motion.tr
@@ -58,12 +57,12 @@ export function RaceTableRow({
       }
       transition={{ duration: 0.2 }}
       className={cn(
-        'h-20 border-b border-border-subtle align-middle transition-colors last:border-b-0 md:h-[72px]',
+        'h-[72px] border-b border-border-subtle align-middle transition-colors last:border-b-0',
         isWinner && 'bg-accent-soft',
         isErrored && 'text-text-muted',
       )}
     >
-      <td className='w-10 px-3 py-3 md:w-12 md:px-4 md:py-4'>
+      <td className='w-12 px-4 py-4'>
         <div className='flex items-center gap-2 font-mono text-label'>
           {isWinner ? (
             <span className={cn('inline-block size-1.5 rounded-full', row.provider.colorClass)} aria-hidden='true' />
@@ -71,20 +70,15 @@ export function RaceTableRow({
           <span className={cn('tabular-nums', isWinner ? 'text-accent' : 'text-text-secondary')}>{rank ?? '—'}</span>
         </div>
       </td>
-      <td className='px-3 py-3 md:px-4 md:py-4'>
-        <div className='flex items-center gap-2.5 md:gap-3'>
+      <td className='px-4 py-4'>
+        <div className='flex items-center gap-3'>
           <Icon src={row.provider.iconUrl} alt='' size='md' />
-          <div className='flex flex-col gap-0.5'>
-            <span className='font-sans text-mark font-medium tracking-[-0.0125em] text-text-primary md:text-base'>
-              {row.provider.displayName}
-            </span>
-            {mobileSubtitle ? (
-              <span className='font-mono text-caption text-text-muted md:hidden'>{mobileSubtitle}</span>
-            ) : null}
-          </div>
+          <span className='font-sans text-base font-medium tracking-[-0.0125em] text-text-primary'>
+            {row.provider.displayName}
+          </span>
         </div>
       </td>
-      <td className='hidden px-4 py-4 md:table-cell'>
+      <td className='px-4 py-4'>
         {isQuerying ? (
           <Skeleton reduceMotion={reduceMotion} />
         ) : isSettled && row.quote?.latencyMs !== undefined ? (
@@ -102,57 +96,32 @@ export function RaceTableRow({
           <span className='font-mono text-label text-text-muted'>—</span>
         )}
       </td>
-      <td className='px-3 py-3 md:px-4 md:py-4'>
+      <td className='px-4 py-4'>
         {isQuerying ? (
           <div className='flex justify-end'>
             <Skeleton wide reduceMotion={reduceMotion} />
           </div>
         ) : isSettled ? (
           <div className='flex flex-col items-end gap-1'>
-            <div className='hidden items-baseline gap-1.5 md:flex'>
+            <div className='flex items-baseline gap-1.5'>
               <span className='font-mono text-mark font-medium text-text-primary tabular-nums'>{outputToken}</span>
               <span className='font-mono text-caption text-text-muted'>{assetSymbol}</span>
             </div>
             {outputUsd > 0 ? (
-              <span className='font-mono text-mark font-medium text-text-primary tabular-nums md:text-caption md:font-normal md:text-text-muted'>
+              <span className='font-mono text-caption text-text-muted tabular-nums'>
                 <AnimatedUsd
                   value={outputUsd}
                   fallback={formatUsd(row.quote?.outputAmountUsd)}
                   reduceMotion={reduceMotion}
                 />
               </span>
-            ) : (
-              <div className='flex items-baseline gap-1.5 md:hidden'>
-                <span className='font-mono text-mark font-medium text-text-primary tabular-nums'>{outputToken}</span>
-                <span className='font-mono text-caption text-text-muted'>{assetSymbol}</span>
-              </div>
-            )}
-            <div className='md:hidden'>
-              <StatusPill
-                status={row.status}
-                isWinner={isWinner}
-                isFirst={isFirst}
-                errorMessage={row.errorMessage}
-                reduceMotion={reduceMotion}
-              />
-            </div>
+            ) : null}
           </div>
         ) : (
-          <div className='flex flex-col items-end gap-1'>
-            <span className='font-mono text-label text-text-muted'>—</span>
-            <div className='md:hidden'>
-              <StatusPill
-                status={row.status}
-                isWinner={isWinner}
-                isFirst={isFirst}
-                errorMessage={row.errorMessage}
-                reduceMotion={reduceMotion}
-              />
-            </div>
-          </div>
+          <span className='flex justify-end font-mono text-label text-text-muted'>—</span>
         )}
       </td>
-      <td className='hidden px-4 py-4 text-right md:table-cell'>
+      <td className='px-4 py-4 text-right'>
         {isQuerying ? (
           <Skeleton reduceMotion={reduceMotion} />
         ) : isSettled ? (
@@ -163,8 +132,8 @@ export function RaceTableRow({
           <span className='font-mono text-label text-text-muted'>—</span>
         )}
       </td>
-      <td className='hidden px-4 py-4 md:table-cell'>
-        <StatusPill
+      <td className='px-4 py-4'>
+        <RaceStatusPill
           status={row.status}
           isWinner={isWinner}
           isFirst={isFirst}
@@ -174,13 +143,6 @@ export function RaceTableRow({
       </td>
     </motion.tr>
   );
-}
-
-function buildMobileSubtitle(row: RaceRow): string | null {
-  if (row.status !== 'settled' || !row.quote) return null;
-  const latency = row.quote.latencyMs !== undefined ? formatLatency(row.quote.latencyMs) : null;
-  const eta = row.quote.eta !== undefined ? formatEta(Math.round(row.quote.eta)) : null;
-  return [latency, eta].filter(Boolean).join(' · ') || null;
 }
 
 function LatencyBar({
@@ -198,46 +160,6 @@ function LatencyBar({
       <div className={cn('h-full', colorClass)} style={{ width: `${widthPercent}%` }} />
     </div>
   );
-}
-
-interface StatusPillProps {
-  status: RowStatus;
-  isWinner: boolean;
-  isFirst: boolean;
-  errorMessage?: string;
-  reduceMotion: boolean;
-}
-
-function StatusPill({ status, isWinner, isFirst, errorMessage, reduceMotion }: StatusPillProps) {
-  let pills: React.ReactNode = null;
-
-  if (status === 'errored') {
-    pills = (
-      <Pill tone='error' title={errorMessage}>
-        no route
-      </Pill>
-    );
-  } else if (status === 'querying') {
-    pills = (
-      <Pill tone='muted' className={reduceMotion ? undefined : 'animate-pulse'}>
-        querying
-      </Pill>
-    );
-  } else if (status === 'settled' && (isWinner || isFirst)) {
-    pills = (
-      <>
-        {isWinner ? (
-          <Pill tone='accent' icon='★'>
-            winner
-          </Pill>
-        ) : null}
-        {isFirst ? <Pill tone='outline'>first</Pill> : null}
-      </>
-    );
-  }
-
-  if (!pills) return null;
-  return <div className='flex flex-wrap items-center justify-end gap-1.5'>{pills}</div>;
 }
 
 function AnimatedLatency({ value, reduceMotion }: { value?: number; reduceMotion: boolean }) {


### PR DESCRIPTION
On mobile the benchmark tables hid most of their columns, so phone users could barely see the data. Below the `md` breakpoint each of the three sections now renders as a card stack instead of a stripped-down table. Desktop is unchanged: the existing `<table>` moves into a `hidden md:block` wrapper and a sibling `md:hidden` div renders the cards, both reading the data already present in the section component (no new fetching). This follows the Pencil "Bench / Mobile" design.

## Card types
- Race: compact row with provider chip, status pill, and the leg stats.
- Leaderboard: scorecard with SUCCESS / P50 / P99 / SIZE / FEE.
- Head-to-head: scorecard with FILLS / SUCCESS / P50 / FEE plus the BEST AT badges.

## Shared primitives
- `components/mobile/`: `ProviderChip` (colored-initials chip), `StatCell` (label-over-value pair), `NoFeedChip`.
- Two extractions that de-duplicate logic across desktop and mobile: `RaceStatusPill` (was private in `RaceTableRow`) and `BestAtBadgeChip` (was private in head-to-head constants).

All formatters and provider metadata are reused (`formatLatency/Eta/TokenAmount/Usd`, `formatSuccessRate/FillSeconds/FeePercent/Size/FillCount/SampleWindow`, `computeBestAtBadges`); no formatting logic is duplicated.

Stacked on #417 (median size) and should merge after it.

Closes EFI-1029