### PR TITLE
feat(cross-chain): add Superbridge validators

### DIFF
--- a/.changeset/superbridge-gasless-signature-validation.md
+++ b/.changeset/superbridge-gasless-signature-validation.md
@@ -1,0 +1,7 @@
+---
+"@wonderland/interop-cross-chain": minor
+---
+
+Validate Superbridge gasless signatures against the quote request
+
+Gasless Superbridge routes now cross-check the EIP-712 envelope the user is asked to sign against their quote request — chain, verifying contract, token, amount cap, spender/recipient and deadline — the same way Bungee, Relay and OIF already do. An envelope that doesn't line up, or one whose type we don't recognise, is rejected instead of handed to the wallet. User-transaction routes keep relying on the aggregator's spender allowlist, so no canonical-address registry lives in the SDK.

--- a/packages/cross-chain/src/protocols/superbridge/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/quoteResponseAdapter.ts
@@ -2,6 +2,7 @@ import type { SignatureStep, Step, TransactionStep } from "../../../core/schemas
 import type { SubmissionMode } from "../../../core/schemas/providerConfig.js";
 import type { Quote, QuoteFeeEntry, QuoteFees } from "../../../core/schemas/quote.js";
 import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
+import type { Eip712Domain, Eip712Envelope } from "../../../core/types/eip712.js";
 import type {
     SuperbridgeEvmGaslessTransaction,
     SuperbridgeFeeGroup,
@@ -14,6 +15,7 @@ import type {
 } from "../schemas.js";
 import { ProviderGetQuoteFailure } from "../../../internal.js";
 import { SuperbridgeRouteQuoteSchema, SuperbridgeTypedDataSchema } from "../schemas.js";
+import { validateSuperbridgeSignatureEnvelope } from "../validators/index.js";
 
 const MODE_BY_TX_TYPE = {
     evm: "user-transaction",
@@ -64,7 +66,7 @@ function adaptRouteQuote(
     params: QuoteRequest,
 ): Quote | null {
     const routeId = meta?.id;
-    const mainStep = buildMainStep(route, routeId);
+    const mainStep = buildMainStep(route, routeId, params);
     if (!mainStep) return null;
 
     return {
@@ -91,7 +93,11 @@ function sumWaitSeconds(steps: SuperbridgeRouteStep[] | undefined): number | und
     return totalMs > 0 ? Math.round(totalMs / 1000) : undefined;
 }
 
-function buildMainStep(route: SuperbridgeRouteQuote, routeId: string | undefined): Step | null {
+function buildMainStep(
+    route: SuperbridgeRouteQuote,
+    routeId: string | undefined,
+    params: QuoteRequest,
+): Step | null {
     const tx = route.initiatingTransaction;
     if (tx.type === "evm") {
         return {
@@ -101,16 +107,25 @@ function buildMainStep(route: SuperbridgeRouteQuote, routeId: string | undefined
             transaction: { to: tx.to, data: tx.data, value: tx.value },
         };
     }
-    return buildSignatureStep(tx, routeId);
+    return buildSignatureStep(tx, routeId, params);
 }
 
 function buildSignatureStep(
     tx: SuperbridgeEvmGaslessTransaction,
     routeId: string | undefined,
+    params: QuoteRequest,
 ): SignatureStep | null {
     const parsed = SuperbridgeTypedDataSchema.safeParse(safeJsonParse(tx.typedData));
     if (!parsed.success) return null;
     if (!routeId) return null;
+
+    const envelope: Eip712Envelope = {
+        domain: parsed.data.domain as Eip712Domain,
+        primaryType: parsed.data.primaryType,
+        types: parsed.data.types,
+        message: parsed.data.message,
+    };
+    validateSuperbridgeSignatureEnvelope(envelope, params);
 
     return {
         kind: "signature",

--- a/packages/cross-chain/src/protocols/superbridge/adapters/quoteResponseAdapter.ts
+++ b/packages/cross-chain/src/protocols/superbridge/adapters/quoteResponseAdapter.ts
@@ -129,7 +129,7 @@ function buildSignatureStep(
 
     return {
         kind: "signature",
-        chainId: Number(tx.chainId),
+        chainId: params.input.chainId,
         description: "Sign gasless authorization for Superbridge",
         signaturePayload: {
             signatureType: "eip712",
@@ -140,7 +140,7 @@ function buildSignatureStep(
         },
         metadata: {
             superbridgeTypedData: tx.typedData,
-            superbridgeChainId: tx.chainId,
+            superbridgeChainId: String(params.input.chainId),
             superbridgeRouteId: routeId,
         },
     };

--- a/packages/cross-chain/src/protocols/superbridge/validators/index.ts
+++ b/packages/cross-chain/src/protocols/superbridge/validators/index.ts
@@ -1,0 +1,1 @@
+export { validateSuperbridgeSignatureEnvelope } from "./signatureEnvelopeValidator.js";

--- a/packages/cross-chain/src/protocols/superbridge/validators/signatureEnvelopeValidator.ts
+++ b/packages/cross-chain/src/protocols/superbridge/validators/signatureEnvelopeValidator.ts
@@ -1,0 +1,162 @@
+import type { Address } from "viem";
+import { getAddress, isAddressEqual } from "viem";
+
+import type { QuoteRequest } from "../../../core/schemas/quoteRequest.js";
+import type { Eip712Envelope } from "../../../core/types/eip712.js";
+import {
+    EIP3009_PRIMARY_TYPES,
+    PERMIT2_ADDRESS,
+    PERMIT2_BATCH_PRIMARY_TYPES,
+    PERMIT2_SINGLE_PRIMARY_TYPES,
+} from "../../../core/constants/eip712.js";
+import { Eip712EnvelopeMismatch } from "../../../core/errors/Eip712EnvelopeMismatch.exception.js";
+import { readAddressField } from "../../../core/utils/eip712Readers.js";
+import { isNativeAddress } from "../../../core/utils/token.js";
+import {
+    validateEnvelopeDomain,
+    validatePrimaryType,
+} from "../../../core/validators/eip712EnvelopeValidator.js";
+import { validateEip3009Message } from "../../../core/validators/eip3009MessageValidator.js";
+import { validatePermit2Message } from "../../../core/validators/permit2MessageValidator.js";
+
+const PROVIDER_NAME = "superbridge";
+
+type Mechanism = "Permit2" | "EIP-3009";
+type RecipientField = "spender" | "to";
+
+const SUPERBRIDGE_PERMIT2_PRIMARY_TYPES: ReadonlySet<string> = new Set<string>([
+    ...PERMIT2_SINGLE_PRIMARY_TYPES,
+    ...PERMIT2_BATCH_PRIMARY_TYPES,
+]);
+
+const SUPERBRIDGE_PRIMARY_TYPES: ReadonlySet<string> = new Set<string>([
+    ...SUPERBRIDGE_PERMIT2_PRIMARY_TYPES,
+    ...EIP3009_PRIMARY_TYPES,
+]);
+
+/**
+ * Validate a Superbridge gasless EIP-712 envelope against the user-supplied quote request.
+ *
+ * Dispatches by `primaryType` to the Permit2 or EIP-3009 path and cross-checks chain,
+ * verifying contract, token, amount cap, recipient and deadline against the user intent.
+ * Any other `primaryType` is rejected so the user never signs an envelope the SDK cannot verify.
+ */
+export function validateSuperbridgeSignatureEnvelope(
+    envelope: Eip712Envelope,
+    params: QuoteRequest,
+): void {
+    validatePrimaryType(envelope, SUPERBRIDGE_PRIMARY_TYPES, PROVIDER_NAME);
+
+    const maxAmount = params.input.amount !== undefined ? BigInt(params.input.amount) : undefined;
+    const user = getAddress(params.user);
+
+    if (EIP3009_PRIMARY_TYPES.has(envelope.primaryType)) {
+        validateEip3009Envelope(envelope, params, user, maxAmount);
+        return;
+    }
+
+    validatePermit2Envelope(envelope, params, user, maxAmount);
+}
+
+function validatePermit2Envelope(
+    envelope: Eip712Envelope,
+    params: QuoteRequest,
+    user: Address,
+    maxAmount: bigint | undefined,
+): void {
+    guardAgainstNativeAsset(envelope, params, "Permit2");
+    guardPermit2DomainHasNoVersion(envelope);
+    validateEnvelopeDomain(envelope, {
+        chainId: params.input.chainId,
+        verifyingContracts: [PERMIT2_ADDRESS],
+        provider: PROVIDER_NAME,
+    });
+    const spender = readRecipientField(envelope, "spender", user);
+    validatePermit2Message(envelope, {
+        provider: PROVIDER_NAME,
+        spender,
+        inputToken: getAddress(params.input.assetAddress),
+        maxAmount,
+    });
+}
+
+function validateEip3009Envelope(
+    envelope: Eip712Envelope,
+    params: QuoteRequest,
+    user: Address,
+    maxAmount: bigint | undefined,
+): void {
+    guardAgainstNativeAsset(envelope, params, "EIP-3009");
+    validateEnvelopeDomain(envelope, {
+        chainId: params.input.chainId,
+        verifyingContracts: [getAddress(params.input.assetAddress)],
+        provider: PROVIDER_NAME,
+    });
+    guardEip3009DomainVersion(envelope);
+    const to = readRecipientField(envelope, "to", user);
+    validateEip3009Message(envelope, {
+        provider: PROVIDER_NAME,
+        user,
+        to,
+        maxValue: maxAmount,
+    });
+}
+
+function readRecipientField(
+    envelope: Eip712Envelope,
+    field: RecipientField,
+    user: Address,
+): Address {
+    const recipient = readAddressField({
+        envelope,
+        path: [field],
+        field,
+        provider: PROVIDER_NAME,
+    });
+    if (isAddressEqual(recipient, user)) {
+        throw new Eip712EnvelopeMismatch({
+            field,
+            provider: PROVIDER_NAME,
+            primaryType: envelope.primaryType,
+            received: recipient,
+            cause: "recipient must not be the user",
+        });
+    }
+    return recipient;
+}
+
+function guardAgainstNativeAsset(
+    envelope: Eip712Envelope,
+    params: QuoteRequest,
+    mechanism: Mechanism,
+): void {
+    if (!isNativeAddress(params.input.assetAddress, "eip155")) return;
+    throw new Eip712EnvelopeMismatch({
+        field: "structure",
+        provider: PROVIDER_NAME,
+        primaryType: envelope.primaryType,
+        cause: `${mechanism} envelope rejected: input asset is the native placeholder`,
+    });
+}
+
+function guardEip3009DomainVersion(envelope: Eip712Envelope): void {
+    const version = envelope.domain.version;
+    if (typeof version === "string" && version.length > 0) return;
+    throw new Eip712EnvelopeMismatch({
+        field: "domainVersion",
+        provider: PROVIDER_NAME,
+        primaryType: envelope.primaryType,
+        received: String(version),
+    });
+}
+
+function guardPermit2DomainHasNoVersion(envelope: Eip712Envelope): void {
+    if (envelope.domain.version === undefined) return;
+    throw new Eip712EnvelopeMismatch({
+        field: "domainVersion",
+        provider: PROVIDER_NAME,
+        primaryType: envelope.primaryType,
+        expected: "absent",
+        received: String(envelope.domain.version),
+    });
+}

--- a/packages/cross-chain/test/protocols/superbridge/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/quoteResponseAdapter.spec.ts
@@ -182,6 +182,31 @@ describe("adaptQuoteResponse", () => {
         expect(quotes[0]!.order.steps[0]!.kind).toBe("signature");
     });
 
+    it("derives the gasless signature chainId from the request, not the response tx", () => {
+        const tamperedTxChainId: SuperbridgeRouteResult = {
+            meta: { id: "route-gasless" },
+            result: {
+                initiatingTransaction: {
+                    type: "evm-gasless",
+                    chainId: "999",
+                    typedData: gaslessTypedData(),
+                },
+            },
+        };
+
+        const quotes = adaptQuoteResponse(
+            response([tamperedTxChainId]),
+            PROVIDER_ID,
+            request(),
+            gaslessModes,
+        );
+
+        const step = quotes[0]!.order.steps[0]!;
+        if (step.kind !== "signature") throw new Error("expected a signature step");
+        expect(step.chainId).toBe(1);
+        expect(step.metadata?.superbridgeChainId).toBe("1");
+    });
+
     it("skips a gasless route that carries invalid typed data", () => {
         const result: SuperbridgeRouteResult = {
             meta: { id: "route-gasless" },

--- a/packages/cross-chain/test/protocols/superbridge/adapters/quoteResponseAdapter.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/adapters/quoteResponseAdapter.spec.ts
@@ -6,12 +6,16 @@ import type {
     SuperbridgeRouteResult,
     SuperbridgeRoutesResponse,
 } from "../../../../src/protocols/superbridge/schemas.js";
+import { PERMIT2_ADDRESS } from "../../../../src/core/constants/eip712.js";
+import { Eip712EnvelopeMismatch } from "../../../../src/core/errors/Eip712EnvelopeMismatch.exception.js";
 import { ProviderGetQuoteFailure } from "../../../../src/core/errors/ProviderGetQuoteFailure.exception.js";
 import { adaptQuoteResponse } from "../../../../src/protocols/superbridge/adapters/quoteResponseAdapter.js";
 
 const USER = "0x1234567890abcdef1234567890abcdef12345678";
 const TO = "0x1111111111111111111111111111111111111111";
 const RECEIVE_TOKEN = "0x2222222222222222222222222222222222222222";
+const SPENDER = "0x3333333333333333333333333333333333333333";
+const FUTURE_DEADLINE = Math.floor(Date.now() / 1000) + 3600;
 const PROVIDER_ID = "superbridge";
 
 function request(): QuoteRequest {
@@ -46,19 +50,36 @@ function evmResult(): SuperbridgeRouteResult {
     };
 }
 
-function gaslessResult(): SuperbridgeRouteResult {
+function gaslessTypedData(messageOverrides?: Record<string, unknown>): string {
+    return JSON.stringify({
+        domain: { name: "Permit2", chainId: 1, verifyingContract: PERMIT2_ADDRESS },
+        types: {
+            PermitTransferFrom: [
+                { name: "permitted", type: "TokenPermissions" },
+                { name: "spender", type: "address" },
+                { name: "nonce", type: "uint256" },
+                { name: "deadline", type: "uint256" },
+            ],
+        },
+        primaryType: "PermitTransferFrom",
+        message: {
+            permitted: { token: TO, amount: "1000" },
+            spender: SPENDER,
+            nonce: "1",
+            deadline: FUTURE_DEADLINE,
+            ...messageOverrides,
+        },
+    });
+}
+
+function gaslessResult(messageOverrides?: Record<string, unknown>): SuperbridgeRouteResult {
     return {
         meta: { id: "route-gasless" },
         result: {
             initiatingTransaction: {
                 type: "evm-gasless",
                 chainId: "1",
-                typedData: JSON.stringify({
-                    domain: { chainId: 1 },
-                    types: { Order: [{ name: "a", type: "uint256" }] },
-                    primaryType: "Order",
-                    message: { a: "1" },
-                }),
+                typedData: gaslessTypedData(messageOverrides),
             },
         },
     };
@@ -184,6 +205,28 @@ describe("adaptQuoteResponse", () => {
         const quotes = adaptQuoteResponse(response([result]), PROVIDER_ID, request(), gaslessModes);
 
         expect(quotes).toHaveLength(0);
+    });
+
+    it("throws when a gasless envelope inflates the permit amount", () => {
+        expect(() =>
+            adaptQuoteResponse(
+                response([gaslessResult({ permitted: { token: TO, amount: "9999" } })]),
+                PROVIDER_ID,
+                request(),
+                gaslessModes,
+            ),
+        ).toThrow(Eip712EnvelopeMismatch);
+    });
+
+    it("throws when a gasless envelope sets the spender to the user", () => {
+        expect(() =>
+            adaptQuoteResponse(
+                response([gaslessResult({ spender: USER })]),
+                PROVIDER_ID,
+                request(),
+                gaslessModes,
+            ),
+        ).toThrow(Eip712EnvelopeMismatch);
     });
 
     it("prepends revoke and approval steps in order", () => {

--- a/packages/cross-chain/test/protocols/superbridge/provider.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/provider.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { HttpClient } from "../../../src/core/interfaces/httpClient.interface.js";
 import type { QuoteRequest } from "../../../src/core/schemas/quoteRequest.js";
+import { PERMIT2_ADDRESS } from "../../../src/core/constants/eip712.js";
 import { ProviderConfigFailure } from "../../../src/core/errors/ProviderConfigFailure.exception.js";
 import { ProviderGetQuoteFailure } from "../../../src/core/errors/ProviderGetQuoteFailure.exception.js";
 import { FetchHttpClient } from "../../../src/core/utils/httpClient.js";
@@ -9,6 +10,9 @@ import { SuperbridgeProvider } from "../../../src/protocols/superbridge/provider
 
 const VALID_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
 const NATIVE = "0x0000000000000000000000000000000000000000";
+const ERC20_TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const GASLESS_SPENDER = "0x1111111111111111111111111111111111111111";
+const FUTURE_DEADLINE = Math.floor(Date.now() / 1000) + 3600;
 const ORIGIN_CHAIN_ID = 1;
 const DESTINATION_CHAIN_ID = 8453;
 const INPUT_AMOUNT = "10000000000000000";
@@ -79,10 +83,22 @@ function makeEvmRouteResult(): unknown {
 
 function makeGaslessRouteResult(): unknown {
     const typedData = JSON.stringify({
-        domain: { chainId: ORIGIN_CHAIN_ID, name: "Superbridge" },
-        types: { Order: [{ name: "amount", type: "uint256" }] },
-        primaryType: "Order",
-        message: { amount: INPUT_AMOUNT },
+        domain: { name: "Permit2", chainId: ORIGIN_CHAIN_ID, verifyingContract: PERMIT2_ADDRESS },
+        types: {
+            PermitTransferFrom: [
+                { name: "permitted", type: "TokenPermissions" },
+                { name: "spender", type: "address" },
+                { name: "nonce", type: "uint256" },
+                { name: "deadline", type: "uint256" },
+            ],
+        },
+        primaryType: "PermitTransferFrom",
+        message: {
+            permitted: { token: ERC20_TOKEN, amount: INPUT_AMOUNT },
+            spender: GASLESS_SPENDER,
+            nonce: "1",
+            deadline: FUTURE_DEADLINE,
+        },
     });
     return {
         meta: { id: "route-gasless", provider: { name: "across-v3" } },
@@ -163,7 +179,15 @@ describe("SuperbridgeProvider", () => {
             });
             mockPost.mockResolvedValue(httpOk({ results: [makeGaslessRouteResult()] }));
 
-            const quotes = await gaslessProvider.getQuotes(makeQuoteRequest());
+            const quotes = await gaslessProvider.getQuotes(
+                makeQuoteRequest({
+                    input: {
+                        chainId: ORIGIN_CHAIN_ID,
+                        assetAddress: ERC20_TOKEN,
+                        amount: INPUT_AMOUNT,
+                    },
+                }),
+            );
 
             expect(quotes).toHaveLength(1);
             expect(quotes[0]!.order.steps[0]!.kind).toBe("signature");
@@ -202,7 +226,15 @@ describe("SuperbridgeProvider", () => {
                 apiKey: API_KEY,
             });
             mockPost.mockResolvedValueOnce(httpOk({ results: [makeGaslessRouteResult()] }));
-            const [quote] = await gaslessProvider.getQuotes(makeQuoteRequest());
+            const [quote] = await gaslessProvider.getQuotes(
+                makeQuoteRequest({
+                    input: {
+                        chainId: ORIGIN_CHAIN_ID,
+                        assetAddress: ERC20_TOKEN,
+                        amount: INPUT_AMOUNT,
+                    },
+                }),
+            );
 
             mockPost.mockResolvedValueOnce(httpOk({ txHash: FILL_TX_HASH, status: "submitted" }));
             const response = await gaslessProvider.submitOrder(quote!, "0xsignature");

--- a/packages/cross-chain/test/protocols/superbridge/validators/signatureEnvelopeValidator.spec.ts
+++ b/packages/cross-chain/test/protocols/superbridge/validators/signatureEnvelopeValidator.spec.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from "vitest";
+
+import type { QuoteRequest } from "../../../../src/core/schemas/quoteRequest.js";
+import type { Eip712Envelope } from "../../../../src/core/types/eip712.js";
+import { PERMIT2_ADDRESS } from "../../../../src/core/constants/eip712.js";
+import { Eip712EnvelopeMismatch } from "../../../../src/core/errors/Eip712EnvelopeMismatch.exception.js";
+import { NATIVE_ASSET_ADDRESS } from "../../../../src/core/utils/token.js";
+import { validateSuperbridgeSignatureEnvelope } from "../../../../src/protocols/superbridge/validators/signatureEnvelopeValidator.js";
+
+const SPENDER = "0xCCC88a9d1B4ed6b0eABA998850414b24F1C315bE";
+const USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const USER = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+const TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const RECIPIENT = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8";
+const FAKE_ADDRESS = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+const ORIGIN_CHAIN_ID = 1;
+const DESTINATION_CHAIN_ID = 10;
+const INPUT_AMOUNT = "1000000";
+const FUTURE_DEADLINE = Math.floor(Date.now() / 1000) + 3600;
+const PAST_DEADLINE = Math.floor(Date.now() / 1000) - 3600;
+
+function makeParams(overrides?: Partial<QuoteRequest>): QuoteRequest {
+    return {
+        user: USER,
+        input: { chainId: ORIGIN_CHAIN_ID, assetAddress: TOKEN, amount: INPUT_AMOUNT },
+        output: { chainId: DESTINATION_CHAIN_ID, assetAddress: TOKEN, recipient: RECIPIENT },
+        ...overrides,
+    };
+}
+
+const eip3009Params = makeParams({
+    input: { chainId: ORIGIN_CHAIN_ID, assetAddress: USDC_BASE, amount: INPUT_AMOUNT },
+});
+
+const nativeInputParams = makeParams({
+    input: { chainId: ORIGIN_CHAIN_ID, assetAddress: NATIVE_ASSET_ADDRESS, amount: INPUT_AMOUNT },
+});
+
+function makePermit2Envelope(overrides?: Partial<Eip712Envelope>): Eip712Envelope {
+    return {
+        domain: { name: "Permit2", chainId: ORIGIN_CHAIN_ID, verifyingContract: PERMIT2_ADDRESS },
+        primaryType: "PermitTransferFrom",
+        types: {},
+        message: {
+            permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+            spender: SPENDER,
+            nonce: "1",
+            deadline: FUTURE_DEADLINE,
+        },
+        ...overrides,
+    };
+}
+
+function makeEip3009Envelope(overrides?: Partial<Eip712Envelope>): Eip712Envelope {
+    return {
+        domain: {
+            name: "USD Coin",
+            version: "2",
+            chainId: ORIGIN_CHAIN_ID,
+            verifyingContract: USDC_BASE,
+        },
+        primaryType: "ReceiveWithAuthorization",
+        types: {},
+        message: {
+            from: USER,
+            to: SPENDER,
+            value: INPUT_AMOUNT,
+            validAfter: "0",
+            validBefore: FUTURE_DEADLINE,
+            nonce: "0x0000000000000000000000000000000000000000000000000000000000000001",
+        },
+        ...overrides,
+    };
+}
+
+describe("validateSuperbridgeSignatureEnvelope", () => {
+    it("rejects an unsupported primaryType", () => {
+        expect(() =>
+            validateSuperbridgeSignatureEnvelope(
+                makePermit2Envelope({ primaryType: "Order" }),
+                makeParams(),
+            ),
+        ).toThrow(/primaryType/);
+    });
+
+    describe("Permit2", () => {
+        it("accepts a valid envelope", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(makePermit2Envelope(), makeParams()),
+            ).not.toThrow();
+        });
+
+        it("rejects a tampered chainId", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(
+                    makePermit2Envelope({
+                        domain: {
+                            name: "Permit2",
+                            chainId: 999,
+                            verifyingContract: PERMIT2_ADDRESS,
+                        },
+                    }),
+                    makeParams(),
+                ),
+            ).toThrow(/chainId/);
+        });
+
+        it("rejects a non-Permit2 verifyingContract", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(
+                    makePermit2Envelope({
+                        domain: {
+                            name: "Permit2",
+                            chainId: ORIGIN_CHAIN_ID,
+                            verifyingContract: FAKE_ADDRESS,
+                        },
+                    }),
+                    makeParams(),
+                ),
+            ).toThrow(/verifyingContract/);
+        });
+
+        it("rejects a domain that carries a version", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(
+                    makePermit2Envelope({
+                        domain: {
+                            name: "Permit2",
+                            version: "1",
+                            chainId: ORIGIN_CHAIN_ID,
+                            verifyingContract: PERMIT2_ADDRESS,
+                        },
+                    }),
+                    makeParams(),
+                ),
+            ).toThrow(/domainVersion/);
+        });
+
+        it("rejects a permitted token that differs from the input asset", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(
+                    makePermit2Envelope({
+                        message: {
+                            permitted: { token: FAKE_ADDRESS, amount: INPUT_AMOUNT },
+                            spender: SPENDER,
+                            nonce: "1",
+                            deadline: FUTURE_DEADLINE,
+                        },
+                    }),
+                    makeParams(),
+                ),
+            ).toThrow(/token/);
+        });
+
+        it("rejects an inflated permit amount", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(
+                    makePermit2Envelope({
+                        message: {
+                            permitted: { token: TOKEN, amount: "9999999999" },
+                            spender: SPENDER,
+                            nonce: "1",
+                            deadline: FUTURE_DEADLINE,
+                        },
+                    }),
+                    makeParams(),
+                ),
+            ).toThrow(/amount/);
+        });
+
+        it("rejects an expired deadline", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(
+                    makePermit2Envelope({
+                        message: {
+                            permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+                            spender: SPENDER,
+                            nonce: "1",
+                            deadline: PAST_DEADLINE,
+                        },
+                    }),
+                    makeParams(),
+                ),
+            ).toThrow(/deadline/);
+        });
+
+        it("rejects a spender equal to the user", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(
+                    makePermit2Envelope({
+                        message: {
+                            permitted: { token: TOKEN, amount: INPUT_AMOUNT },
+                            spender: USER,
+                            nonce: "1",
+                            deadline: FUTURE_DEADLINE,
+                        },
+                    }),
+                    makeParams(),
+                ),
+            ).toThrow(/spender/);
+        });
+
+        it("rejects a native input asset", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(makePermit2Envelope(), nativeInputParams),
+            ).toThrow(Eip712EnvelopeMismatch);
+        });
+    });
+
+    describe("EIP-3009", () => {
+        it("accepts a valid envelope", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(makeEip3009Envelope(), eip3009Params),
+            ).not.toThrow();
+        });
+
+        it("rejects a verifyingContract that is not the input token", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(
+                    makeEip3009Envelope({
+                        domain: {
+                            name: "USD Coin",
+                            version: "2",
+                            chainId: ORIGIN_CHAIN_ID,
+                            verifyingContract: FAKE_ADDRESS,
+                        },
+                    }),
+                    eip3009Params,
+                ),
+            ).toThrow(/verifyingContract/);
+        });
+
+        it("rejects a domain without a version", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(
+                    makeEip3009Envelope({
+                        domain: {
+                            name: "USD Coin",
+                            chainId: ORIGIN_CHAIN_ID,
+                            verifyingContract: USDC_BASE,
+                        },
+                    }),
+                    eip3009Params,
+                ),
+            ).toThrow(/domainVersion/);
+        });
+
+        it("rejects a from that is not the user", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(
+                    makeEip3009Envelope({
+                        message: {
+                            from: FAKE_ADDRESS,
+                            to: SPENDER,
+                            value: INPUT_AMOUNT,
+                            validAfter: "0",
+                            validBefore: FUTURE_DEADLINE,
+                            nonce: "0x01",
+                        },
+                    }),
+                    eip3009Params,
+                ),
+            ).toThrow(/user/);
+        });
+
+        it("rejects an inflated value", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(
+                    makeEip3009Envelope({
+                        message: {
+                            from: USER,
+                            to: SPENDER,
+                            value: "9999999999",
+                            validAfter: "0",
+                            validBefore: FUTURE_DEADLINE,
+                            nonce: "0x01",
+                        },
+                    }),
+                    eip3009Params,
+                ),
+            ).toThrow(/amount/);
+        });
+
+        it("rejects an expired validBefore", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(
+                    makeEip3009Envelope({
+                        message: {
+                            from: USER,
+                            to: SPENDER,
+                            value: INPUT_AMOUNT,
+                            validAfter: "0",
+                            validBefore: PAST_DEADLINE,
+                            nonce: "0x01",
+                        },
+                    }),
+                    eip3009Params,
+                ),
+            ).toThrow(/deadline/);
+        });
+
+        it("rejects a recipient equal to the user", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(
+                    makeEip3009Envelope({
+                        message: {
+                            from: USER,
+                            to: USER,
+                            value: INPUT_AMOUNT,
+                            validAfter: "0",
+                            validBefore: FUTURE_DEADLINE,
+                            nonce: "0x01",
+                        },
+                    }),
+                    eip3009Params,
+                ),
+            ).toThrow(/to/);
+        });
+
+        it("rejects a native input asset", () => {
+            expect(() =>
+                validateSuperbridgeSignatureEnvelope(makeEip3009Envelope(), nativeInputParams),
+            ).toThrow(Eip712EnvelopeMismatch);
+        });
+    });
+});


### PR DESCRIPTION
Adds the EIP-712 envelope validation that the gasless submission path (EFI-1000) deliberately left out, bringing Superbridge in line with Bungee, Relay and OIF.

Closes EFI-1031.

## What's here

- **`validators/signatureEnvelopeValidator.ts`** — `validateSuperbridgeSignatureEnvelope` cross-checks the gasless EIP-712 envelope the user is asked to sign against their quote request: chain id, verifying contract, input token, amount cap, spender/recipient (must not be the user) and deadline. It dispatches by `primaryType` to the Permit2 or EIP-3009 path, reusing the existing `core/validators` helpers. Any other primary type throws `Eip712EnvelopeMismatch`, so a tampered or unrecognised envelope is rejected instead of being handed to the wallet.
- **`adapters/quoteResponseAdapter.ts`** — `buildSignatureStep` runs the validator before emitting the signature step. The error propagates, so an unsafe gasless quote fails the call rather than reaching the user.

User-transaction routes are left to the aggregator's `AllowlistSpenderValidator` (consumer-owned), which already checks `transactionTo` and the decoded approval spender on every quote — so no canonical-address registry lives in the SDK.

## Tests

New unit tests for the validator covering Permit2 and EIP-3009 (tampered chain id, wrong verifying contract, swapped token, inflated amount, expired deadline, spender/recipient equal to the user, native placeholder), plus fail-closed cases on the quote-response adapter. The synthetic gasless fixtures were updated to valid envelopes. Full cross-chain suite green; typecheck and lint clean.

## Note

Stacked on `feat/superbridge-impl`.
